### PR TITLE
recv_append_entries: Fix memory leak

### DIFF
--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -2,6 +2,7 @@
 
 #include "assert.h"
 #include "convert.h"
+#include "entry.h"
 #include "heap.h"
 #include "log.h"
 #include "recv.h"
@@ -112,6 +113,8 @@ int recvAppendEntries(struct raft *r,
      * something smarter, e.g. buffering the entries in the I/O backend, which
      * should be in charge of serializing everything. */
     if (r->snapshot.put.data != NULL && args->n_entries > 0) {
+        tracef("ignoring AppendEntries RPC during snapshot install");
+        entryBatchesDestroy(args->entries, args->n_entries);
         return 0;
     }
 


### PR DESCRIPTION
AppendEntries RPC's are ignored during installation of a snapshot.
Free the memory associated to the ignored RPC.

Should help with https://github.com/canonical/dqlite/issues/276

Test script output looks like:

> => Spawning database                                                               
> => Spawning test loops                                                             
> => Monitor the result                                                              
> ==> 20210202-1609: db1=80812 db2=81472 db3=162832 leader=127.0.0.1:9001            
> mykey1|foo=1 loop=1                                                                
> mykey2|foo=1 loop=8074                                                             
> ==> 20210202-1610: db1=100788 db2=94684 db3=121800 leader=127.0.0.1:9001           
> mykey1|foo=1 loop=1                                                                
> mykey2|foo=6 loop=67                                                               
> ==> 20210202-1611: db1=101184 db2=95952 db3=130304 leader=127.0.0.1:9001           
> mykey1|foo=1 loop=1                                                                
> mykey2|foo=10 loop=3050                                                            
> ==> 20210202-1612: db1=100912 db2=96548 db3=137808 leader=127.0.0.1:9001           
> mykey1|foo=1 loop=1                                                                
> mykey2|foo=14 loop=6934                                                            
> ...
> ==> 20210202-1648: db1=104232 db2=98924 db3=140100 leader=127.0.0.1:9001           
> mykey1|foo=100 loop=9999                                                           
> mykey2|foo=97 loop=2581                                                            
> Loop mykey2 exited                                                                 
> ==> 20210202-1649: db1=104100 db2=99816 db3=140100 leader=127.0.0.1:9001           
> mykey1|foo=100 loop=9999                                                           
> mykey2|foo=100 loop=9999                                                           
> ==> 20210202-1650: db1=104100 db2=99952 db3=140360 leader=127.0.0.1:9001           
> mykey1|foo=100 loop=9999                                                           
> mykey2|foo=100 loop=9999                                                           
> ==> 20210202-1651: db1=104100 db2=99952 db3=139916 leader=127.0.0.1:9001           
> mykey1|foo=100 loop=9999                                                           
> mykey2|foo=100 loop=9999     

Have seen a run where db3 memory usage spikes to +- 770MB, but goes down again quickly, should be further investigated.

> ==> 20210202-1803: db1=103812 db2=100856 db3=169220 leader=127.0.0.1:9001          
> mykey1|foo=58 loop=7233                                                            
> mykey2|foo=51 loop=3964                                                            
> ==> 20210202-1804: db1=104192 db2=100964 db3=211648 leader=127.0.0.1:9001          
> mykey1|foo=58 loop=7233                                                            
> mykey2|foo=55 loop=3296                                                            
> ==> 20210202-1805: db1=104264 db2=100800 db3=211648 leader=127.0.0.1:9001          
> mykey1|foo=58 loop=7233                                                            
> mykey2|foo=59 loop=4699                                                            
> ==> 20210202-1806: db1=104192 db2=101168 db3=**772276** leader=127.0.0.1:9001          
> mykey1|foo=58 loop=7233                                                            
> mykey2|foo=63 loop=3533                                                            
> ==> 20210202-1807: db1=104928 db2=101004 db3=150536 leader=127.0.0.1:9001          
> mykey1|foo=58 loop=7233                                                            
> mykey2|foo=67 loop=4411                                                            
> ==> 20210202-1808: db1=104528 db2=101108 db3=149344 leader=127.0.0.1:9001          
> mykey1|foo=58 loop=7233                                                            
> mykey2|foo=71 loop=5290                                                            
> ==> 20210202-1809: db1=104476 db2=101532 db3=149344 leader=127.0.0.1:9001          
> mykey2|foo=74 loop=9900                                                            
> mykey1|foo=69 loop=7238  