### PR TITLE
Only include AIO syscall wrappers on Linux

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,4 @@
 ((nil . ((fill-column . 80)))
- (c-mode . ((flycheck-clang-definitions . ("HAVE_LINUX_IO_URING_H" "_GNU_SOURCE"))
+ (c-mode . ((flycheck-clang-definitions . ("HAVE_LINUX_AIO_ABI_H", "HAVE_LINUX_IO_URING_H" "_GNU_SOURCE"))
 	    (flycheck-clang-args . ("-Wpedantic" "-Wall" "-Wextra"))
 	    (flycheck-gcc-definitions . ("HAVE_LINUX_IO_URING_H" "_GNU_SOURCE")))))

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - autoreconf -i
   - ./configure --enable-example --enable-debug --enable-code-coverage --enable-sanitize
   - amalgamate.py --config=amalgamation.json --source=$(pwd)
-  - $CC raft.c -c -D_GNU_SOURCE -Wall -Wextra -Wpedantic -fpic
+  - $CC raft.c -c -D_GNU_SOURCE -DHAVE_LINUX_AIO_ABI_H -Wall -Wextra -Wpedantic -fpic
   - ./test/lib/fs.sh setup
   - make check CFLAGS=-O0 $(./test/lib/fs.sh detect) || (cat ./test-suite.log && false)
   - if [ $TRAVIS_COMPILER = gcc ]; then make code-coverage-capture; fi

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AM_CONDITIONAL(SANITIZE_ENABLED, test x"$enable_sanitize" = x"yes")
 AX_CODE_COVERAGE
 
 # Checks for header files.
-AC_CHECK_HEADERS([stdlib.h string.h stdio.h assert.h unistd.h linux/io_uring.h])
+AC_CHECK_HEADERS([stdlib.h string.h stdio.h assert.h unistd.h linux/io_uring.h linux/aio_abi.h])
 
 # Check if zfs >= 0.8.0 is available (for direct I/O support).
 AC_CHECK_PROG(have_zfs, zfs, yes)

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -1,8 +1,11 @@
 #include "syscall.h"
 
+#if HAVE_LINUX_AIO_ABI_H || HAVE_LINUX_IO_URING_H
 #include <sys/syscall.h>
 #include <unistd.h>
+#endif
 
+#if HAVE_LINUX_AIO_ABI_H
 int io_setup(unsigned nr_events, aio_context_t *ctx_idp)
 {
     return (int)syscall(__NR_io_setup, nr_events, ctx_idp);
@@ -26,6 +29,7 @@ int io_getevents(aio_context_t ctx_id,
 {
     return (int)syscall(__NR_io_getevents, ctx_id, min_nr, nr, events, timeout);
 }
+#endif
 
 #if HAVE_LINUX_IO_URING_H
 int io_uring_register(int fd,

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -3,13 +3,17 @@
 #ifndef SYSCALL_H_
 #define SYSCALL_H_
 
+#if HAVE_LINUX_AIO_ABI_H
 #include <linux/aio_abi.h>
 #include <signal.h>
 #include <time.h>
+#endif
+
 #if HAVE_LINUX_IO_URING_H
 #include <linux/io_uring.h>
 #endif
 
+#if HAVE_LINUX_AIO_ABI_H
 /* AIO */
 int io_setup(unsigned nr_events, aio_context_t *ctx_idp);
 
@@ -22,6 +26,7 @@ int io_getevents(aio_context_t ctx_id,
                  long nr,
                  struct io_event *events,
                  struct timespec *timeout);
+#endif
 
 #if HAVE_LINUX_IO_URING_H
 /* uring */


### PR DESCRIPTION
Fixes #125.