### PR TITLE
uv: resilience improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([raft], [0.9.6])
+AC_INIT([raft], [0.9.10])
 AC_LANG([C])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([ac])

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -1372,7 +1372,7 @@ static void completeRequest(struct raft_fixture *f, unsigned i, raft_time t)
 {
     struct io *io = f->servers[i].io.impl;
     queue *head;
-    struct request *r;
+    struct request *r = NULL;
     bool found = false;
     f->time = t;
     f->event.server_index = i;

--- a/src/progress.c
+++ b/src/progress.c
@@ -104,7 +104,7 @@ bool progressShouldReplicate(struct raft *r, unsigned i)
     bool needs_heartbeat = now - p->last_send >= r->heartbeat_timeout;
     raft_index last_index = logLastIndex(&r->log);
     bool is_up_to_date = p->next_index == last_index + 1;
-    bool result;
+    bool result = false;
 
     /* We must be in a valid state. */
     assert(p->state == PROGRESS__PROBE || p->state == PROGRESS__PIPELINE ||

--- a/src/tick.c
+++ b/src/tick.c
@@ -180,7 +180,7 @@ static int tickLeader(struct raft *r)
 
 static int tick(struct raft *r)
 {
-    int rv;
+    int rv = -1;
 
     assert(r->state == RAFT_UNAVAILABLE || r->state == RAFT_FOLLOWER ||
            r->state == RAFT_CANDIDATE || r->state == RAFT_LEADER);

--- a/src/uv.c
+++ b/src/uv.c
@@ -592,6 +592,11 @@ int raft_uv_init(struct raft_io *io,
     if (uv == NULL) {
         return RAFT_NOMEM;
     }
+    memset (uv, 0, sizeof (struct uv));
+    /* during initialization of a structure this big,
+       you're guaranteed to leave something uninitialized */
+    /* TODO: there actually are an unitialized fields
+       (8 octets, according to Valgrind) -- find them */
 
     uv->io = io;
     uv->loop = loop;

--- a/src/uv.c
+++ b/src/uv.c
@@ -593,20 +593,21 @@ int raft_uv_init(struct raft_io *io,
         return RAFT_NOMEM;
     }
     memset (uv, 0, sizeof (struct uv));
-    /* during initialization of a structure this big,
-       you're guaranteed to leave something uninitialized */
-    /* TODO: there actually are an unitialized fields
-       (8 octets, according to Valgrind) -- find them */
+    /* during initialization of a structure this big (40 fields),
+       you're guaranteed to forget to initialize something */
 
     uv->io = io;
     uv->loop = loop;
     strcpy(uv->dir, dir);
     uv->transport = transport;
     uv->transport->data = uv;
+    uv->logger = NULL;  /* will be set later, or will fail earlier */
     uv->id = 0;
     UvFsInit(&uv->fs, uv->loop);
     uv->state = 0;
     uv->errored = false;
+    uv->direct_io = false;  /* assume unsupported */
+    uv->async_io = false;  /* assume unsupported */
     uv->block_size = 0; /* Detected in raft_io->init() */
     uv->n_blocks = 0;   /* Calculated in raft_io->init() */
     uv->clients = NULL;
@@ -630,11 +631,16 @@ int raft_uv_init(struct raft_io *io,
     QUEUE_INIT(&uv->snapshot_put_reqs);
     QUEUE_INIT(&uv->snapshot_get_reqs);
     uv->snapshot_put_work.data = NULL;
-    uv->tick_cb = NULL;
+    /* TODO: struct uvMetadata metadata;  /\* Cache of metadata on disk *\/ */
+    /* TODO: struct uv_timer_s timer;     /\* Timer for periodic ticks *\/ */
+    uv->tick_cb = NULL;  /* will be set at ~start~ */
+    uv->recv_cb = NULL;  /* will be set at ~start~ */
     uv->closing = false;
     uv->close_cb = NULL;
 
     /* Set the raft_io implementation. */
+    io->version = 1;  /* future-proof'ing */
+    io->data = NULL;  /* canary-poison */
     io->impl = uv;
     io->init = uvInit;
     io->start = uvStart;

--- a/test/unit/test_uv_writer.c
+++ b/test/unit/test_uv_writer.c
@@ -241,24 +241,24 @@ static void submitCbAssertFail(struct UvWriterReq *req, int status)
 
 /* Assert that the content of the test file has the given number of blocks, each
  * filled with progressive numbers. */
-#define ASSERT_CONTENT(N)                                   \
-    {                                                       \
-        size_t size = N * f->block_size;                    \
-        void *buf = munit_malloc(size);                     \
-        unsigned i;                                         \
-        unsigned j;                                         \
-                                                            \
-        test_dir_read_file(f->dir, "foo", buf, size);       \
-                                                            \
-        for (i = 0; i < N; i++) {                           \
-            char *cursor = (char *)buf + i * f->block_size; \
-            for (j = 0; j < f->block_size; j++) {           \
-                munit_assert_int(cursor[j], ==, i + 1);     \
-            }                                               \
-        }                                                   \
-                                                            \
-        free(buf);                                          \
-    }
+#define ASSERT_CONTENT(N)                                       \
+  {                                                             \
+    size_t size = N * f->block_size;                            \
+    void *buf = munit_malloc(size);                             \
+                                                                \
+    test_dir_read_file(f->dir, "foo", buf, size);               \
+                                                                \
+    for (unsigned __i = 0; __i < N; __i++)                      \
+      {                                                         \
+        char *cursor = (char *)buf + __i * f->block_size;       \
+        for (unsigned __j = 0; __j < f->block_size; __j++)      \
+          {                                                     \
+            munit_assert_int (cursor[__j], ==, __i + 1);        \
+          }                                                     \
+      }                                                         \
+                                                                \
+    free(buf);                                                  \
+  }
 
 SUITE(UvWriterSubmit)
 


### PR DESCRIPTION
Somehow fixed the warnings about the possibly uninitialized memory (although Valgrind-memcheck still complains).
But not the warnings about the (set-but-not-)unused variables, because they're actually used in assertions. Don't know why the compiler can't detect that.
Also, the package version shouldn't lag behind, but always point to the coming release.