### PR TITLE
Fix may be used uninitialized warning

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1460,7 +1460,7 @@ abort:
 int replicationApply(struct raft *r)
 {
     raft_index index;
-    int rv;
+    int rv = 0;
 
     assert(r->state == RAFT_LEADER || r->state == RAFT_FOLLOWER);
     assert(r->last_applied <= r->commit_index);


### PR DESCRIPTION
Fix gcc 4.8.5 warning