### PR TITLE
Handle open segments with entries up to last snapshot

### DIFF
--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -516,6 +516,11 @@ static int loadOpen(struct uv *uv,
                 uvWarnf(uv, "%s has non-zero trail", info->filename);
             }
 
+            uvWarnf(uv,
+                    "truncate open segment %s at %ld, since it has corrupted "
+                    "entries",
+                    info->filename, offset);
+
             rv = ftruncate(fd, offset);
             if (rv == -1) {
                 uvErrorf(uv, "ftruncate %s: %s", info->filename,


### PR DESCRIPTION
Start cleanly in case an open segment has all entries between the
last closed segment and the last snapshot.