### PR TITLE
Fix scheduling appends to follow up segments

### DIFF
--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -305,6 +305,7 @@ static int uvAppendMaybeStart(struct uv *uv)
     int rv;
 
     assert(!uv->closing);
+    assert(!QUEUE_IS_EMPTY(&uv->append_pending_reqs));
 
     /* If we are already writing, let's wait. */
     if (!QUEUE_IS_EMPTY(&uv->append_writing_reqs)) {
@@ -641,6 +642,7 @@ int UvAppend(struct raft_io *io,
     }
 
     assert(append->segment != NULL);
+    assert(!QUEUE_IS_EMPTY(&uv->append_pending_reqs));
 
     /* Try to write immediately. */
     rv = uvAppendMaybeStart(uv);

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -580,7 +580,7 @@ static int uvAppendEnqueueRequest(struct uv *uv, struct uvAppend *append)
     /* If we have no segments yet, it means this is the very first append, and
      * we need to add a new segment. Otherwise we check if the last segment has
      * enough room for this batch of entries. */
-    segment = uvGetCurrentAliveSegment(uv);
+    segment = uvGetLastAliveSegment(uv);
     if (segment == NULL || segment->finalize) {
         fits = false;
     } else {

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -288,6 +288,20 @@ TEST(append, secondBig, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
+/* Schedule multiple appends each one exceeding the segment size. */
+TEST(append, severalBig, setUp, tearDownDeps, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND_SUBMIT(0, 2, MAX_SEGMENT_BLOCKS * SEGMENT_BLOCK_SIZE);
+    APPEND_SUBMIT(1, 2, MAX_SEGMENT_BLOCKS * SEGMENT_BLOCK_SIZE);
+    APPEND_SUBMIT(2, 2, MAX_SEGMENT_BLOCKS * SEGMENT_BLOCK_SIZE);
+    APPEND_WAIT(0);
+    APPEND_WAIT(1);
+    APPEND_WAIT(2);
+    ASSERT_ENTRIES(6, 6 * MAX_SEGMENT_BLOCKS * SEGMENT_BLOCK_SIZE);
+    return MUNIT_OK;
+}
+
 /* Write the very first entry and then another one, both fitting in the same
  * block. */
 TEST(append, fitBlock, setUp, tearDownDeps, 0, NULL)


### PR DESCRIPTION
In case there is more than one segment in the pending writes queue, attempt to
schedule the write to the last segment, not the current one, so it gets properly finalize
upon completion.
