### PR TITLE
Fix conversion to 'int' from 'unsigned int'

### DIFF
--- a/src/uv_os.c
+++ b/src/uv_os.c
@@ -201,7 +201,7 @@ int UvOsIoGetevents(aio_context_t ctx,
     return rv;
 }
 
-int UvOsEventfd(unsigned int initval, int flags)
+int UvOsEventfd(int initval, int flags)
 {
     int rv;
     /* At the moment only UV_FS_O_NONBLOCK is supported */

--- a/src/uv_os.h
+++ b/src/uv_os.h
@@ -113,7 +113,7 @@ int UvOsIoGetevents(aio_context_t ctx,
                     long max_nr,
                     struct io_event *events,
                     struct timespec *timeout);
-int UvOsEventfd(unsigned int initval, int flags);
+int UvOsEventfd(int initval, int flags);
 int UvOsSetDirectIo(uv_file fd);
 
 /* Format an error message caused by a failed system call or stdlib function. */


### PR DESCRIPTION
Fix conversion to 'int' from 'unsigned int' may change the sign of the
result warning.

Fix gcc 4.8.5 warning.