### PR TITLE
Mbordere/barrier wait for segments

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,6 +167,7 @@ test_unit_uv_CFLAGS = $(AM_CFLAGS) -Wno-conversion
 test_unit_uv_LDADD = libtest.la
 
 test_integration_uv_SOURCES = \
+  ${libraft_la_SOURCES} \
   test/integration/main_uv.c \
   test/integration/test_uv_init.c \
   test/integration/test_uv_append.c \

--- a/src/uv.h
+++ b/src/uv.h
@@ -338,6 +338,9 @@ int UvBarrier(struct uv *uv,
               struct UvBarrier *barrier,
               UvBarrierCb cb);
 
+/* Returns @true if there are no more segments referencing uv->barrier */
+bool UvBarrierReady(struct uv *uv);
+
 /* Resume writing append requests after UvBarrier has been called. */
 void UvUnblock(struct uv *uv);
 

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -699,6 +699,24 @@ static void uvFinalizeCurrentAliveSegmentOnceIdle(struct uv *uv)
     }
 }
 
+bool UvBarrierReady(struct uv *uv)
+{
+    if (uv->barrier == NULL) {
+        return true;
+    }
+
+    queue *head;
+    QUEUE_FOREACH(head, &uv->append_segments)
+    {
+        struct uvAliveSegment *segment;
+        segment = QUEUE_DATA(head, struct uvAliveSegment, queue);
+        if (segment->barrier == uv->barrier) {
+                return false;
+        }
+    }
+    return true;
+}
+
 int UvBarrier(struct uv *uv,
               raft_index next_index,
               struct UvBarrier *barrier,

--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -92,7 +92,7 @@ static void uvFinalizeAfterWorkCb(uv_work_t *work, int status)
     /* If we have no more dismissed segments to close, check if there's a
      * barrier to unblock or if we are done closing. */
     if (QUEUE_IS_EMPTY(&uv->finalize_reqs)) {
-        if (uv->barrier != NULL) {
+        if (uv->barrier != NULL && UvBarrierReady(uv)) {
             uv->barrier->cb(uv->barrier);
         }
         uvMaybeFireCloseCb(uv);

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -493,6 +493,11 @@ static void uvSnapshotPutStart(struct uvSnapshotPut *put)
 static void uvSnapshotPutBarrierCb(struct UvBarrier *barrier)
 {
     struct uvSnapshotPut *put = barrier->data;
+    if (put == NULL) {
+        tracef("uvSnapshotPutBarrierCb already fired, wait for UvUnblock\n");
+        return;
+    }
+
     struct uv *uv = put->uv;
     assert(put->trailing == 0);
     put->barrier.data = NULL;

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -1,6 +1,7 @@
 #include "../lib/runner.h"
 #include "../lib/uv.h"
 #include "../lib/aio.h"
+#include "../../src/uv.h"
 
 /* Maximum number of blocks a segment can have */
 #define MAX_SEGMENT_BLOCKS 4
@@ -34,6 +35,7 @@ struct result
 {
     int status;
     bool done;
+    void *data;
 };
 
 static void appendCbAssertResult(struct raft_io_append *req, int status)
@@ -66,17 +68,24 @@ static void appendCbAssertResult(struct raft_io_append *req, int status)
     }
 
 /* Submit an append request identified by I, with N_ENTRIES entries, each one of
- * size ENTRY_SIZE. The default expectation is for the operation to succeed. A
- * custom STATUS can be set with APPEND_EXPECT. */
-#define APPEND_SUBMIT(I, N_ENTRIES, ENTRY_SIZE)                     \
+ * size ENTRY_SIZE. When the append request completes, CB will be called
+ * and DATA will be available in result->data. */
+#define APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE, CB, DATA)   \
     struct raft_io_append _req##I;                                  \
-    struct result _result##I = {0, false};                          \
+    struct result _result##I = {0, false, DATA};                    \
     int _rv##I;                                                     \
     ENTRIES(I, N_ENTRIES, ENTRY_SIZE);                              \
     _req##I.data = &_result##I;                                     \
     _rv##I = f->io.append(&f->io, &_req##I, _entries##I, N_ENTRIES, \
-                          appendCbAssertResult);                    \
+                          CB);                                      \
     munit_assert_int(_rv##I, ==, 0)
+
+/* Submit an append request identified by I, with N_ENTRIES entries, each one of
+ * size ENTRY_SIZE. The default expectation is for the operation to succeed. A
+ * custom STATUS can be set with APPEND_EXPECT. */
+#define APPEND_SUBMIT(I, N_ENTRIES, ENTRY_SIZE)                       \
+        APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE,               \
+                              appendCbAssertResult, NULL)             \
 
 /* Try to submit an append request and assert that the given error code and
  * message are returned. */
@@ -674,5 +683,90 @@ TEST(append, ioSetupError, setUp, tearDown, 0, NULL)
     }
     APPEND_FAILURE(1, 64, RAFT_TOOMANY,
                    "setup writer for open-1: AIO events user limit exceeded");
+    return MUNIT_OK;
+}
+
+/*===========================================================================
+  Test interaction between UvAppend and UvBarrier
+  ===========================================================================*/
+
+struct barrierData
+{
+   int current;     /* Count the number of finished AppendEntries RPCs */
+   int expected;    /* Expected number of finished AppendEntries RPCs  */
+   bool done;       /* @true if the Barrier CB has fired               */
+   bool expectDone; /* Expect the Barrier CB to have fired or not      */
+   struct uv *uv;
+};
+
+static void barrierCbCompareCounter(struct UvBarrier *barrier)
+{
+    struct barrierData *bd = barrier->data;
+    munit_assert_false(bd->done);
+    bd->done = true;
+    struct uv *uv = bd->uv;
+    UvUnblock(uv);
+    munit_assert_int(bd->current, ==, bd->expected);
+}
+
+static void appendCbIncreaseCounterAssertResult(struct raft_io_append *req,
+                                                int status)
+{
+    struct result *result = req->data;
+    munit_assert_int(status, ==, result->status);
+    result->done = true;
+    struct barrierData *bd = result->data;
+    munit_assert_true(bd->done == bd->expectDone);
+    bd->current += 1;
+}
+
+/* Fill up 3 segments worth of AppendEntries RPC's.
+ * Request a Barrier and expect that the AppendEntries RPC's are finished before
+ * the Barrier callback is fired.
+ */
+TEST(append, barrierOpenSegments, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    struct barrierData bd = {0};
+    bd.current = 0;
+    bd.expected = 3;
+    bd.done = false;
+    bd.expectDone = false;
+    bd.uv = f->io.impl;
+
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+
+    struct UvBarrier barrier = {0};
+    barrier.data = (void*) &bd;
+    UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
+
+    APPEND_WAIT(2);
+    return MUNIT_OK;
+}
+
+/* Request a Barrier and expect that the no AppendEntries RPC's are finished before
+ * the Barrier callback is fired.
+ */
+TEST(append, barrierNoOpenSegments, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    struct barrierData bd = {0};
+    bd.current = 0;
+    bd.expected = 0;
+    bd.done = false;
+    bd.expectDone = true;
+    bd.uv = f->io.impl;
+
+    struct UvBarrier barrier = {0};
+    barrier.data = (void*) &bd;
+    UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
+
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+
+    APPEND_WAIT(2);
     return MUNIT_OK;
 }


### PR DESCRIPTION
A UvBarrier's Callback should only fire when all open segments that reference the barrier have been finalized.

Before this PR, that was not the case, the callback fired once the first open segment referencing the barrier was finalized.
This could occur when a follower was installing a snapshot; eventually `uvSnapshotPutFinish` was called, freeing the put request's memory, including the memory of the `UvBarrier`. Because the barrier CB fired early, there were still segments referencing the barrier and one of them would become the active barrier due to the logic after the `start` label in `uvAppendMaybeStart`. This would lead to accessing freed memory when attempting to call `uv->barrier->cb` in `uvFinalizeAfterWorkCb`.