### PR TITLE
Mbordere/barrier wait for segments

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,6 +167,7 @@ test_unit_uv_CFLAGS = $(AM_CFLAGS) -Wno-conversion
 test_unit_uv_LDADD = libtest.la
 
 test_integration_uv_SOURCES = \
+  ${libraft_la_SOURCES} \
   test/integration/main_uv.c \
   test/integration/test_uv_init.c \
   test/integration/test_uv_append.c \

--- a/src/uv.h
+++ b/src/uv.h
@@ -338,6 +338,9 @@ int UvBarrier(struct uv *uv,
               struct UvBarrier *barrier,
               UvBarrierCb cb);
 
+/* Returns @true if there are no more segments referencing uv->barrier */
+bool UvBarrierReady(struct uv *uv);
+
 /* Resume writing append requests after UvBarrier has been called. */
 void UvUnblock(struct uv *uv);
 

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -699,6 +699,24 @@ static void uvFinalizeCurrentAliveSegmentOnceIdle(struct uv *uv)
     }
 }
 
+bool UvBarrierReady(struct uv *uv)
+{
+    if (uv->barrier == NULL) {
+        return true;
+    }
+
+    queue *head;
+    QUEUE_FOREACH(head, &uv->append_segments)
+    {
+        struct uvAliveSegment *segment;
+        segment = QUEUE_DATA(head, struct uvAliveSegment, queue);
+        if (segment->barrier == uv->barrier) {
+                return false;
+        }
+    }
+    return true;
+}
+
 int UvBarrier(struct uv *uv,
               raft_index next_index,
               struct UvBarrier *barrier,

--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -92,7 +92,7 @@ static void uvFinalizeAfterWorkCb(uv_work_t *work, int status)
     /* If we have no more dismissed segments to close, check if there's a
      * barrier to unblock or if we are done closing. */
     if (QUEUE_IS_EMPTY(&uv->finalize_reqs)) {
-        if (uv->barrier != NULL) {
+        if (uv->barrier != NULL && UvBarrierReady(uv)) {
             uv->barrier->cb(uv->barrier);
         }
         uvMaybeFireCloseCb(uv);

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -493,6 +493,11 @@ static void uvSnapshotPutStart(struct uvSnapshotPut *put)
 static void uvSnapshotPutBarrierCb(struct UvBarrier *barrier)
 {
     struct uvSnapshotPut *put = barrier->data;
+    if (put == NULL) {
+        tracef("uvSnapshotPutBarrierCb already fired, wait for UvUnblock\n");
+        return;
+    }
+
     struct uv *uv = put->uv;
     assert(put->trailing == 0);
     put->barrier.data = NULL;


### PR DESCRIPTION
A UvBarrier's Callback should only fire when all open segments that reference the barrier have been finalized. 

Before this PR, that was not the case, the callback fired once the first open segment referencing the barrier was finalized.
This occurred when a follower was installing a snapshot; eventually `uvSnapshotPutFinish` was called, freeing the put request's memory, including the memory of the UvBarrier. Because the barrier CB fired early, there were still segments referencing the barrier and one of them would become the active barrier due to the logic after the `start` label in `uvAppendMaybeStart`. This would lead to accessing freed memory when attempting to call `uv->barrier->cb` in `uvFinalizeAfterWorkCb`.