### PR TITLE
README: more accurate logger initialization instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,14 @@ Create an instance of the stock ```raft_logger``` interface implementation:
 
 ```C
 struct raft_logger logger;
-raft_ring_logger_init(&logger, stdio);
+raft_stream_logger_init (&logger, stdout);
+```
+
+or
+
+```C
+struct raft_logger logger;
+raft_ring_logger_init (&logger, buffer_size);
 ```
 
 Pick a unique ID and address for each server and initialize the raft object:

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([raft], [0.9.3])
+AC_INIT([raft], [0.9.6])
 AC_LANG([C])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([ac])


### PR DESCRIPTION
Either the stream logger with the standard output, or the ring logger with the buffer size.