### PR TITLE
Add raft_aligned_free() API for releasing aligned memory

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,4 @@
 ((nil . ((fill-column . 80)))
- (c-mode . ((flycheck-clang-definitions . ("HAVE_LINUX_AIO_ABI_H", "HAVE_LINUX_IO_URING_H" "_GNU_SOURCE"))
+ (c-mode . ((flycheck-clang-definitions . ("HAVE_LINUX_AIO_ABI_H" "HAVE_LINUX_IO_URING_H" "_GNU_SOURCE"))
 	    (flycheck-clang-args . ("-Wpedantic" "-Wall" "-Wextra"))
 	    (flycheck-gcc-definitions . ("HAVE_LINUX_IO_URING_H" "_GNU_SOURCE")))))

--- a/include/raft.h
+++ b/include/raft.h
@@ -947,6 +947,7 @@ struct raft_heap
     void *(*calloc)(void *data, size_t nmemb, size_t size);
     void *(*realloc)(void *data, void *ptr, size_t size);
     void *(*aligned_alloc)(void *data, size_t alignment, size_t size);
+    void (*aligned_free)(void *data, size_t alignment, void *ptr);
 };
 
 RAFT_API void *raft_malloc(size_t size);
@@ -954,6 +955,7 @@ RAFT_API void raft_free(void *ptr);
 RAFT_API void *raft_calloc(size_t nmemb, size_t size);
 RAFT_API void *raft_realloc(void *ptr, size_t size);
 RAFT_API void *raft_aligned_alloc(size_t alignment, size_t size);
+RAFT_API void raft_aligned_free(size_t alignment, void *ptr);
 
 /**
  * Use a custom dynamic memory allocator.

--- a/src/heap.c
+++ b/src/heap.c
@@ -34,13 +34,20 @@ static void *defaultAlignedAlloc(void *data, size_t alignment, size_t size)
     return aligned_alloc(alignment, size);
 }
 
+static void defaultAlignedFree(void *data, size_t alignment, void *ptr)
+{
+    (void)alignment;
+    defaultFree(data, ptr);
+}
+
 static struct raft_heap defaultHeap = {
-    NULL,               /* data */
-    defaultMalloc,      /* malloc */
-    defaultFree,        /* free */
-    defaultCalloc,      /* calloc */
-    defaultRealloc,     /* realloc */
-    defaultAlignedAlloc /* aligned_alloc */
+    NULL,                /* data */
+    defaultMalloc,       /* malloc */
+    defaultFree,         /* free */
+    defaultCalloc,       /* calloc */
+    defaultRealloc,      /* realloc */
+    defaultAlignedAlloc, /* aligned_alloc */
+    defaultAlignedFree   /* aligned_free */
 };
 
 static struct raft_heap *currentHeap = &defaultHeap;
@@ -91,6 +98,11 @@ void *raft_realloc(void *ptr, size_t size)
 void *raft_aligned_alloc(size_t alignment, size_t size)
 {
     return currentHeap->aligned_alloc(currentHeap->data, alignment, size);
+}
+
+void raft_aligned_free(size_t alignment, void *ptr)
+{
+    currentHeap->aligned_free(currentHeap->data, alignment, ptr);
 }
 
 void raft_heap_set(struct raft_heap *heap)

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -643,7 +643,7 @@ static int uvEnsureSegmentBufferIsLargeEnough(struct uvSegmentBuffer *b,
     if (b->arena.base != NULL) {
         assert(b->arena.len >= b->block_size);
         memcpy(base, b->arena.base, b->arena.len);
-        raft_free(b->arena.base);
+        raft_aligned_free(b->block_size, b->arena.base);
     }
 
     b->arena.base = base;
@@ -663,7 +663,7 @@ void uvSegmentBufferInit(struct uvSegmentBuffer *b, size_t block_size)
 void uvSegmentBufferClose(struct uvSegmentBuffer *b)
 {
     if (b->arena.base != NULL) {
-        raft_free(b->arena.base);
+        raft_aligned_free(b->block_size, b->arena.base);
     }
 }
 


### PR DESCRIPTION
This should help ports to other platforms (e.g. Windows, #119) and language bindings (e.g. Rust, #130).