### PR TITLE
README.md: Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ I/O. Patches are welcome to add support for more platforms.
 
 See [raft.h](https://github.com/canonical/raft/blob/master/include/raft.h) for full documentation.
 
-Licence
+License
 -------
 
 This raft C library is released under a slightly modified version of LGPLv3,
-that includes a copiright exception letting users to statically link the library
+that includes a copyright exception letting users to statically link the library
 code in their project and release the final work under their own terms. See the
 full [license](https://github.com/canonical/raft/blob/LICENSE) text.
 


### PR DESCRIPTION
copiright => copyright
licence => license