### PR TITLE
Mbordere/fix hanging barrier

### DIFF
--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -270,6 +270,12 @@ out:
         if (rv != 0) {
             uv->errored = true;
         }
+    } else if (s->finalize) {
+        /* If there are no more append_pending_reqs, this segment
+         * must be finalized here in case we don't receive AppendEntries
+         * RPCs anymore (could happen during a Snapshot install, causing
+         * the BarrierCb to never fire) */
+        uvAliveSegmentFinalize(s);
     }
 }
 

--- a/test/integration/append_helpers.h
+++ b/test/integration/append_helpers.h
@@ -1,0 +1,100 @@
+#include "../../src/uv.h"
+#include "../lib/runner.h"
+
+/******************************************************************************
+ *
+ * Helper macros
+ *
+ *****************************************************************************/
+
+struct result
+{
+    int status;
+    bool done;
+    void *data;
+};
+
+static void appendCbAssertResult(struct raft_io_append *req, int status)
+{
+    struct result *result = req->data;
+    munit_assert_int(status, ==, result->status);
+    result->done = true;
+}
+
+/* Declare and fill the entries array for the append request identified by
+ * I. The array will have N entries, and each entry will have a data buffer of
+ * SIZE bytes.*/
+#define ENTRIES(I, N, SIZE)                                 \
+    struct raft_entry _entries##I[N];                       \
+    uint8_t _entries_data##I[N * SIZE];                     \
+    {                                                       \
+        int _i;                                             \
+        for (_i = 0; _i < N; _i++) {                        \
+            struct raft_entry *entry = &_entries##I[_i];    \
+            entry->term = 1;                                \
+            entry->type = RAFT_COMMAND;                     \
+            entry->buf.base = &_entries_data##I[_i * SIZE]; \
+            entry->buf.len = SIZE;                          \
+            entry->batch = NULL;                            \
+            munit_assert_ptr_not_null(entry->buf.base);     \
+            memset(entry->buf.base, 0, entry->buf.len);     \
+            *(uint64_t *)entry->buf.base = f->count;        \
+            f->count++;                                     \
+        }                                                   \
+    }
+
+/* Submit an append request identified by I, with N_ENTRIES entries, each one of
+ * size ENTRY_SIZE. When the append request completes, CB will be called
+ * and DATA will be available in result->data. */
+#define APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE, CB, DATA)   \
+    struct raft_io_append _req##I;                                  \
+    struct result _result##I = {0, false, DATA};                    \
+    int _rv##I;                                                     \
+    ENTRIES(I, N_ENTRIES, ENTRY_SIZE);                              \
+    _req##I.data = &_result##I;                                     \
+    _rv##I = f->io.append(&f->io, &_req##I, _entries##I, N_ENTRIES, \
+                          CB);                                      \
+    munit_assert_int(_rv##I, ==, 0)
+
+/* Submit an append request identified by I, with N_ENTRIES entries, each one of
+ * size ENTRY_SIZE. The default expectation is for the operation to succeed. A
+ * custom STATUS can be set with APPEND_EXPECT. */
+#define APPEND_SUBMIT(I, N_ENTRIES, ENTRY_SIZE)                       \
+        APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE,               \
+                              appendCbAssertResult, NULL)             \
+
+/* Try to submit an append request and assert that the given error code and
+ * message are returned. */
+#define APPEND_ERROR(N_ENTRIES, ENTRY_SIZE, RV, ERRMSG)                \
+    do {                                                               \
+        struct raft_io_append _req;                                    \
+        int _rv;                                                       \
+        ENTRIES(0, N_ENTRIES, ENTRY_SIZE);                             \
+        _rv = f->io.append(&f->io, &_req, _entries0, N_ENTRIES, NULL); \
+        munit_assert_int(_rv, ==, RV);                                 \
+        /* munit_assert_string_equal(f->io.errmsg, ERRMSG);*/          \
+    } while (0)
+
+#define APPEND_EXPECT(I, STATUS) _result##I.status = STATUS
+
+/* Wait for the append request identified by I to complete. */
+#define APPEND_WAIT(I) LOOP_RUN_UNTIL(&_result##I.done)
+
+/* Submit an append request with an entries array with N_ENTRIES entries, each
+ * one of size ENTRY_SIZE, and wait for the operation to successfully
+ * complete. */
+#define APPEND(N_ENTRIES, ENTRY_SIZE)            \
+    do {                                         \
+        APPEND_SUBMIT(0, N_ENTRIES, ENTRY_SIZE); \
+        APPEND_WAIT(0);                          \
+    } while (0)
+
+/* Submit an append request with the given parameters and wait for the operation
+ * to fail with the given code and message. */
+#define APPEND_FAILURE(N_ENTRIES, ENTRY_SIZE, STATUS, ERRMSG) \
+    {                                                         \
+        APPEND_SUBMIT(0, N_ENTRIES, ENTRY_SIZE);              \
+        APPEND_EXPECT(0, STATUS);                             \
+        APPEND_WAIT(0);                                       \
+        munit_assert_string_equal(f->io.errmsg, ERRMSG);      \
+    }

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -646,6 +646,10 @@ TEST(append, barrierOpenSegments, setUp, tearDown, 0, NULL)
     barrier.data = (void*) &bd;
     UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
 
+    /* Make sure every callback fired */
+    LOOP_RUN_UNTIL(&bd.done);
+    APPEND_WAIT(0);
+    APPEND_WAIT(1);
     APPEND_WAIT(2);
     return MUNIT_OK;
 }
@@ -671,6 +675,10 @@ TEST(append, barrierNoOpenSegments, setUp, tearDown, 0, NULL)
     APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
     APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
 
+    /* Make sure every callback fired */
+    LOOP_RUN_UNTIL(&bd.done);
+    APPEND_WAIT(0);
+    APPEND_WAIT(1);
     APPEND_WAIT(2);
     return MUNIT_OK;
 }

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -1,3 +1,4 @@
+#include "append_helpers.h"
 #include "../lib/runner.h"
 #include "../lib/uv.h"
 #include "../lib/aio.h"
@@ -25,103 +26,6 @@ struct fixture
     int count; /* To generate deterministic entry data */
 };
 
-/******************************************************************************
- *
- * Helper macros
- *
- *****************************************************************************/
-
-struct result
-{
-    int status;
-    bool done;
-    void *data;
-};
-
-static void appendCbAssertResult(struct raft_io_append *req, int status)
-{
-    struct result *result = req->data;
-    munit_assert_int(status, ==, result->status);
-    result->done = true;
-}
-
-/* Declare and fill the entries array for the append request identified by
- * I. The array will have N entries, and each entry will have a data buffer of
- * SIZE bytes.*/
-#define ENTRIES(I, N, SIZE)                                 \
-    struct raft_entry _entries##I[N];                       \
-    uint8_t _entries_data##I[N * SIZE];                     \
-    {                                                       \
-        int _i;                                             \
-        for (_i = 0; _i < N; _i++) {                        \
-            struct raft_entry *entry = &_entries##I[_i];    \
-            entry->term = 1;                                \
-            entry->type = RAFT_COMMAND;                     \
-            entry->buf.base = &_entries_data##I[_i * SIZE]; \
-            entry->buf.len = SIZE;                          \
-            entry->batch = NULL;                            \
-            munit_assert_ptr_not_null(entry->buf.base);     \
-            memset(entry->buf.base, 0, entry->buf.len);     \
-            *(uint64_t *)entry->buf.base = f->count;        \
-            f->count++;                                     \
-        }                                                   \
-    }
-
-/* Submit an append request identified by I, with N_ENTRIES entries, each one of
- * size ENTRY_SIZE. When the append request completes, CB will be called
- * and DATA will be available in result->data. */
-#define APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE, CB, DATA)   \
-    struct raft_io_append _req##I;                                  \
-    struct result _result##I = {0, false, DATA};                    \
-    int _rv##I;                                                     \
-    ENTRIES(I, N_ENTRIES, ENTRY_SIZE);                              \
-    _req##I.data = &_result##I;                                     \
-    _rv##I = f->io.append(&f->io, &_req##I, _entries##I, N_ENTRIES, \
-                          CB);                                      \
-    munit_assert_int(_rv##I, ==, 0)
-
-/* Submit an append request identified by I, with N_ENTRIES entries, each one of
- * size ENTRY_SIZE. The default expectation is for the operation to succeed. A
- * custom STATUS can be set with APPEND_EXPECT. */
-#define APPEND_SUBMIT(I, N_ENTRIES, ENTRY_SIZE)                       \
-        APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE,               \
-                              appendCbAssertResult, NULL)             \
-
-/* Try to submit an append request and assert that the given error code and
- * message are returned. */
-#define APPEND_ERROR(N_ENTRIES, ENTRY_SIZE, RV, ERRMSG)                \
-    do {                                                               \
-        struct raft_io_append _req;                                    \
-        int _rv;                                                       \
-        ENTRIES(0, N_ENTRIES, ENTRY_SIZE);                             \
-        _rv = f->io.append(&f->io, &_req, _entries0, N_ENTRIES, NULL); \
-        munit_assert_int(_rv, ==, RV);                                 \
-        /* munit_assert_string_equal(f->io.errmsg, ERRMSG);*/          \
-    } while (0)
-
-#define APPEND_EXPECT(I, STATUS) _result##I.status = STATUS
-
-/* Wait for the append request identified by I to complete. */
-#define APPEND_WAIT(I) LOOP_RUN_UNTIL(&_result##I.done)
-
-/* Submit an append request with an entries array with N_ENTRIES entries, each
- * one of size ENTRY_SIZE, and wait for the operation to successfully
- * complete. */
-#define APPEND(N_ENTRIES, ENTRY_SIZE)            \
-    do {                                         \
-        APPEND_SUBMIT(0, N_ENTRIES, ENTRY_SIZE); \
-        APPEND_WAIT(0);                          \
-    } while (0)
-
-/* Submit an append request with the given parameters and wait for the operation
- * to fail with the given code and message. */
-#define APPEND_FAILURE(N_ENTRIES, ENTRY_SIZE, STATUS, ERRMSG) \
-    {                                                         \
-        APPEND_SUBMIT(0, N_ENTRIES, ENTRY_SIZE);              \
-        APPEND_EXPECT(0, STATUS);                             \
-        APPEND_WAIT(0);                                       \
-        munit_assert_string_equal(f->io.errmsg, ERRMSG);      \
-    }
 
 /******************************************************************************
  *


### PR DESCRIPTION
I fixed a bug in PR #170 where `UvBarrier` didn't wait for all segments to be finalized, but introduced another bug where the BarrierCb would never fire in case the server didn't receive AppendEntries RPC's anymore (which is the case when we install a Snapshot). The test that should have caught this passed erroneously.