### PR TITLE
Convert naming of internal identifiers to camelCase

### DIFF
--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -410,10 +410,10 @@ RAFT_API void raft_fixture_add_entry(struct raft_fixture *f,
  * Inject an I/O failure that will be triggered on the @i'th server after @delay
  * I/O requests and occur @repeat times.
  */
-RAFT_API void raft_fixture_io_fault(struct raft_fixture *f,
-                                    unsigned i,
-                                    int delay,
-                                    int repeat);
+RAFT_API void raftFixtureIoFault(struct raft_fixture *f,
+                                 unsigned i,
+                                 int delay,
+                                 int repeat);
 
 /**
  * Return the number of messages of the given type that the @i'th server has

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -223,16 +223,16 @@ RAFT_API struct raft_fixture_event *raft_fixture_step_n(struct raft_fixture *f,
                                                         unsigned n);
 
 /**
- * Step the cluster until the given @stop function returns #true, or @max_msecs
+ * Step the cluster until the given @stop function returns #true, or @maxMsecs
  * have elapsed.
  *
- * Return #true if the @stop function has returned #true within @max_msecs.
+ * Return #true if the @stop function has returned #true within @maxMsecs.
  */
 RAFT_API bool raft_fixture_step_until(struct raft_fixture *f,
                                       bool (*stop)(struct raft_fixture *f,
                                                    void *arg),
                                       void *arg,
-                                      unsigned max_msecs);
+                                      unsigned maxMsecs);
 
 /**
  * Step the cluster until @msecs have elapsed.
@@ -241,63 +241,63 @@ RAFT_API void raft_fixture_step_until_elapsed(struct raft_fixture *f,
                                               unsigned msecs);
 
 /**
- * Step the cluster until a leader is elected, or @max_msecs have elapsed.
+ * Step the cluster until a leader is elected, or @maxMsecs have elapsed.
  */
 RAFT_API bool raft_fixture_step_until_has_leader(struct raft_fixture *f,
-                                                 unsigned max_msecs);
+                                                 unsigned maxMsecs);
 
 /**
- * Step the cluster until the current leader gets deposed, or @max_msecs have
+ * Step the cluster until the current leader gets deposed, or @maxMsecs have
  * elapsed.
  */
 RAFT_API bool raft_fixture_step_until_has_no_leader(struct raft_fixture *f,
-                                                    unsigned max_msecs);
+                                                    unsigned maxMsecs);
 
 /**
  * Step the cluster until the @i'th server has applied the entry at the given
- * index, or @max_msecs have elapsed. If @i equals the number of servers, then
+ * index, or @maxMsecs have elapsed. If @i equals the number of servers, then
  * step until all servers have applied the given entry.
  */
 RAFT_API bool raft_fixture_step_until_applied(struct raft_fixture *f,
                                               unsigned i,
                                               raft_index index,
-                                              unsigned max_msecs);
+                                              unsigned maxMsecs);
 
 /**
  * Step the cluster until the state of the @i'th server matches the given one,
- * or @max_msecs have elapsed.
+ * or @maxMsecs have elapsed.
  */
 RAFT_API bool raft_fixture_step_until_state_is(struct raft_fixture *f,
                                                unsigned i,
                                                int state,
-                                               unsigned max_msecs);
+                                               unsigned maxMsecs);
 
 /**
  * Step the cluster until the term of the @i'th server matches the given one,
- * or @max_msecs have elapsed.
+ * or @maxMsecs have elapsed.
  */
 RAFT_API bool raft_fixture_step_until_term_is(struct raft_fixture *f,
                                               unsigned i,
                                               raft_term term,
-                                              unsigned max_msecs);
+                                              unsigned maxMsecs);
 
 /**
  * Step the cluster until the @i'th server has voted for the @j'th one, or
- * @max_msecs have elapsed.
+ * @maxMsecs have elapsed.
  */
 RAFT_API bool raft_fixture_step_until_voted_for(struct raft_fixture *f,
                                                 unsigned i,
                                                 unsigned j,
-                                                unsigned max_msecs);
+                                                unsigned maxMsecs);
 
 /**
  * Step the cluster until all pending network messages from the @i'th server to
- * the @j'th server have been delivered, or @max_msecs have elapsed.
+ * the @j'th server have been delivered, or @maxMsecs have elapsed.
  */
 RAFT_API bool raft_fixture_step_until_delivered(struct raft_fixture *f,
                                                 unsigned i,
                                                 unsigned j,
-                                                unsigned max_msecs);
+                                                unsigned maxMsecs);
 
 /**
  * Set a function to be called after every time a fixture event occurs as

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -90,10 +90,10 @@ RAFT_API void raft_fixture_close(struct raft_fixture *f);
 
 /**
  * Convenience to generate a configuration object containing all servers in the
- * cluster. The first @n_voting servers will be voting ones.
+ * cluster. The first @nVoting servers will be voting ones.
  */
 RAFT_API int raft_fixture_configuration(struct raft_fixture *f,
-                                        unsigned n_voting,
+                                        unsigned nVoting,
                                         struct raft_configuration *conf);
 
 /**

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -168,28 +168,28 @@ RAFT_API void raft_fixture_depose(struct raft_fixture *f);
  *
  * In particular, the following happens:
  *
- * 1. If there are pending #raft_io_send requests, that have been submitted
- *    using #raft_io->send() and not yet sent, the oldest one is picked and the
+ * 1. If there are pending #raftIo_send requests, that have been submitted
+ *    using #raftIo->send() and not yet sent, the oldest one is picked and the
  *    relevant callback fired. This simulates completion of a socket write,
  *    which means that the send request has been completed. The receiver does
  *    not immediately receives the message, as the message is propagating
- *    through the network. However any memory associated with the #raft_io_send
+ *    through the network. However any memory associated with the #raftIo_send
  *    request can be released (e.g. log entries). The in-memory I/O
  *    implementation assigns a latency to each RPC message, which will get
  *    delivered to the receiver only after that amount of time elapses. If the
  *    sender and the receiver are currently disconnected, the RPC message is
  *    simply dropped. If a callback was fired, jump directly to 3. and skip 2.
  *
- * 2. All pending #raft_io_append disk writes across all servers, that have been
- *    submitted using #raft_io->append() but not yet completed, are scanned and
+ * 2. All pending #raftIo_append disk writes across all servers, that have been
+ *    submitted using #raftIo->append() but not yet completed, are scanned and
  *    the one with the lowest completion time is picked. All in-flight network
  *    messages waiting to be delivered are scanned and the one with the lowest
  *    delivery time is picked. All servers are scanned, and the one with the
  *    lowest tick expiration time is picked. The three times are compared and
- *    the lowest one is picked. If a #raft_io_append disk write has completed,
+ *    the lowest one is picked. If a #raftIo_append disk write has completed,
  *    the relevant callback will be invoked, if there's a network message to be
  *    delivered, the receiver's @raft_io_recv_cb callback gets fired, if a tick
- *    timer has expired the relevant #raft_io->tick() callback will be
+ *    timer has expired the relevant #raftIo->tick() callback will be
  *    invoked. Only one event will be fired. If there is more than one event to
  *    fire, one of them is picked according to the following rules: events for
  *    servers with lower index are fired first, tick events take precedence over
@@ -359,7 +359,7 @@ RAFT_API int raft_fixture_grow(struct raft_fixture *f, struct raft_fsm *fsm);
 
 /**
  * Set the value that will be returned to the @i'th raft instance when it asks
- * the underlying #raft_io implementation for a randomized election timeout
+ * the underlying #raftIo implementation for a randomized election timeout
  * value. The default value is 1000 + @i * 100, meaning that the election timer
  * of server 0 will expire first.
  */

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -126,7 +126,7 @@ RAFT_API struct raft *raft_fixture_get(struct raft_fixture *f, unsigned i);
 /**
  * Return @true if the @i'th server hasn't been killed.
  */
-RAFT_API bool raft_fixture_alive(struct raft_fixture *f, unsigned i);
+RAFT_API bool raftFixtureAlive(struct raft_fixture *f, unsigned i);
 
 /**
  * Return the index of the current leader, or the current number of servers if

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -168,12 +168,12 @@ RAFT_API void raft_fixture_depose(struct raft_fixture *f);
  *
  * In particular, the following happens:
  *
- * 1. If there are pending #raftIo_send requests, that have been submitted
+ * 1. If there are pending #raftIoSend requests, that have been submitted
  *    using #raftIo->send() and not yet sent, the oldest one is picked and the
  *    relevant callback fired. This simulates completion of a socket write,
  *    which means that the send request has been completed. The receiver does
  *    not immediately receives the message, as the message is propagating
- *    through the network. However any memory associated with the #raftIo_send
+ *    through the network. However any memory associated with the #raftIoSend
  *    request can be released (e.g. log entries). The in-memory I/O
  *    implementation assigns a latency to each RPC message, which will get
  *    delivered to the receiver only after that amount of time elapses. If the

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -180,13 +180,13 @@ RAFT_API void raft_fixture_depose(struct raft_fixture *f);
  *    sender and the receiver are currently disconnected, the RPC message is
  *    simply dropped. If a callback was fired, jump directly to 3. and skip 2.
  *
- * 2. All pending #raftIo_append disk writes across all servers, that have been
+ * 2. All pending #raftIoAppend disk writes across all servers, that have been
  *    submitted using #raftIo->append() but not yet completed, are scanned and
  *    the one with the lowest completion time is picked. All in-flight network
  *    messages waiting to be delivered are scanned and the one with the lowest
  *    delivery time is picked. All servers are scanned, and the one with the
  *    lowest tick expiration time is picked. The three times are compared and
- *    the lowest one is picked. If a #raftIo_append disk write has completed,
+ *    the lowest one is picked. If a #raftIoAppend disk write has completed,
  *    the relevant callback will be invoked, if there's a network message to be
  *    delivered, the receiver's @raft_io_recv_cb callback gets fired, if a tick
  *    timer has expired the relevant #raftIo->tick() callback will be

--- a/include/raft/uv.h
+++ b/include/raft/uv.h
@@ -75,7 +75,7 @@ struct raft_uv_transport;
  *
  * [4 bytes] CRC32 checksum of the batch header, little endian.
  * [4 bytes] CRC32 checksum of the batch data, little endian.
- * [  ...  ] Batch (as described in @raft_decode_entries_batch).
+ * [  ...  ] Batch (as described in @raftDecodeEntriesBatch).
  *
  * [0] https://github.com/logcabin/logcabin/blob/master/Storage/SegmentedLog.h
  */

--- a/src/array.h
+++ b/src/array.h
@@ -8,18 +8,18 @@
 /* Append item I of type T to array A which currently has N items.
  *
  * A and N must both by pointers. Set RV to -1 in case of failure. */
-#define ARRAY__APPEND(T, I, A, N, RV)			     \
-    {                                                        \
-        T *tmp_array;                                        \
-        tmp_array = raft_realloc(*A, (*N + 1) * sizeof **A); \
-        if (tmp_array != NULL) {                             \
-            (*N)++;                                          \
-            *A = tmp_array;                                  \
-            (*A)[(*N) - 1] = I;                              \
-            RV = 0;                                          \
-        } else {                                             \
-            RV = -1;                                         \
-        }                                                    \
+#define ARRAY__APPEND(T, I, A, N, RV)                       \
+    {                                                       \
+        T *tmpArray;                                        \
+        tmpArray = raft_realloc(*A, (*N + 1) * sizeof **A); \
+        if (tmpArray != NULL) {                             \
+            (*N)++;                                         \
+            *A = tmpArray;                                  \
+            (*A)[(*N) - 1] = I;                             \
+            RV = 0;                                         \
+        } else {                                            \
+            RV = -1;                                        \
+        }                                                   \
     }
 
 #endif /* ARRAY_H_ */

--- a/src/assert.h
+++ b/src/assert.h
@@ -4,15 +4,15 @@
 #define ASSERT_H_
 
 #if defined(RAFT_TEST)
-extern void munit_errorf_ex(const char *filename,
-                            int line,
-                            const char *format,
-                            ...);
-#define assert(expr)                                                          \
-    do {                                                                      \
-        if (!expr) {                                                          \
-            munit_errorf_ex(__FILE__, __LINE__, "assertion failed: ", #expr); \
-        }                                                                     \
+extern void munitErrorfEx(const char *filename,
+                          int line,
+                          const char *format,
+                          ...);
+#define assert(expr)                                                        \
+    do {                                                                    \
+        if (!expr) {                                                        \
+            munitErrorfEx(__FILE__, __LINE__, "assertion failed: ", #expr); \
+        }                                                                   \
     } while (0)
 #elif defined(NDEBUG)
 #define assert(x)        \

--- a/src/byte.h
+++ b/src/byte.h
@@ -145,18 +145,18 @@ BYTE_INLINE uint64_t byteGet64Unaligned(const void **cursor)
     return byteFlip64(value);
 }
 
-BYTE_INLINE const char *byteGetString(const void **cursor, size_t max_len)
+BYTE_INLINE const char *byteGetString(const void **cursor, size_t maxLen)
 {
     const char **p = (const char **)cursor;
     const char *value = *p;
     size_t len = 0;
-    while (len < max_len) {
+    while (len < maxLen) {
         if (*(*p + len) == 0) {
             break;
         }
         len++;
     }
-    if (len == max_len) {
+    if (len == maxLen) {
         return NULL;
     }
     *p += len + 1;

--- a/src/byte.h
+++ b/src/byte.h
@@ -23,7 +23,7 @@
 #define BYTE_LITTLE_ENDIAN
 #elif defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN) && \
     defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8
-#define RAFT__BIG_ENDIAN
+#define RAFT_BIG_ENDIAN
 #endif
 
 /* Flip a 32-bit number to network byte order (little endian) */
@@ -31,7 +31,7 @@ BYTE_INLINE uint32_t byteFlip32(uint32_t v)
 {
 #if defined(BYTE_LITTLE_ENDIAN)
     return v;
-#elif defined(RAFT__BIG_ENDIAN)
+#elif defined(RAFT_BIG_ENDIAN)
     return __builtin_bswap32(v);
 #else /* Unknown endianess */
     union {
@@ -53,7 +53,7 @@ BYTE_INLINE uint64_t byteFlip64(uint64_t v)
 {
 #if defined(BYTE_LITTLE_ENDIAN)
     return v;
-#elif defined(RAFT__BIG_ENDIAN)
+#elif defined(RAFT_BIG_ENDIAN)
     return __builtin_bswap64(v);
 #else
     union {

--- a/src/convert.h
+++ b/src/convert.h
@@ -22,9 +22,9 @@ void convertToFollower(struct raft *r);
  *
  *   On conversion to candidate, start election
  *
- * If the disrupt_leader flag is true, the server will set the disrupt leader
+ * If the disruptLeader flag is true, the server will set the disrupt leader
  * flag of the RequestVote messages it sends.  */
-int convertToCandidate(struct raft *r, bool disrupt_leader);
+int convertToCandidate(struct raft *r, bool disruptLeader);
 
 /* Convert from candidate to leader.
  *

--- a/src/election.h
+++ b/src/election.h
@@ -5,7 +5,7 @@
 
 #include "../include/raft.h"
 
-/* Reset the election_timer clock and set randomized_election_timeout to a
+/* Reset the electionTimer clock and set randomized_election_timeout to a
  * random value between election_timeout and 2 * election_timeout.
  *
  * From Section 3.4:

--- a/src/election.h
+++ b/src/election.h
@@ -76,6 +76,6 @@ int electionVote(struct raft *r,
 /* Update the votes array by adding the vote from the server at the given
  * index. Return true if with this vote the server has reached the majority of
  * votes and won elections. */
-bool electionTally(struct raft *r, size_t voter_index);
+bool electionTally(struct raft *r, size_t voterIndex);
 
 #endif /* ELECTION_H_ */

--- a/src/log.h
+++ b/src/log.h
@@ -90,17 +90,17 @@ void logTruncate(struct raft_log *l, const raft_index index);
 void logDiscard(struct raft_log *l, const raft_index index);
 
 /* To be called when taking a new snapshot. The log must contain an entry at
- * last_index, which is the index of the last entry included in the
+ * lastIndex, which is the index of the last entry included in the
  * snapshot. The function will update the last snapshot information and delete
- * all entries up last_index - trailing (included). If the log contains no entry
- * a last_index - trailing, then no entry will be deleted. */
-void logSnapshot(struct raft_log *l, raft_index last_index, unsigned trailing);
+ * all entries up lastIndex - trailing (included). If the log contains no entry
+ * a lastIndex - trailing, then no entry will be deleted. */
+void logSnapshot(struct raft_log *l, raft_index lastIndex, unsigned trailing);
 
 /* To be called when installing a snapshot.
  *
  * The log can be in any state. All outstanding entries will be discarded, the
  * last index and last term of the most recent snapshot will be set to the given
  * values, and the offset adjusted accordingly. */
-void logRestore(struct raft_log *l, raft_index last_index, raft_term last_term);
+void logRestore(struct raft_log *l, raft_index lastIndex, raft_term last_term);
 
 #endif /* RAFT_LOG_H_ */

--- a/src/log.h
+++ b/src/log.h
@@ -16,9 +16,9 @@ void logClose(struct raft_log *l);
 
 /* Called at startup when populating the log with entries loaded from disk. It
  * sets the starting state of the log. The start index must be lower or equal
- * than snapshot_index + 1. */
+ * than snapshotIndex + 1. */
 void logStart(struct raft_log *l,
-              raft_index snapshot_index,
+              raft_index snapshotIndex,
               raft_term snapshot_term,
               raft_index start_index);
 

--- a/src/log.h
+++ b/src/log.h
@@ -19,7 +19,7 @@ void logClose(struct raft_log *l);
  * than snapshotIndex + 1. */
 void logStart(struct raft_log *l,
               raft_index snapshotIndex,
-              raft_term snapshot_term,
+              raft_term snapshotTerm,
               raft_index start_index);
 
 /* Get the number of entries the log currently contains. */

--- a/src/log.h
+++ b/src/log.h
@@ -20,7 +20,7 @@ void logClose(struct raft_log *l);
 void logStart(struct raft_log *l,
               raft_index snapshotIndex,
               raft_term snapshotTerm,
-              raft_index start_index);
+              raft_index startIndex);
 
 /* Get the number of entries the log currently contains. */
 size_t logNumEntries(struct raft_log *l);

--- a/src/log.h
+++ b/src/log.h
@@ -101,6 +101,6 @@ void logSnapshot(struct raft_log *l, raft_index lastIndex, unsigned trailing);
  * The log can be in any state. All outstanding entries will be discarded, the
  * last index and last term of the most recent snapshot will be set to the given
  * values, and the offset adjusted accordingly. */
-void logRestore(struct raft_log *l, raft_index lastIndex, raft_term last_term);
+void logRestore(struct raft_log *l, raft_index lastIndex, raft_term lastTerm);
 
 #endif /* RAFT_LOG_H_ */

--- a/src/progress.h
+++ b/src/progress.h
@@ -87,16 +87,16 @@ void progressOptimisticNextIndex(struct raft *r,
 /* Return false if the given @index comes from an outdated message. Otherwise
  * update the progress and returns true. To be called when receiving a
  * successful AppendEntries RPC response. */
-bool progressMaybeUpdate(struct raft *r, unsigned i, raft_index last_index);
+bool progressMaybeUpdate(struct raft *r, unsigned i, raft_index lastIndex);
 
 /* Return false if the given rejected index comes from an out of order
  * message. Otherwise decrease the progress next index to min(rejected,
- * last_index) and returns true. To be called when receiving an unsuccessful
+ * lastIndex) and returns true. To be called when receiving an unsuccessful
  * AppendEntries RPC response. */
 bool progressMaybeDecrement(struct raft *r,
                             unsigned i,
                             raft_index rejected,
-                            raft_index last_index);
+                            raft_index lastIndex);
 
 /* Return true if match_index is equal or higher than the snapshot_index. */
 bool progressSnapshotDone(struct raft *r, unsigned i);

--- a/src/progress.h
+++ b/src/progress.h
@@ -5,7 +5,7 @@
 
 #include "../include/raft.h"
 
-/* Possible values for the state field of struct raft_progress. */
+/* Possible values for the state field of struct raftProgress. */
 enum {
     PROGRESS__PROBE = 0, /* At most one AppendEntries per heartbeat interval */
     PROGRESS__PIPELINE,  /* Optimistically stream AppendEntries */

--- a/src/progress.h
+++ b/src/progress.h
@@ -45,7 +45,7 @@ raft_index progressNextIndex(struct raft *r, unsigned i);
  * as replicated. */
 raft_index progressMatchIndex(struct raft *r, unsigned i);
 
-/* Update the last_send timestamp after an AppendEntries request has been
+/* Update the lastSend timestamp after an AppendEntries request has been
  * sent. */
 void progressUpdateLastSend(struct raft *r, unsigned i);
 

--- a/src/progress.h
+++ b/src/progress.h
@@ -98,7 +98,7 @@ bool progressMaybeDecrement(struct raft *r,
                             raft_index rejected,
                             raft_index lastIndex);
 
-/* Return true if match_index is equal or higher than the snapshot_index. */
+/* Return true if matchIndex is equal or higher than the snapshot_index. */
 bool progressSnapshotDone(struct raft *r, unsigned i);
 
 #endif /* PROGRESS_H_ */

--- a/src/progress.h
+++ b/src/progress.h
@@ -98,7 +98,7 @@ bool progressMaybeDecrement(struct raft *r,
                             raft_index rejected,
                             raft_index lastIndex);
 
-/* Return true if matchIndex is equal or higher than the snapshot_index. */
+/* Return true if matchIndex is equal or higher than the snapshotIndex. */
 bool progressSnapshotDone(struct raft *r, unsigned i);
 
 #endif /* PROGRESS_H_ */

--- a/src/progress.h
+++ b/src/progress.h
@@ -49,13 +49,13 @@ raft_index progressMatchIndex(struct raft *r, unsigned i);
  * sent. */
 void progressUpdateLastSend(struct raft *r, unsigned i);
 
-/* Reset to false the recent_recv flag of the server at the given index,
+/* Reset to false the recentRecv flag of the server at the given index,
  * returning the previous value.
  *
  * To be called once every election_timeout milliseconds. */
 bool progressResetRecentRecv(struct raft *r, unsigned i);
 
-/* Set to true the recent_recv flag of the server at the given index.
+/* Set to true the recentRecv flag of the server at the given index.
  *
  * To be called whenever we receive an AppendEntries RPC result */
 void progressMarkRecentRecv(struct raft *r, unsigned i);

--- a/src/raft.c
+++ b/src/raft.c
@@ -120,7 +120,7 @@ void raft_set_snapshot_trailing(struct raft *r, unsigned n)
     r->snapshot.trailing = n;
 }
 
-void raft_set_max_catch_up_rounds(struct raft *r, unsigned n)
+void raftSetMaxCatchUpRounds(struct raft *r, unsigned n)
 {
     r->max_catch_up_rounds = n;
 }

--- a/src/raft.c
+++ b/src/raft.c
@@ -195,8 +195,8 @@ int raft_configuration_add(struct raft_configuration *c,
     return configurationAdd(c, id, address, role);
 }
 
-int raft_configuration_encode(const struct raft_configuration *c,
-                              struct raft_buffer *buf)
+int raftConfigurationEncode(const struct raft_configuration *c,
+                            struct raft_buffer *buf)
 {
     return configurationEncode(c, buf);
 }

--- a/src/raft.c
+++ b/src/raft.c
@@ -125,7 +125,7 @@ void raft_set_max_catch_up_rounds(struct raft *r, unsigned n)
     r->max_catch_up_rounds = n;
 }
 
-void raft_set_max_catch_up_round_duration(struct raft *r, unsigned msecs)
+void raftSetMaxCatchUpRoundDuration(struct raft *r, unsigned msecs)
 {
     r->max_catch_up_round_duration = msecs;
 }

--- a/src/raft.c
+++ b/src/raft.c
@@ -68,11 +68,11 @@ int raft_init(struct raft *r,
     rv = r->io->init(r->io, r->id, r->address);
     if (rv != 0) {
         ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
-        goto err_after_address_alloc;
+        goto errAfterAddressAlloc;
     }
     return 0;
 
-err_after_address_alloc:
+errAfterAddressAlloc:
     HeapFree(r->address);
 err:
     assert(rv != 0);

--- a/src/replication.h
+++ b/src/replication.h
@@ -57,7 +57,7 @@ int replicationUpdate(struct raft *r,
  * satisfied.
  *
  * The rejected output parameter will be set to 0 if the Log Matching Property
- * was satisfied, or to args->prev_log_index if not.
+ * was satisfied, or to args->prevLogIndex if not.
  *
  * The async output parameter will be set to true if some of the entries in the
  * request were not present in our log, and a disk write was started to persist

--- a/src/request.h
+++ b/src/request.h
@@ -6,7 +6,7 @@
 /* Abstract request type */
 struct request
 {
-    /* Must be kept in sync with RAFT__REQUEST in raft.h */
+    /* Must be kept in sync with RAFT_REQUEST in raft.h */
     void *data;
     int type;
     raft_index index;

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -37,11 +37,11 @@ int io_uring_register(int fd,
 
 int io_uring_setup(unsigned int entries, struct io_uring_params *p);
 
-int io_uring_enter(int fd,
-                   unsigned int to_submit,
-                   unsigned int min_complete,
-                   unsigned int flags,
-                   sigset_t *sig);
+int ioUringEnter(int fd,
+                 unsigned int to_submit,
+                 unsigned int min_complete,
+                 unsigned int flags,
+                 sigset_t *sig);
 #endif
 
 #endif /* SYSCALL_ */

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -30,10 +30,10 @@ int io_getevents(aio_context_t ctxId,
 
 #if HAVE_LINUX_IO_URING_H
 /* uring */
-int io_uring_register(int fd,
-                      unsigned int opcode,
-                      const void *arg,
-                      unsigned int nr_args);
+int ioUringRegister(int fd,
+                    unsigned int opcode,
+                    const void *arg,
+                    unsigned int nr_args);
 
 int io_uring_setup(unsigned int entries, struct io_uring_params *p);
 

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -33,7 +33,7 @@ int io_getevents(aio_context_t ctxId,
 int ioUringRegister(int fd,
                     unsigned int opcode,
                     const void *arg,
-                    unsigned int nr_args);
+                    unsigned int nrArgs);
 
 int ioUringSetup(unsigned int entries, struct io_uring_params *p);
 

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -39,7 +39,7 @@ int ioUringSetup(unsigned int entries, struct io_uring_params *p);
 
 int ioUringEnter(int fd,
                  unsigned int to_submit,
-                 unsigned int min_complete,
+                 unsigned int minComplete,
                  unsigned int flags,
                  sigset_t *sig);
 #endif

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -38,7 +38,7 @@ int ioUringRegister(int fd,
 int ioUringSetup(unsigned int entries, struct io_uring_params *p);
 
 int ioUringEnter(int fd,
-                 unsigned int to_submit,
+                 unsigned int toSubmit,
                  unsigned int minComplete,
                  unsigned int flags,
                  sigset_t *sig);

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -35,7 +35,7 @@ int ioUringRegister(int fd,
                     const void *arg,
                     unsigned int nr_args);
 
-int io_uring_setup(unsigned int entries, struct io_uring_params *p);
+int ioUringSetup(unsigned int entries, struct io_uring_params *p);
 
 int ioUringEnter(int fd,
                  unsigned int to_submit,

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -22,7 +22,7 @@ int io_destroy(aio_context_t ctxId);
 int io_submit(aio_context_t ctxId, long nr, struct iocb **iocbpp);
 
 int io_getevents(aio_context_t ctxId,
-                 long min_nr,
+                 long minNr,
                  long nr,
                  struct io_event *events,
                  struct timespec *timeout);

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -15,7 +15,7 @@
 
 #if HAVE_LINUX_AIO_ABI_H
 /* AIO */
-int io_setup(unsigned nr_events, aio_context_t *ctxIdp);
+int io_setup(unsigned nrEvents, aio_context_t *ctxIdp);
 
 int io_destroy(aio_context_t ctxId);
 

--- a/src/uv.h
+++ b/src/uv.h
@@ -153,7 +153,7 @@ int uvSegmentLoadClosed(struct uv *uv,
 int uvSegmentLoadAll(struct uv *uv,
                      const raft_index start_index,
                      struct uvSegmentInfo *segments,
-                     size_t n_segments,
+                     size_t nSegments,
                      struct raft_entry **entries,
                      size_t *nEntries);
 
@@ -268,7 +268,7 @@ int UvList(struct uv *uv,
            struct uvSnapshotInfo *snapshots[],
            size_t *n_snapshots,
            struct uvSegmentInfo *segments[],
-           size_t *n_segments,
+           size_t *nSegments,
            char *errmsg);
 
 /* Request to obtain a newly prepared open segment. */

--- a/src/uv.h
+++ b/src/uv.h
@@ -148,10 +148,10 @@ int uvSegmentLoadClosed(struct uv *uv,
                         struct raft_entry *entries[],
                         size_t *n);
 
-/* Load raft entries from the given segments. The @start_index is the expected
+/* Load raft entries from the given segments. The @startIndex is the expected
  * index of the first entry of the first segment. */
 int uvSegmentLoadAll(struct uv *uv,
-                     const raft_index start_index,
+                     const raft_index startIndex,
                      struct uvSegmentInfo *segments,
                      size_t nSegments,
                      struct raft_entry **entries,

--- a/src/uv.h
+++ b/src/uv.h
@@ -266,7 +266,7 @@ int UvSnapshotGet(struct raft_io *io,
  * open ones). */
 int UvList(struct uv *uv,
            struct uvSnapshotInfo *snapshots[],
-           size_t *n_snapshots,
+           size_t *nSnapshots,
            struct uvSegmentInfo *segments[],
            size_t *nSegments,
            char *errmsg);

--- a/src/uv.h
+++ b/src/uv.h
@@ -280,7 +280,7 @@ struct uvPrepare
     uv_file fd;                 /* Resulting segment file descriptor */
     unsigned long long counter; /* Resulting segment counter */
     uvPrepareCb cb;             /* Completion callback */
-    queue queue;                /* Links in uv_io->prepare_reqs */
+    queue queue;                /* Links in uvIo->prepare_reqs */
 };
 
 /* Get a prepared open segment ready for writing. If a prepared open segment is

--- a/src/uv.h
+++ b/src/uv.h
@@ -155,7 +155,7 @@ int uvSegmentLoadAll(struct uv *uv,
                      struct uvSegmentInfo *segments,
                      size_t n_segments,
                      struct raft_entry **entries,
-                     size_t *n_entries);
+                     size_t *nEntries);
 
 /* Return the number of blocks in a segments. */
 #define uvSegmentBlocks(UV) (UV->segment_size / UV->block_size)
@@ -187,7 +187,7 @@ int uvSegmentBufferFormat(struct uvSegmentBuffer *b);
  * will be appended. */
 int uvSegmentBufferAppend(struct uvSegmentBuffer *b,
                           const struct raft_entry entries[],
-                          unsigned n_entries);
+                          unsigned nEntries);
 
 /* After all entries to write have been encoded, finalize the buffer by zeroing
  * the unused memory of the last block. The out parameter will point to the

--- a/src/uv.h
+++ b/src/uv.h
@@ -138,7 +138,7 @@ void uvSegmentSort(struct uvSegmentInfo *infos, size_t n_infos);
 int uvSegmentKeepTrailing(struct uv *uv,
                           struct uvSegmentInfo *segments,
                           size_t n,
-                          raft_index last_index,
+                          raft_index lastIndex,
                           size_t trailing,
                           char *errmsg);
 
@@ -353,7 +353,7 @@ int UvFinalize(struct uv *uv,
                unsigned long long counter,
                size_t used,
                raft_index first_index,
-               raft_index last_index);
+               raft_index lastIndex);
 
 /* Implementation of raft_io->send. */
 int UvSend(struct raft_io *io,

--- a/src/uv.h
+++ b/src/uv.h
@@ -249,14 +249,14 @@ int UvSnapshotLoad(struct uv *uv,
                    struct raft_snapshot *snapshot,
                    char *errmsg);
 
-/* Implementation raft_io->snapshot_put (defined in uv_snapshot.c). */
+/* Implementation raft_io->snapshot_put (defined in uvSnapshot.c). */
 int UvSnapshotPut(struct raft_io *io,
                   unsigned trailing,
                   struct raft_io_snapshot_put *req,
                   const struct raft_snapshot *snapshot,
                   raft_io_snapshot_put_cb cb);
 
-/* Implementation of raft_io->snapshot_get (defined in uv_snapshot.c). */
+/* Implementation of raft_io->snapshot_get (defined in uvSnapshot.c). */
 int UvSnapshotGet(struct raft_io *io,
                   struct raft_io_snapshot_get *req,
                   raft_io_snapshot_get_cb cb);

--- a/src/uv.h
+++ b/src/uv.h
@@ -21,7 +21,7 @@
 #define UV__OPEN_TEMPLATE "open-%llu"
 
 /* Enough to hold a segment filename (either open or closed) */
-#define UV__SEGMENT_FILENAME_BUF_SIZE 34
+#define UV_SEGMENT_FILENAME_BUF_SIZE 34
 
 /* Template string for snapshot filenames: snapshot term, snapshot index,
  * creation timestamp (milliseconds since epoch). */
@@ -117,7 +117,7 @@ struct uvSegmentInfo
             unsigned long long counter; /* Open segment counter */
         };
     };
-    char filename[UV__SEGMENT_FILENAME_BUF_SIZE]; /* Segment filename */
+    char filename[UV_SEGMENT_FILENAME_BUF_SIZE]; /* Segment filename */
 };
 
 /* Append a new item to the given segment info list if the given filename

--- a/src/uv.h
+++ b/src/uv.h
@@ -125,12 +125,12 @@ struct uvSegmentInfo
  * segment (open-xxx). */
 int uvSegmentInfoAppendIfMatch(const char *filename,
                                struct uvSegmentInfo *infos[],
-                               size_t *n_infos,
+                               size_t *nInfos,
                                bool *appended);
 
 /* Sort the given list of segments by comparing their filenames. Closed segments
  * come before open segments. */
-void uvSegmentSort(struct uvSegmentInfo *infos, size_t n_infos);
+void uvSegmentSort(struct uvSegmentInfo *infos, size_t nInfos);
 
 /* Keep only the closed segments whose entries are within the given trailing
  * amount past the given snapshot last index. If the given trailing amount is 0,
@@ -236,12 +236,12 @@ void uvSnapshotFilenameOf(struct uvSnapshotInfo *info, char *filename);
 int UvSnapshotInfoAppendIfMatch(struct uv *uv,
                                 const char *filename,
                                 struct uvSnapshotInfo *infos[],
-                                size_t *n_infos,
+                                size_t *nInfos,
                                 bool *appended);
 
 /* Sort the given list of snapshots by comparing their filenames. Older
  * snapshots will come first. */
-void UvSnapshotSort(struct uvSnapshotInfo *infos, size_t n_infos);
+void UvSnapshotSort(struct uvSnapshotInfo *infos, size_t nInfos);
 
 /* Load the snapshot associated with the given metadata. */
 int UvSnapshotLoad(struct uv *uv,

--- a/src/uv.h
+++ b/src/uv.h
@@ -54,7 +54,7 @@ struct uv
 {
     struct raft_io *io;                  /* I/O object we're implementing */
     struct uv_loop_s *loop;              /* UV event loop */
-    char dir[UV__DIR_LEN];               /* Data directory */
+    char dir[UV_DIR_LEN];                /* Data directory */
     struct raft_uv_transport *transport; /* Network transport */
     struct raft_tracer *tracer;          /* Debug tracing */
     raft_id id;                          /* Server ID */

--- a/src/uv_encoding.h
+++ b/src/uv_encoding.h
@@ -17,7 +17,7 @@ int uvEncodeMessage(const struct raft_message *message,
 int uvDecodeMessage(unsigned long type,
                     const uv_buf_t *header,
                     struct raft_message *message,
-                    size_t *payload_len);
+                    size_t *payloadLen);
 
 int uvDecodeBatchHeader(const void *batch,
                         struct raft_entry **entries,

--- a/src/uv_os.h
+++ b/src/uv_os.h
@@ -59,10 +59,10 @@
 #define LEN_AT_MOST_(STR, LEN) (strnlen(STR, LEN + 1) <= LEN)
 
 /* Maximum length of a directory path string. */
-#define UV__DIR_LEN (UV__PATH_SZ - UV__SEP_LEN - UV__FILENAME_LEN - 1)
+#define UV_DIR_LEN (UV__PATH_SZ - UV__SEP_LEN - UV__FILENAME_LEN - 1)
 
-/* True if the given DIR string has at most UV__DIR_LEN chars. */
-#define UV__DIR_HAS_VALID_LEN(DIR) LEN_AT_MOST_(DIR, UV__DIR_LEN)
+/* True if the given DIR string has at most UV_DIR_LEN chars. */
+#define UV__DIR_HAS_VALID_LEN(DIR) LEN_AT_MOST_(DIR, UV_DIR_LEN)
 
 /* True if the given FILENAME string has at most UV__FILENAME_LEN chars. */
 #define UV__FILENAME_HAS_VALID_LEN(FILENAME) \

--- a/src/uv_os.h
+++ b/src/uv_os.h
@@ -109,7 +109,7 @@ int UvOsIoSetup(unsigned nr, aio_context_t *ctxp);
 int UvOsIoDestroy(aio_context_t ctx);
 int UvOsIoSubmit(aio_context_t ctx, long nr, struct iocb **iocbpp);
 int UvOsIoGetevents(aio_context_t ctx,
-                    long min_nr,
+                    long minNr,
                     long maxNr,
                     struct io_event *events,
                     struct timespec *timeout);

--- a/src/uv_os.h
+++ b/src/uv_os.h
@@ -110,7 +110,7 @@ int UvOsIoDestroy(aio_context_t ctx);
 int UvOsIoSubmit(aio_context_t ctx, long nr, struct iocb **iocbpp);
 int UvOsIoGetevents(aio_context_t ctx,
                     long min_nr,
-                    long max_nr,
+                    long maxNr,
                     struct io_event *events,
                     struct timespec *timeout);
 int UvOsEventfd(unsigned int initval, int flags);

--- a/src/uv_os.h
+++ b/src/uv_os.h
@@ -53,13 +53,13 @@
 #define UV__FILENAME_LEN 128
 
 /* Length of path separator. */
-#define UV__SEP_LEN 1 /* strlen("/") */
+#define UV_SEP_LEN 1 /* strlen("/") */
 
 /* True if STR's length is at most LEN. */
 #define LEN_AT_MOST_(STR, LEN) (strnlen(STR, LEN + 1) <= LEN)
 
 /* Maximum length of a directory path string. */
-#define UV_DIR_LEN (UV__PATH_SZ - UV__SEP_LEN - UV__FILENAME_LEN - 1)
+#define UV_DIR_LEN (UV__PATH_SZ - UV_SEP_LEN - UV__FILENAME_LEN - 1)
 
 /* True if the given DIR string has at most UV_DIR_LEN chars. */
 #define UV__DIR_HAS_VALID_LEN(DIR) LEN_AT_MOST_(DIR, UV_DIR_LEN)

--- a/src/uv_writer.h
+++ b/src/uv_writer.h
@@ -41,7 +41,7 @@ int UvWriterInit(struct UvWriter *w,
                  uv_file fd,
                  bool direct /* Whether to use direct I/O */,
                  bool async /* Whether async I/O is available */,
-                 unsigned max_concurrent_writes,
+                 unsigned maxConcurrentWrites,
                  char *errmsg);
 
 /* Close the given file and release all associated resources. */

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -279,17 +279,17 @@
 
 /* Add a new pristine server to the cluster, connected to all others. Then
  * submit a request to add it to the configuration as an idle server. */
-#define CLUSTER_ADD(REQ)                                               \
-    {                                                                  \
-        int rc;                                                        \
-        struct raft *new_raft;                                         \
-        CLUSTER_GROW;                                                  \
-        rc = raft_start(CLUSTER_RAFT(CLUSTER_N - 1));                  \
-        munit_assert_int(rc, ==, 0);                                   \
-        new_raft = CLUSTER_RAFT(CLUSTER_N - 1);                        \
-        rc = raft_add(CLUSTER_RAFT(CLUSTER_LEADER), REQ, new_raft->id, \
-                      new_raft->address, NULL);                        \
-        munit_assert_int(rc, ==, 0);                                   \
+#define CLUSTER_ADD(REQ)                                              \
+    {                                                                 \
+        int rc;                                                       \
+        struct raft *newRaft;                                         \
+        CLUSTER_GROW;                                                 \
+        rc = raft_start(CLUSTER_RAFT(CLUSTER_N - 1));                 \
+        munit_assert_int(rc, ==, 0);                                  \
+        newRaft = CLUSTER_RAFT(CLUSTER_N - 1);                        \
+        rc = raft_add(CLUSTER_RAFT(CLUSTER_LEADER), REQ, newRaft->id, \
+                      newRaft->address, NULL);                        \
+        munit_assert_int(rc, ==, 0);                                  \
     }
 
 /* Assign the given role to the server that was added last. */

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -381,7 +381,7 @@
 
 /* Make an I/O error occur on the I'th server after @DELAY operations. */
 #define CLUSTER_IO_FAULT(I, DELAY, REPEAT) \
-    raft_fixture_io_fault(&f->cluster, I, DELAY, REPEAT)
+    raftFixtureIoFault(&f->cluster, I, DELAY, REPEAT)
 
 /* Return the number of messages sent by the given server. */
 #define CLUSTER_N_SEND(I, TYPE) raft_fixture_n_send(&f->cluster, I, TYPE)

--- a/test/lib/dir.h
+++ b/test/lib/dir.h
@@ -12,7 +12,7 @@
 #include "munit.h"
 
 /* Munit parameter defining the file system type backing the temporary directory
- * created by test_dir_setup().
+ * created by testDirSetup().
  *
  * The various file systems must have been previously setup with the fs.sh
  * script. */

--- a/test/lib/loop.h
+++ b/test/lib/loop.h
@@ -51,9 +51,9 @@
  * iterations is reached. */
 #define LOOP_RUN(N)                                                       \
     {                                                                     \
-        unsigned i__;                                                     \
+        unsigned i_;                                                      \
         int rv__;                                                         \
-        for (i__ = 0; i__ < N; i__++) {                                   \
+        for (i_ = 0; i_ < N; i_++) {                                      \
             rv__ = uv_run(&f->loop, UV_RUN_ONCE);                         \
             if (rv__ < 0) {                                               \
                 munit_errorf("uv_run: %s (%d)", uv_strerror(rv__), rv__); \

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -39,7 +39,7 @@ extern int _main_suites_n;
  * the prefix attribute of the slot will be set to /S. */
 #define SUITE(S)      \
     SUITE__DECLARE(S) \
-    SUITE__ADD_CHILD(main, #S, S)
+    SUITE_ADD_CHILD(main, #S, S)
 
 /* Declare and register a new test. */
 #define TEST(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)                \
@@ -76,7 +76,7 @@ extern int _main_suites_n;
 /* Set the tests and suites attributes of the next available slot of the
  * MunitSuite[] array of S1 to the MunitTest[] and MunitSuite[] arrays of S2,
  * using the given PREXIX. */
-#define SUITE__ADD_CHILD(S1, PREFIX, S2)                               \
+#define SUITE_ADD_CHILD(S1, PREFIX, S2)                                \
     __attribute__((constructor)) static void _##S1##_##S2##_init(void) \
     {                                                                  \
         int n = _##S1##_suites_n;                                      \

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -14,11 +14,11 @@ extern MunitSuite _main_suites[];
 extern int _main_suites_n;
 
 /* Maximum number of test cases for each suite */
-#define SUITE__CAP 128
+#define SUITE_CAP 128
 
 /* Define the top-level suites array and the main() function of the test. */
 #define RUNNER(NAME)                                               \
-    MunitSuite _main_suites[SUITE__CAP];                           \
+    MunitSuite _main_suites[SUITE_CAP];                            \
     int _main_suites_n = 0;                                        \
                                                                    \
     int main(int argc, char *argv[MUNIT_ARRAY_PARAM(argc + 1)])    \
@@ -31,8 +31,8 @@ extern int _main_suites_n;
  *
  * A test suite is a pair of static variables:
  *
- * static MunitTest _##S##_suites[SUITE__CAP]
- * static MunitTest _##S##_tests[SUITE__CAP]
+ * static MunitTest _##S##_suites[SUITE_CAP]
+ * static MunitTest _##S##_tests[SUITE_CAP]
  *
  * The tests and suites attributes of the next available MunitSuite slot in the
  * _module_suites array will be set to the suite's tests and suites arrays, and
@@ -57,8 +57,8 @@ extern int _main_suites_n;
 /* Declare the MunitSuite[] and the MunitTest[] arrays that compose the test
  * suite identified by S. */
 #define SUITE__DECLARE(S)                                      \
-    static MunitSuite _##S##_suites[SUITE__CAP];               \
-    static MunitTest _##S##_tests[SUITE__CAP];                 \
+    static MunitSuite _##S##_suites[SUITE_CAP];                \
+    static MunitTest _##S##_tests[SUITE_CAP];                  \
     static MunitTestSetup _##S##_setup = NULL;                 \
     static MunitTestTearDown _##S##_tear_down = NULL;          \
     static int _##S##_suites_n = 0;                            \

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -89,24 +89,24 @@ extern int _main_suites_n;
     }
 
 /* Add a test case to the MunitTest[] array of suite S. */
-#define TEST_ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)             \
-    __attribute__((constructor)) static void _##S##_tests_##C##_init(void)     \
-    {                                                                          \
-        MunitTest *tests = _##S##_tests;                                       \
-        int n = _##S##_tests_n;                                                \
-        TEST__SET_IN_ARRAY(tests, n, "/" #C, test_##S##_##C, SETUP, TEAR_DOWN, \
-                           OPTIONS, PARAMS);                                   \
-        _##S##_tests_n = n + 1;                                                \
+#define TEST_ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)            \
+    __attribute__((constructor)) static void _##S##_tests_##C##_init(void)    \
+    {                                                                         \
+        MunitTest *tests = _##S##_tests;                                      \
+        int n = _##S##_tests_n;                                               \
+        TEST_SET_IN_ARRAY(tests, n, "/" #C, test_##S##_##C, SETUP, TEAR_DOWN, \
+                          OPTIONS, PARAMS);                                   \
+        _##S##_tests_n = n + 1;                                               \
     }
 
 /* Set the values of the I'th test case slot in the given test array */
-#define TEST__SET_IN_ARRAY(TESTS, I, NAME, FUNC, SETUP, TEAR_DOWN, OPTIONS, \
-                           PARAMS)                                          \
-    TESTS[I].name = NAME;                                                   \
-    TESTS[I].test = FUNC;                                                   \
-    TESTS[I].setup = SETUP;                                                 \
-    TESTS[I].tear_down = TEAR_DOWN;                                         \
-    TESTS[I].options = OPTIONS;                                             \
+#define TEST_SET_IN_ARRAY(TESTS, I, NAME, FUNC, SETUP, TEAR_DOWN, OPTIONS, \
+                          PARAMS)                                          \
+    TESTS[I].name = NAME;                                                  \
+    TESTS[I].test = FUNC;                                                  \
+    TESTS[I].setup = SETUP;                                                \
+    TESTS[I].tear_down = TEAR_DOWN;                                        \
+    TESTS[I].options = OPTIONS;                                            \
     TESTS[I].parameters = PARAMS
 
 #endif /* TEST_RUNNER_H_ */

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -37,8 +37,8 @@ extern int _main_suites_n;
  * The tests and suites attributes of the next available MunitSuite slot in the
  * _module_suites array will be set to the suite's tests and suites arrays, and
  * the prefix attribute of the slot will be set to /S. */
-#define SUITE(S)      \
-    SUITE__DECLARE(S) \
+#define SUITE(S)     \
+    SUITE_DECLARE(S) \
     SUITE_ADD_CHILD(main, #S, S)
 
 /* Declare and register a new test. */
@@ -56,7 +56,7 @@ extern int _main_suites_n;
 
 /* Declare the MunitSuite[] and the MunitTest[] arrays that compose the test
  * suite identified by S. */
-#define SUITE__DECLARE(S)                                      \
+#define SUITE_DECLARE(S)                                       \
     static MunitSuite _##S##_suites[SUITE_CAP];                \
     static MunitTest _##S##_tests[SUITE_CAP];                  \
     static MunitTestSetup _##S##_setup = NULL;                 \

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -45,7 +45,7 @@ extern int _main_suites_n;
 #define TEST(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)                \
     static MunitResult test_##S##_##C(const MunitParameter params[], \
                                       void *data);                   \
-    TEST__ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)      \
+    TEST_ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)       \
     static MunitResult test_##S##_##C(                               \
         MUNIT_UNUSED const MunitParameter params[], MUNIT_UNUSED void *data)
 
@@ -89,7 +89,7 @@ extern int _main_suites_n;
     }
 
 /* Add a test case to the MunitTest[] array of suite S. */
-#define TEST__ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)            \
+#define TEST_ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)             \
     __attribute__((constructor)) static void _##S##_tests_##C##_init(void)     \
     {                                                                          \
         MunitTest *tests = _##S##_tests;                                       \

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -32,7 +32,7 @@ extern int _main_suites_n;
  * A test suite is a pair of static variables:
  *
  * static MunitTest _##S##_suites[SUITE_CAP]
- * static MunitTest _##S##_tests[SUITE_CAP]
+ * static MunitTest _##S##Tests[SUITE_CAP]
  *
  * The tests and suites attributes of the next available MunitSuite slot in the
  * _module_suites array will be set to the suite's tests and suites arrays, and
@@ -58,17 +58,17 @@ extern int _main_suites_n;
  * suite identified by S. */
 #define SUITE_DECLARE(S)                                       \
     static MunitSuite _##S##_suites[SUITE_CAP];                \
-    static MunitTest _##S##_tests[SUITE_CAP];                  \
+    static MunitTest _##S##Tests[SUITE_CAP];                   \
     static MunitTestSetup _##S##_setup = NULL;                 \
     static MunitTestTearDown _##S##_tear_down = NULL;          \
     static int _##S##_suites_n = 0;                            \
-    static int _##S##_tests_n = 0;                             \
+    static int _##S##Tests_n = 0;                              \
     __attribute__((constructor)) static void _##S##_init(void) \
     {                                                          \
         memset(_##S##_suites, 0, sizeof(_##S##_suites));       \
-        memset(_##S##_tests, 0, sizeof(_##S##_tests));         \
+        memset(_##S##Tests, 0, sizeof(_##S##Tests));           \
         (void)_##S##_suites_n;                                 \
-        (void)_##S##_tests_n;                                  \
+        (void)_##S##Tests_n;                                   \
         (void)_##S##_setup;                                    \
         (void)_##S##_tear_down;                                \
     }
@@ -81,7 +81,7 @@ extern int _main_suites_n;
     {                                                                  \
         int n = _##S1##_suites_n;                                      \
         _##S1##_suites[n].prefix = PREFIX;                             \
-        _##S1##_suites[n].tests = _##S2##_tests;                       \
+        _##S1##_suites[n].tests = _##S2##Tests;                        \
         _##S1##_suites[n].suites = _##S2##_suites;                     \
         _##S1##_suites[n].iterations = 0;                              \
         _##S1##_suites[n].options = 0;                                 \
@@ -90,13 +90,13 @@ extern int _main_suites_n;
 
 /* Add a test case to the MunitTest[] array of suite S. */
 #define TEST_ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)            \
-    __attribute__((constructor)) static void _##S##_tests_##C##_init(void)    \
+    __attribute__((constructor)) static void _##S##Tests_##C##_init(void)     \
     {                                                                         \
-        MunitTest *tests = _##S##_tests;                                      \
-        int n = _##S##_tests_n;                                               \
+        MunitTest *tests = _##S##Tests;                                       \
+        int n = _##S##Tests_n;                                                \
         TEST_SET_IN_ARRAY(tests, n, "/" #C, test_##S##_##C, SETUP, TEAR_DOWN, \
                           OPTIONS, PARAMS);                                   \
-        _##S##_tests_n = n + 1;                                               \
+        _##S##Tests_n = n + 1;                                                \
     }
 
 /* Set the values of the I'th test case slot in the given test array */

--- a/test/lib/tcp.h
+++ b/test/lib/tcp.h
@@ -73,10 +73,10 @@ void test_tcp_tear_down(struct test_tcp *t);
 /**
  * Start listening to a random free port on localhost.
  */
-void test_tcp_listen(struct test_tcp *t);
+void test_tcpListen(struct test_tcp *t);
 
 /**
- * Return the address of the server socket created with @test_tcp_listen.
+ * Return the address of the server socket created with @test_tcpListen.
  */
 const char *test_tcp_address(struct test_tcp *t);
 

--- a/test/lib/tcp.h
+++ b/test/lib/tcp.h
@@ -103,6 +103,6 @@ int test_tcpAccept(struct test_tcp *t);
 /**
  * Close the server socket.
  */
-void test_tcp_stop(struct test_tcp *t);
+void testTcpStop(struct test_tcp *t);
 
 #endif /* TEST_TCP_H */

--- a/test/lib/tcp.h
+++ b/test/lib/tcp.h
@@ -78,7 +78,7 @@ void test_tcpListen(struct test_tcp *t);
 /**
  * Return the address of the server socket created with @test_tcpListen.
  */
-const char *test_tcp_address(struct test_tcp *t);
+const char *testTcpAddress(struct test_tcp *t);
 
 /**
  * Connect the client socket to the given port on localhost.

--- a/test/lib/tcp.h
+++ b/test/lib/tcp.h
@@ -98,7 +98,7 @@ void test_tcp_send(struct test_tcp *t, const void *buf, int len);
 /**
  * Accept inbound client connection and return the relevant socket.
  */
-int test_tcp_accept(struct test_tcp *t);
+int test_tcpAccept(struct test_tcp *t);
 
 /**
  * Close the server socket.

--- a/test/lib/tcp.h
+++ b/test/lib/tcp.h
@@ -98,7 +98,7 @@ void test_tcp_send(struct test_tcp *t, const void *buf, int len);
 /**
  * Accept inbound client connection and return the relevant socket.
  */
-int test_tcpAccept(struct test_tcp *t);
+int testTcpAccept(struct test_tcp *t);
 
 /**
  * Close the server socket.

--- a/test/lib/tcp.h
+++ b/test/lib/tcp.h
@@ -73,10 +73,10 @@ void test_tcp_tear_down(struct test_tcp *t);
 /**
  * Start listening to a random free port on localhost.
  */
-void test_tcpListen(struct test_tcp *t);
+void testTcpListen(struct test_tcp *t);
 
 /**
- * Return the address of the server socket created with @test_tcpListen.
+ * Return the address of the server socket created with @testTcpListen.
  */
 const char *testTcpAddress(struct test_tcp *t);
 


### PR DESCRIPTION
A double underscore within an identifier is illegal in C++, for interop.
