### PR TITLE
Attempt to skip tests that rely on the AIO sub-system not being used

### DIFF
--- a/test/lib/dir.c
+++ b/test/lib/dir.c
@@ -418,7 +418,7 @@ void test_dir_fill(const char *dir, const size_t n)
     close(fd);
 }
 
-void test_aio_fill(aio_context_t *ctx, unsigned n)
+int test_aio_fill(aio_context_t *ctx, unsigned n)
 {
     char buf[256];
     int fd;
@@ -448,8 +448,17 @@ void test_aio_fill(aio_context_t *ctx, unsigned n)
 
     used = atoi(buf);
 
+    /* Best effort check that nothing process is using AIO. Our own unit tests
+     * case use up to 2 event slots at the time this function is called, so we
+     * don't consider those. */
+    if (used > 2) {
+        return -1;
+    }
+
     rv = syscall(__NR_io_setup, limit - used - n, ctx);
     munit_assert_int(rv, ==, 0);
+
+    return 0;
 }
 
 void test_aio_destroy(aio_context_t ctx)

--- a/test/lib/dir.h
+++ b/test/lib/dir.h
@@ -172,8 +172,12 @@ void test_dir_fill(const char *dir, const size_t n);
 
 /* Fill the AIO subsystem resources by allocating a lot of events to the given
  * context, and leaving only @n events available for subsequent calls to
- * @io_setup. */
-void test_aio_fill(aio_context_t *ctx, unsigned n);
+ * @io_setup.
+ *
+ * Return -1 if it looks like there is another process already using the AIO
+ * subsytem, which would most probably make the calling test flaky because there
+ * won't be exactly @n events available anymore. */
+int test_aio_fill(aio_context_t *ctx, unsigned n);
 
 /* Destroy the given AIO context. */
 void test_aio_destroy(aio_context_t ctx);

--- a/test/unit/test_uv_file.c
+++ b/test/unit/test_uv_file.c
@@ -218,7 +218,11 @@ TEST(uvFileCreate, noResources, setupFile, tearDownFile, 0, NULL)
 {
     struct file *f = data;
     aio_context_t ctx = 0;
-    test_aio_fill(&ctx, 0);
+    int rv;
+    rv = test_aio_fill(&ctx, 0);
+    if (rv != 0) {
+        return MUNIT_SKIP;
+    }
     CREATE_ERROR_("foo",     /* file name */
                   4096,      /* file size */
                   1,         /* max concurrent writes */
@@ -476,9 +480,13 @@ TEST(uvFileWrite, noResources, setupFile, tearDownFile, 0, dir_no_aio_params)
 {
     struct file *f = data;
     aio_context_t ctx = 0;
+    int rv;
     SKIP_IF_NO_FIXTURE;
     CREATE_("foo", f->block_size, 2);
-    test_aio_fill(&ctx, 0);
+    rv = test_aio_fill(&ctx, 0);
+    if (rv != 0) {
+        return MUNIT_SKIP;
+    }
     WRITE_FAILURE(1, 0, 0, UV__ERROR,
                   "io_setup: Resource temporarily unavailable");
     test_aio_destroy(ctx);

--- a/test/unit/test_uv_os.c
+++ b/test/unit/test_uv_os.c
@@ -249,10 +249,14 @@ TEST(uvProbeIoCapabilities, noResources, setupBtrfsDir, tearDownDir, 0, NULL)
 {
     const char *dir = data;
     aio_context_t ctx = 0;
+    int rv;
     if (dir == NULL) {
         return MUNIT_SKIP;
     }
-    test_aio_fill(&ctx, 0);
+    rv = test_aio_fill(&ctx, 0);
+    if (rv != 0) {
+        return MUNIT_SKIP;
+    }
     PROBE_IO_CAPABILITIES_ERROR(dir, UV__ERROR,
                                 "io_setup: Resource temporarily unavailable");
     test_aio_destroy(ctx);

--- a/test/unit/test_uv_prepare.c
+++ b/test/unit/test_uv_prepare.c
@@ -137,8 +137,12 @@ TEST_CASE(error, no_resources, NULL)
 {
     struct fixture *f = data;
     aio_context_t ctx = 0;
+    int rv;
     (void)params;
-    test_aio_fill(&ctx, 0);
+    rv = test_aio_fill(&ctx, 0);
+    if (rv != 0) {
+        return MUNIT_SKIP;
+    }
     PREPARE;
     WAIT_CB(RAFT_IOERR);
     test_aio_destroy(ctx);


### PR DESCRIPTION
Fixes #79.