### PR TITLE
Use single read to load a segment from disk

### DIFF
--- a/src/uv_encoding.c
+++ b/src/uv_encoding.c
@@ -497,20 +497,21 @@ int uvDecodeMessage(const unsigned long type,
     return rv;
 }
 
-void uvDecodeEntriesBatch(const struct raft_buffer *buf,
+void uvDecodeEntriesBatch(uint8_t *batch,
+                          size_t offset,
                           struct raft_entry *entries,
                           unsigned n)
 {
-    void *cursor;
+    uint8_t *cursor;
     size_t i;
 
-    assert(buf != NULL);
+    assert(batch != NULL);
 
-    cursor = buf->base;
+    cursor = batch + offset;
 
     for (i = 0; i < n; i++) {
         struct raft_entry *entry = &entries[i];
-        entry->batch = buf->base;
+        entry->batch = batch;
 
         if (entry->buf.len == 0) {
             entry->buf.base = NULL;
@@ -519,10 +520,10 @@ void uvDecodeEntriesBatch(const struct raft_buffer *buf,
 
         entry->buf.base = cursor;
 
-        cursor = (uint8_t *)cursor + entry->buf.len;
+        cursor = cursor + entry->buf.len;
         if (entry->buf.len % 8 != 0) {
             /* Add padding */
-            cursor = (uint8_t *)cursor + 8 - (entry->buf.len % 8);
+            cursor = cursor + 8 - (entry->buf.len % 8);
         }
     }
 }

--- a/src/uv_encoding.h
+++ b/src/uv_encoding.h
@@ -23,7 +23,8 @@ int uvDecodeBatchHeader(const void *batch,
                         struct raft_entry **entries,
                         unsigned *n);
 
-void uvDecodeEntriesBatch(const struct raft_buffer *buf,
+void uvDecodeEntriesBatch(uint8_t *batch,
+                          size_t offset,
                           struct raft_entry *entries,
                           unsigned n);
 

--- a/src/uv_fs.h
+++ b/src/uv_fs.h
@@ -61,10 +61,6 @@ int UvFsMakeOrOverwriteFile(const char *dir,
                             const struct raft_buffer *buf,
                             char *errmsg);
 
-/* Check if the content of the file associated with the given file descriptor
- * contains all zeros from the current offset onward. */
-int UvFsFileHasOnlyTrailingZeros(uv_file fd, bool *flag, char *errmsg);
-
 /* Check if the given file descriptor has reached the end of the file. */
 bool UvFsIsAtEof(uv_file fd);
 

--- a/src/uv_recv.c
+++ b/src/uv_recv.c
@@ -3,11 +3,11 @@
 #include "../include/raft/uv.h"
 #include "assert.h"
 #include "byte.h"
+#include "configuration.h"
 #include "err.h"
 #include "heap.h"
 #include "uv.h"
 #include "uv_encoding.h"
-#include "configuration.h"
 
 #if 0
 #define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
@@ -257,8 +257,8 @@ static void uvServerReadCb(uv_stream_t *stream,
             type = byteFlip64(s->preamble[0]);
             assert(type > 0);
 
-            rv =
-                uvDecodeMessage((unsigned long)type, &s->header, &s->message, &s->payload.len);
+            rv = uvDecodeMessage((unsigned long)type, &s->header, &s->message,
+                                 &s->payload.len);
             if (rv != 0) {
                 Tracef(s->uv->tracer, "decode message: %s",
                        errCodeToString(rv));
@@ -283,7 +283,7 @@ static void uvServerReadCb(uv_stream_t *stream,
                 case RAFT_IO_APPEND_ENTRIES:
                     payload.base = s->payload.base;
                     payload.len = s->payload.len;
-                    uvDecodeEntriesBatch(&payload,
+                    uvDecodeEntriesBatch(payload.base, 0,
                                          s->message.append_entries.entries,
                                          s->message.append_entries.n_entries);
                     break;

--- a/test/integration/test_uv_load.c
+++ b/test/integration/test_uv_load.c
@@ -825,9 +825,7 @@ TEST(load, openSegmentWithIncompleteFormat, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     DirWriteFileWithZeros(f->dir, "open-1", WORD_SIZE / 2);
-    LOAD_ERROR(RAFT_IOERR,
-               "load open segment open-1: read format: short read: 4 bytes "
-               "instead of 8");
+    LOAD_ERROR(RAFT_IOERR, "load open segment open-1: file has only 4 bytes");
     return MUNIT_OK;
 }
 
@@ -960,7 +958,7 @@ TEST(load, openSegmentWithNoAccessPermission, setUp, tearDown, 0, NULL)
     UNFINALIZE(1, 1, 1);
     DirMakeFileUnreadable(f->dir, "open-1");
     LOAD_ERROR(RAFT_IOERR,
-               "load open segment open-1: open file: open: permission denied");
+               "load open segment open-1: read file: open: permission denied");
     return MUNIT_OK;
 }
 

--- a/test/integration/test_uv_load.c
+++ b/test/integration/test_uv_load.c
@@ -312,7 +312,9 @@ struct snapshot
                 struct raft_entry *_entry = &_entries[_i];                    \
                 if (_entry->batch != _batch) {                                \
                     _batch = _entry->batch;                                   \
+                    fprintf(stderr, "CP1 BATCH\n");                           \
                     raft_free(_batch);                                        \
+                    fprintf(stderr, "CP2 BATCH\n");                           \
                 }                                                             \
             }                                                                 \
             raft_free(_entries);                                              \
@@ -839,8 +841,8 @@ TEST(load, openSegmentWithIncompletePreamble, setUp, tearDown, 0, NULL)
     UNFINALIZE(1, 1, 1);
     DirTruncateFile(f->dir, "open-1", offset);
     LOAD_ERROR(RAFT_IOERR,
-               "load open segment open-1: entries batch 1 starting at byte 8: "
-               "read preamble: short read: 8 bytes instead of 16");
+               "load open segment open-1: entries batch 1 starting at byte 16: "
+               "read preamble: short read: 0 bytes instead of 8");
     return MUNIT_OK;
 }
 


### PR DESCRIPTION
Load entries from a segment using a single `read()` call to read the entire segment from disk at once, instead of multiple reads for each batch of entries. Besides being slightly more efficient, this will allow cleaner separation of I/O logic and parsing logic later down the road.