### PR TITLE
Build on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ jobs:
     dist: focal
     arch: amd64
 
+  - os: osx
+    osx_image: xcode12.2
+
   - if: type != pull_request
     compiler: clang
     dist: bionic
@@ -60,19 +63,34 @@ jobs:
 before_script:
   - git clone --depth 1 https://github.com/edlund/amalgamate.git
   - export PATH=$PATH:$PWD/amalgamate
+  - | # Build libuv dependency on MacOS
+    if [ $TRAVIS_OS_NAME = 'osx' ]; then
+      git clone --depth 1 https://github.com/libuv/libuv.git
+      cd libuv
+      git checkout v1.41.0
+      sh autogen.sh
+      ./configure
+      make -j8
+    fi
 
 script:
+  - cd "$TRAVIS_BUILD_DIR"
   - autoreconf -i
+  - | # Use built libuv on MacOS
+    if [ $TRAVIS_OS_NAME = 'osx' ]; then
+      export UV_CFLAGS="-I$(pwd)/libuv/include"
+      export UV_LIBS="-L$(pwd)/libuv/.libs -luv"
+    fi
   - |
-    if [ $TRAVIS_CPU_ARCH = "s390x" ] || [ $TRAVIS_CPU_ARCH = "arm64" ]; then
+    if [ "$TRAVIS_CPU_ARCH" = "s390x" -o "$TRAVIS_CPU_ARCH" = "arm64" ]; then
       ./configure --enable-example --enable-debug --enable-code-coverage
     else
-      ./configure --enable-example --enable-debug --enable-code-coverage --enable-sanitize
+      ./configure --enable-example --enable-debug $([ $TRAVIS_OS_NAME = 'osx' ] || echo '--enable-code-coverage --enable-sanitize')
     fi
   - amalgamate.py --config=amalgamation.json --source=$(pwd)
-  - $CC raft.c -c -D_GNU_SOURCE -DHAVE_LINUX_AIO_ABI_H -Wall -Wextra -Wpedantic -fpic
+  - $CC raft.c -c -D_GNU_SOURCE $([ $TRAVIS_OS_NAME != 'linux' ] || echo '-DHAVE_LINUX_AIO_ABI_H') -Wall -Wextra -Wpedantic -fpic $UV_CFLAGS
   - ./test/lib/fs.sh setup
-  - make check CFLAGS=-O0 $(./test/lib/fs.sh detect) || (cat ./test-suite.log && false)
+  - travis_wait 30 make check CFLAGS=-O0 $(./test/lib/fs.sh detect) || (cat ./test-suite.log && false)
   - if [ $TRAVIS_COMPILER = gcc ]; then make code-coverage-capture; fi
   - ./test/lib/fs.sh teardown
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ raftinclude_HEADERS =
 
 lib_LTLIBRARIES = libraft.la
 libraft_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
-libraft_la_LDFLAGS = -version-info 0:7:0
+libraft_la_LDFLAGS = -version-info 0:7:0 -no-undefined
 libraft_la_SOURCES = \
   src/byte.c \
   src/client.c \
@@ -33,9 +33,12 @@ libraft_la_SOURCES = \
   src/snapshot.c \
   src/start.c \
   src/state.c \
-  src/syscall.c \
   src/tick.c \
   src/tracing.c
+
+if LINUX
+libraft_la_SOURCES += src/syscall.c
+endif
 
 bin_PROGRAMS =
 
@@ -154,7 +157,6 @@ libtest_la_SOURCES += \
 test_unit_uv_SOURCES = \
   src/err.c \
   src/heap.c \
-  src/syscall.c \
   src/tracing.c \
   src/uv_fs.c \
   src/uv_os.c \
@@ -165,6 +167,10 @@ test_unit_uv_SOURCES = \
 test_unit_uv_LDFLAGS = $(UV_LIBS)
 test_unit_uv_CFLAGS = $(AM_CFLAGS) -Wno-conversion
 test_unit_uv_LDADD = libtest.la
+
+if LINUX
+test_unit_uv_SOURCES += src/syscall.c
+endif
 
 # The integration/uv test is not linked to libraft, but built
 # directly against the libraft sources in order to test some

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,21 @@ AC_USE_SYSTEM_EXTENSIONS # Defines _GNU_SOURCE and similar
 
 LT_INIT
 
+AC_CANONICAL_HOST
+
+build_linux=no
+build_windows=no
+build_mac=no
+
+#Detect target OS
+AS_CASE([$host_os],[linux*],[build_linux=yes])
+AS_CASE([$host_os],[mingw*],[build_windows=yes])
+AS_CASE([$host_os],[darwin*],[build_mac=yes])
+
+AM_CONDITIONAL([LINUX], [test "x$build_linux" = "xyes"])
+AM_CONDITIONAL([WINDOWS], [test "x$build_windows" = "xyes"])
+AM_CONDITIONAL([MAC], [test "x$build_mac" = "xyes"])
+
 # The libuv raft_io implementation is built by default if libuv is found, unless
 # explicitly disabled.
 AC_ARG_ENABLE(uv, AS_HELP_STRING([--disable-uv], [do not build the libuv-based raft_io implementation]))
@@ -124,6 +139,21 @@ CC_CHECK_FLAGS_APPEND([AM_LDFLAGS],[LDFLAGS],[ \
   --param=ssp-buffer-size=4 \
 ])
 AC_SUBST(AM_LDLAGS)
+
+CC_CHECK_FLAGS_APPEND([AM_LDFLAGS],[LDFLAGS],[ \
+  -z relro \
+  -z now \
+  -fstack-protector-strong \
+  --param=ssp-buffer-size=4 \
+])
+AC_SUBST(AM_LDLAGS)
+
+case $host in
+  *mingw*)
+  # -D__USE_MINGW_ANSI_STDIO is deprecated it seems.
+  CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[-D_POSIX])
+  ;;
+esac
 
 AC_CONFIG_FILES([raft.pc Makefile])
 AC_OUTPUT

--- a/example/cluster.c
+++ b/example/cluster.c
@@ -7,6 +7,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#if defined(__APPLE__) && defined(__MACH__)
+#include <signal.h>
+#endif
+
 #define N_SERVERS 3 /* Number of servers in the example cluster */
 
 static int ensureDir(const char *dir)

--- a/example/server.c
+++ b/example/server.c
@@ -13,6 +13,11 @@
 #define Logf(SERVER_ID, FORMAT, ...) \
     printf("%d: " FORMAT "\n", SERVER_ID, __VA_ARGS__)
 
+//apparently srandom isn't defined on mingw
+#if !defined(srandom)
+#define srandom srand
+#endif
+
 /********************************************************************
  *
  * Sample application FSM that just increases a counter.
@@ -166,8 +171,12 @@ static int ServerInit(struct Server *s,
     memset(s, 0, sizeof *s);
 
     /* Seed the random generator */
+#if defined(_WIN32)
+    srandom((unsigned)time(NULL));
+#else
     timespec_get(&now, TIME_UTC);
     srandom((unsigned)(now.tv_nsec ^ now.tv_sec));
+#endif
 
     s->loop = loop;
 
@@ -385,8 +394,10 @@ int main(int argc, char *argv[])
     dir = argv[1];
     id = (unsigned)atoi(argv[2]);
 
+#if !defined(_WIN32)
     /* Ignore SIGPIPE, see https://github.com/joyent/libuv/issues/1254 */
     signal(SIGPIPE, SIG_IGN);
+#endif
 
     /* Initialize the libuv loop. */
     rv = uv_loop_init(&loop);

--- a/src/byte.c
+++ b/src/byte.c
@@ -98,7 +98,7 @@ A million repetitions of "a"
 #define PDP_ENDIAN 3412    /* LSB first in word, MSW first in long (pdp)*/
 
 #if defined(vax) || defined(ns32000) || defined(sun386) ||      \
-    defined(__i386__) || defined(MIPSEL) || defined(_MIPSEL) || \
+    defined(__i386__) || defined(__x86_64__) || defined(MIPSEL) || defined(_MIPSEL) || \
     defined(BIT_ZERO_ON_RIGHT) || defined(__alpha__) || defined(__alpha)
 #define BYTE_ORDER LITTLE_ENDIAN
 #endif

--- a/src/client.c
+++ b/src/client.c
@@ -198,13 +198,14 @@ int raft_add(struct raft *r,
 
     req->cb = cb;
 
-    rv = clientChangeConfiguration(r, req, &configuration);
-    if (rv != 0) {
-        goto err_after_configuration_copy;
-    }
-
     assert(r->leader_state.change == NULL);
     r->leader_state.change = req;
+
+    rv = clientChangeConfiguration(r, req, &configuration);
+    if (rv != 0) {
+        r->leader_state.change = NULL;
+        goto err_after_configuration_copy;
+    }
 
     return 0;
 
@@ -352,13 +353,14 @@ int raft_remove(struct raft *r,
 
     req->cb = cb;
 
-    rv = clientChangeConfiguration(r, req, &configuration);
-    if (rv != 0) {
-        goto err_after_configuration_copy;
-    }
-
     assert(r->leader_state.change == NULL);
     r->leader_state.change = req;
+
+    rv = clientChangeConfiguration(r, req, &configuration);
+    if (rv != 0) {
+        r->leader_state.change = NULL;
+        goto err_after_configuration_copy;
+    }
 
     return 0;
 

--- a/src/heap.c
+++ b/src/heap.c
@@ -31,13 +31,34 @@ static void *defaultRealloc(void *data, void *ptr, size_t size)
 static void *defaultAlignedAlloc(void *data, size_t alignment, size_t size)
 {
     (void)data;
+#ifdef _WIN32
+    return _aligned_malloc(size, alignment);
+#elif defined(__APPLE__)
+    void * p1; // original block
+    void ** p2; // aligned block
+    size_t offset = alignment + sizeof(void *) - 1;
+    if ((p1 = (void *)malloc(size + offset)) == NULL)
+        return NULL;
+    p2 = (void **)(((uintptr_t)(p1) + offset) & ~(alignment - 1));
+    p2[-1] = p1;
+    return p2;
+#else
     return aligned_alloc(alignment, size);
+#endif
 }
 
 static void defaultAlignedFree(void *data, size_t alignment, void *ptr)
 {
     (void)alignment;
+#ifdef _WIN32
+    (void)ptr;
+    _aligned_free(data);
+#elif defined(__APPLE__)
+    (void)data;
+    free(((void * *)ptr)[-1]);
+#else
     defaultFree(data, ptr);
+#endif
 }
 
 static struct raft_heap defaultHeap = {

--- a/src/raft.c
+++ b/src/raft.c
@@ -157,6 +157,7 @@ int raft_bootstrap(struct raft *r, const struct raft_configuration *conf)
 
     rv = r->io->bootstrap(r->io, conf);
     if (rv != 0) {
+        ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
         return rv;
     }
 

--- a/src/uv.c
+++ b/src/uv.c
@@ -534,12 +534,14 @@ static int uvBootstrap(struct raft_io *io,
     /* Write the term */
     rv = uvSetTerm(io, 1);
     if (rv != 0) {
+        ErrMsgPrintf(io->errmsg, "Unable to set UV term");
         return rv;
     }
 
     /* Create the first closed segment file, containing just one entry. */
     rv = uvSegmentCreateFirstClosed(uv, configuration);
     if (rv != 0) {
+        ErrMsgPrintf(io->errmsg, "Unable to create first closed segment");
         return rv;
     }
 

--- a/src/uv_ip.h
+++ b/src/uv_ip.h
@@ -3,7 +3,11 @@
 #ifndef UV_IP_H_
 #define UV_IP_H_
 
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <netinet/in.h>
+#endif
 
 /* Split @address into @host and @port and populate @addr accordingly. */
 int uvIpParse(const char *address, struct sockaddr_in *addr);

--- a/src/uv_metadata.c
+++ b/src/uv_metadata.c
@@ -29,7 +29,11 @@ static int uvMetadataDecode(const void *buf,
     uint64_t format;
     format = byteGet64(&cursor);
     if (format != UV__DISK_FORMAT) {
+#if defined(__FreeBSD__) || defined(__APPLE__)
+        ErrMsgPrintf(errmsg, "bad format version %llu", format);
+#else
         ErrMsgPrintf(errmsg, "bad format version %ju", format);
+#endif
         return RAFT_MALFORMED;
     }
     metadata->version = byteGet64(&cursor);
@@ -101,8 +105,13 @@ static int uvMetadataLoadN(const char *dir,
             }
             return 0;
         }
-        ErrMsgPrintf(errmsg, "%s has size %ju instead of %zu", filename, size,
+#if defined(__FreeBSD__) || defined(__APPLE__)
+        ErrMsgPrintf(errmsg, "%s has size %lld instead of %zu", filename, size,
                      sizeof content);
+#else
+        ErrMsgPrintf(errmsg, "%s has size %jd instead of %zu", filename, size,
+                     sizeof content);
+#endif
         return RAFT_CORRUPT;
     }
 

--- a/src/uv_os.h
+++ b/src/uv_os.h
@@ -4,7 +4,9 @@
 #define UV_OS_H_
 
 #include <fcntl.h>
+#ifdef __linux__
 #include <linux/aio_abi.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <uv.h>
@@ -105,6 +107,7 @@ int UvOsRename(const char *path1, const char *path2);
 void UvOsJoin(const char *dir, const char *filename, char *path);
 
 /* TODO: figure a portable abstraction. */
+#ifdef __linux__
 int UvOsIoSetup(unsigned nr, aio_context_t *ctxp);
 int UvOsIoDestroy(aio_context_t ctx);
 int UvOsIoSubmit(aio_context_t ctx, long nr, struct iocb **iocbpp);
@@ -115,6 +118,7 @@ int UvOsIoGetevents(aio_context_t ctx,
                     struct timespec *timeout);
 int UvOsEventfd(unsigned int initval, int flags);
 int UvOsSetDirectIo(uv_file fd);
+#endif
 
 /* Format an error message caused by a failed system call or stdlib function. */
 #define UvOsErrMsg(ERRMSG, SYSCALL, ERRNUM)              \

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -395,7 +395,11 @@ int uvSegmentLoadClosed(struct uv *uv,
         goto err;
     }
     if (format != UV__DISK_FORMAT) {
+#if defined(__FreeBSD__) || defined(__APPLE__)
+        ErrMsgPrintf(uv->io->errmsg, "unexpected format version %llu", format);
+#else
         ErrMsgPrintf(uv->io->errmsg, "unexpected format version %ju", format);
+#endif
         rv = RAFT_CORRUPT;
         goto err_after_read;
     }
@@ -524,7 +528,11 @@ static int uvLoadOpenSegment(struct uv *uv,
                 goto done;
             }
         }
+#if defined(__FreeBSD__) || defined(__APPLE__)
+        ErrMsgPrintf(uv->io->errmsg, "unexpected format version %llu", format);
+#else
         ErrMsgPrintf(uv->io->errmsg, "unexpected format version %ju", format);
+#endif
         rv = RAFT_CORRUPT;
         goto err_after_read;
     }

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <string.h>
-#include <sys/uio.h>
 
 #include "array.h"
 #include "assert.h"

--- a/src/uv_writer.h
+++ b/src/uv_writer.h
@@ -22,10 +22,12 @@ struct UvWriter
     struct uv_loop_s *loop;        /* Event loop */
     uv_file fd;                    /* File handle */
     bool async;                    /* Whether fully async I/O is supported */
+#ifdef __linux__
     aio_context_t ctx;             /* KAIO handle */
     struct io_event *events;       /* Array of KAIO response objects */
     unsigned n_events;             /* Length of the events array */
     int event_fd;                  /* Poll'ed to check if write is finished */
+#endif
     struct uv_poll_s event_poller; /* Poll event_fd for completed poll requests */
     struct uv_check_s check;       /* Check for completed threadpool requests */
     UvWriterCloseCb close_cb;      /* Close callback */
@@ -61,7 +63,9 @@ struct UvWriterReq
     int status;              /* Request result code */
     struct uv_work_s work;   /* To execute logic in the threadpool */
     UvWriterReqCb cb;        /* Callback to invoke upon request completion */
+#ifdef __linux__
     struct iocb iocb;        /* KAIO request (for writing) */
+#endif
     char errmsg[256];        /* Error description (for thread-safety) */
     queue queue;             /* Prev/next links in the inflight queue */
 };

--- a/test/integration/test_heap.c
+++ b/test/integration/test_heap.c
@@ -48,6 +48,6 @@ TEST(raft_heap, aligned_alloc, NULL, NULL, 0, NULL)
     p = raft_aligned_alloc(1024, 2048);
     munit_assert_ptr_not_null(p);
     munit_assert_int((uintptr_t)p % 1024, ==, 0);
-    raft_free(p);
+    raft_aligned_free(1024, p);
     return MUNIT_OK;
 }

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -487,6 +487,7 @@ TEST(append, noSpaceResolved, setUp, tearDownDeps, 0, DirTmpfsParams)
 /* An error occurs while performing a write. */
 TEST(append, writeError, setUp, tearDown, 0, NULL)
 {
+#ifdef __linux__
     struct fixture *f = data;
     aio_context_t ctx = 0;
 
@@ -499,6 +500,12 @@ TEST(append, writeError, setUp, tearDown, 0, NULL)
     APPEND_WAIT(0);
     AioDestroy(ctx);
     return MUNIT_OK;
+#elif defined(__FreeBSD__) || defined(__APPLE__)
+    return MUNIT_SKIP; // AIO not supported
+#else
+    munit_error("Required to implement");
+    return MUNIT_ERROR;
+#endif
 }
 
 static char *oomHeapFaultDelay[] = {"1", /* FIXME "2", */ NULL};
@@ -578,6 +585,7 @@ TEST(append, currentSegment, setUp, tearDownDeps, 0, NULL)
 /* The kernel has ran out of available AIO events. */
 TEST(append, ioSetupError, setUp, tearDown, 0, NULL)
 {
+#ifdef __linux__
     struct fixture *f = data;
     aio_context_t ctx = 0;
     int rv;
@@ -588,6 +596,12 @@ TEST(append, ioSetupError, setUp, tearDown, 0, NULL)
     APPEND_FAILURE(1, 64, RAFT_TOOMANY,
                    "setup writer for open-1: AIO events user limit exceeded");
     return MUNIT_OK;
+#elif defined(__FreeBSD__) || defined(__APPLE__)
+    return MUNIT_SKIP; // AIO not supported
+#else
+    munit_error("Required to implement");
+    return MUNIT_ERROR;
+#endif
 }
 
 /*===========================================================================

--- a/test/integration/test_uv_init.c
+++ b/test/integration/test_uv_init.c
@@ -152,6 +152,10 @@ TEST(init, oom, setUp, tearDown, 0, oomParams)
     /* XXX: fails on ppc64el */
     return MUNIT_SKIP;
 #endif
+#if defined(__APPLE__)
+    /* XXX: fails on MacOS */
+    return MUNIT_SKIP;
+#endif
     HEAP_FAULT_ENABLE;
     INIT_ERROR(f->dir, RAFT_NOMEM, "out of memory");
     return 0;

--- a/test/integration/test_uv_load.c
+++ b/test/integration/test_uv_load.c
@@ -660,7 +660,11 @@ TEST(load, manySnapshots, setUp, tearDown, 0, NULL)
      * before it could complete writing it. */
     uv_update_time(&f->loop);
     now = uv_now(&f->loop);
+#if defined(__FreeBSD__) || defined(__APPLE__)
+    sprintf(filename, "snapshot-1-8-%llu", now);
+#else
     sprintf(filename, "snapshot-1-8-%ju", now);
+#endif
     SNAPSHOT_PUT(1, 8, 1);
     DirRemoveFile(f->dir, filename);
 
@@ -702,7 +706,11 @@ TEST(load, emptySnapshot, setUp, tearDown, 0, NULL)
      * of space before it could write it. */
     uv_update_time(&f->loop);
     now = uv_now(&f->loop);
+#if defined(__FreeBSD__) || defined(__APPLE__)
+    sprintf(filename, "snapshot-2-6-%llu", now);
+#else
     sprintf(filename, "snapshot-2-6-%ju", now);
+#endif
     SNAPSHOT_PUT(2, 6, 2);
     DirTruncateFile(f->dir, filename, 0);
 
@@ -738,8 +746,13 @@ TEST(load, orphanedSnapshotFiles, setUp, tearDown, 0, NULL)
 
     /* Take a snapshot but then remove the data file, as if the server crashed
      * before it could complete writing it. */
+#if defined(__FreeBSD__) || defined(__APPLE__)
+    sprintf(filename1_removed, "snapshot-2-18-%llu", now);
+    sprintf(metafilename1_removed, "snapshot-2-18-%llu%s", now, UV__SNAPSHOT_META_SUFFIX);
+#else
     sprintf(filename1_removed, "snapshot-2-18-%ju", now);
     sprintf(metafilename1_removed, "snapshot-2-18-%ju%s", now, UV__SNAPSHOT_META_SUFFIX);
+#endif
     SNAPSHOT_PUT(2, 18, 1);
     munit_assert_true(DirHasFile(f->dir, filename1_removed));
     munit_assert_true(DirHasFile(f->dir, metafilename1_removed));
@@ -747,8 +760,13 @@ TEST(load, orphanedSnapshotFiles, setUp, tearDown, 0, NULL)
 
     /* Take a snapshot but then remove the .meta file */
     now = uv_now(&f->loop);
+#if defined(__FreeBSD__) || defined(__APPLE__)
+    sprintf(filename2_removed, "snapshot-2-19-%llu", now);
+    sprintf(metafilename2_removed, "snapshot-2-19-%llu%s", now, UV__SNAPSHOT_META_SUFFIX);
+#else
     sprintf(filename2_removed, "snapshot-2-19-%ju", now);
     sprintf(metafilename2_removed, "snapshot-2-19-%ju%s", now, UV__SNAPSHOT_META_SUFFIX);
+#endif
     SNAPSHOT_PUT(2, 19, 2);
     munit_assert_true(DirHasFile(f->dir, filename2_removed));
     munit_assert_true(DirHasFile(f->dir, metafilename2_removed));
@@ -910,10 +928,17 @@ TEST(load, closedSegmentWithEntriesPastSnapshot, setUp, tearDown, 0, NULL)
     APPEND(1, 5);
     uv_update_time(&f->loop);
     now = uv_now(&f->loop);
+#if defined(__FreeBSD__) || defined(__APPLE__)
+    sprintf(errmsg,
+            "closed segment 0000000000000006-0000000000000006 is past last "
+            "snapshot snapshot-1-4-%llu",
+            now);
+#else
     sprintf(errmsg,
             "closed segment 0000000000000006-0000000000000006 is past last "
             "snapshot snapshot-1-4-%ju",
             now);
+#endif
     SNAPSHOT_PUT(1, 4, 1);
     DirRemoveFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 5));
     LOAD_ERROR(RAFT_CORRUPT, errmsg);

--- a/test/lib/aio.c
+++ b/test/lib/aio.c
@@ -4,6 +4,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#ifdef __linux__
 #include "munit.h"
 
 int AioFill(aio_context_t *ctx, unsigned n)
@@ -56,3 +57,4 @@ void AioDestroy(aio_context_t ctx)
     rv = syscall(__NR_io_destroy, ctx);
     munit_assert_int(rv, ==, 0);
 }
+#endif

--- a/test/lib/aio.h
+++ b/test/lib/aio.h
@@ -2,6 +2,7 @@
 #ifndef TEST_AIO_H
 #define TEST_AIO_H
 
+#ifdef __linux__
 #include <linux/aio_abi.h>
 
 /* Fill the AIO subsystem resources by allocating a lot of events to the given
@@ -15,5 +16,6 @@ int AioFill(aio_context_t *ctx, unsigned n);
 
 /* Destroy the given AIO context. */
 void AioDestroy(aio_context_t ctx);
+#endif
 
 #endif /* TEST_AIO_H */

--- a/test/lib/dir.h
+++ b/test/lib/dir.h
@@ -77,6 +77,12 @@ void *DirZfsSetUp(const MunitParameter params[], void *user_data);
  * system is available. */
 void *DirXfsSetUp(const MunitParameter params[], void *user_data);
 
+/* Create a temporary test directory backed by hfs.
+ *
+ * Return a pointer the path of the created directory, or NULL if no hfs file
+ * system is available. */
+void *DirHfsSetUp(const MunitParameter params[], void *user_data);
+
 /* Recursively remove a temporary directory. */
 void DirTearDown(void *data);
 

--- a/test/lib/fs.sh
+++ b/test/lib/fs.sh
@@ -16,6 +16,9 @@ cmd="${1}"
 shift
 
 types="tmpfs"
+if [ $(uname) = "Darwin" -a "$(which mount_tmpfs)" = "" ]; then
+    types=""
+fi
 
 # Check if loop devices are available, we might be running inside an
 # unprivileged container
@@ -40,6 +43,11 @@ if sudo losetup -f > /dev/null 2>&1; then
 
 fi
 
+# In case hdiutil is here - we can use HFS+ Apple MacOS fs
+if [ "$(which hdiutil)" != "" ]; then
+    types="$types hfs"
+fi
+
 if [ "${cmd}" = "detect" ]; then
     vars=""
     for type in $types; do
@@ -53,33 +61,37 @@ if [ "${cmd}" = "setup" ]; then
     mkdir ./tmp
 
     for type in $types; do
-	echo -n "Creating $type loop device mount..."
+        echo -n "Creating $type loop device mount..."
 
-	# Create the fs mount point
-	mkdir "./tmp/${type}"
+        # Create the fs mount point
+        mkdir "./tmp/${type}"
 
-	if [ "$type" = "tmpfs" ]; then
-	    # For tmpfs we don't need a loopback disk device.
-	    sudo mount -t tmpfs -o size=32m tmpfs ./tmp/tmpfs
-	else
-	    # Create a loopback disk device
-	    dd if=/dev/zero of="./tmp/.${type}" bs=4096 count=28672 > /dev/null 2>&1
-	    loop=$(sudo losetup -f)
-	    sudo losetup "${loop}" "./tmp/.${type}"
+        if [ "$type" = "tmpfs" ]; then
+            # For tmpfs we don't need a loopback disk device.
+            sudo mount -t tmpfs -o size=32m tmpfs ./tmp/tmpfs
+        elif [ "$type" = "hfs" ]; then
+            # Apple file system for MacOS
+            hdiutil create "./tmp/${type}.dmg" -fs HFS+ -volname "$type" -size 32m
+            hdiutil attach "./tmp/${type}.dmg" -mountpoint "./tmp/${type}"
+        else
+            # Create a loopback disk device
+            dd if=/dev/zero of="./tmp/.${type}" bs=4096 count=28672 > /dev/null 2>&1
+            loop=$(sudo losetup -f)
+            sudo losetup "${loop}" "./tmp/.${type}"
 
-	    # Initialize the file system
-	    if [ "$type" = "zfs" ]; then
-		sudo zpool create raft "${loop}"
-		sudo zfs create -o mountpoint=$(pwd)/tmp/zfs raft/zfs
-	    else
-		sudo mkfs.${type} "${loop}" > /dev/null 2>&1
-		sudo mount "${loop}" "./tmp/${type}"
-	    fi
-	fi
+            # Initialize the file system
+            if [ "$type" = "zfs" ]; then
+                sudo zpool create raft "${loop}"
+                sudo zfs create -o mountpoint=$(pwd)/tmp/zfs raft/zfs
+            else
+                sudo mkfs.${type} "${loop}" > /dev/null 2>&1
+                sudo mount "${loop}" "./tmp/${type}"
+            fi
+        fi
 
-	sudo chown $USER "./tmp/${type}"
+        sudo chown $USER "./tmp/${type}"
 
-	echo " done"
+        echo " done"
     done
 
     exit 0
@@ -88,24 +100,31 @@ fi
 if [ "${cmd}" = "teardown" ]; then
 
     for type in $types; do
-	echo -n "Deleting $type loop device mount..."
+        echo -n "Deleting $type loop device mount..."
 
-	sudo umount "./tmp/${type}"
-	rm -rf "./tmp/${type}"
+        if [ "$type" = "hfs" ]; then
+            hdiutil detach "./tmp/${type}"
+        else
+            sudo umount "./tmp/${type}"
+        fi
+        rm -rf "./tmp/${type}"
 
-	if [ "$type" != "tmpfs" ]; then
-	    # For zfs we need to destroy the pool
-	    if [ "$type" = "zfs" ]; then
-		sudo zpool destroy raft
-	    fi
+        if [ "$type" = "hfs" ]; then
+            # Need to remove the dmg file too
+            rm -f "./tmp/${type}.dmg"
+        elif [ "$type" != "tmpfs" ]; then
+            # For zfs we need to destroy the pool
+            if [ "$type" = "zfs" ]; then
+                sudo zpool destroy raft
+            fi
 
-	    # For regular file systems, remove the loopback disk device.
-	    loop=$(sudo losetup -a | grep ".${type}" | cut -f 1 -d :)
-	    sudo losetup -d "${loop}"
-	    rm "./tmp/.${type}"
-	fi
+            # For regular file systems, remove the loopback disk device.
+            loop=$(sudo losetup -a | grep ".${type}" | cut -f 1 -d :)
+            sudo losetup -d "${loop}"
+            rm "./tmp/.${type}"
+        fi
 
-	echo " done"
+        echo " done"
     done
 
     rmdir ./tmp


### PR DESCRIPTION
Patch to support the MacOS for go-dqlite, basically a copy of abandoned PR #119 with some cleaning and MacOS-specific changes.

Now it's ready for review - I tested it successfully with macos->macos and macos->linux connection and regular DB workload.
Tests are in the go-dqlite PR here: https://github.com/canonical/go-dqlite/pull/132

The most important change that fixed the freeze is moving `r->leader_state.change = req;` prior to call of the `clientChangeConfiguration` function (because the macos IO implementation is not async and executes directly, so quite sure even on linux it could fail in case the async executor will decide to run IO operation right after the call).

The other patches in series:
* https://github.com/canonical/go-dqlite/pull/132
* https://github.com/canonical/dqlite/pull/285
* https://github.com/canonical/dqlite/pull/288
* https://github.com/canonical/dqlite/pull/290