### PR TITLE
Set start index to 1 when there is a snapshot and only open segments

### DIFF
--- a/src/uv.c
+++ b/src/uv.c
@@ -337,8 +337,12 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
         if (rv != 0) {
             goto err;
         }
-        if (segments != NULL && !segments[0].is_open) {
-            *start_index = segments[0].first_index;
+        if (segments != NULL) {
+            if (segments[0].is_open) {
+                *start_index = 1;
+            } else {
+                *start_index = segments[0].first_index;
+            }
         } else {
             *start_index = (*snapshot)->index + 1;
         }


### PR DESCRIPTION
The current logic was buggy as in that case it would have set the start index to
the snapshot index, effectively jumping forward the index.