### PR TITLE
test/lib/dir.h: add missing include <sys/types.h>

### DIFF
--- a/test/lib/dir.h
+++ b/test/lib/dir.h
@@ -7,6 +7,8 @@
 #ifndef TEST_DIR_H
 #define TEST_DIR_H
 
+#include <sys/types.h>
+
 #include "munit.h"
 
 /* Munit parameter defining the file system type backing the temporary directory


### PR DESCRIPTION
Fixes building tests with musl libc.