### PR TITLE
Mbordere/retry install snapshot

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -613,6 +613,12 @@ struct raft
     unsigned heartbeat_timeout;
 
     /*
+     * When the leader sends an InstallSnapshot RPC to a follower it will consider
+     * the RPC as failed after this timeout and retry.
+     */
+    unsigned install_snapshot_timeout;
+
+    /*
      * The fields below hold the part of the server's volatile state which is
      * always applicable regardless of the whether the server is follower,
      * candidate or leader (Figure 3.1). This state is rebuilt automatically
@@ -766,6 +772,11 @@ RAFT_API void raft_set_election_timeout(struct raft *r, unsigned msecs);
  * Set the heartbeat timeout.
  */
 RAFT_API void raft_set_heartbeat_timeout(struct raft *r, unsigned msecs);
+
+/**
+ * Set the snapshot install timeout.
+ */
+RAFT_API void raft_set_install_snapshot_timeout(struct raft *r, unsigned msecs);
 
 /**
  * Number of outstanding log entries before starting a new snapshot. The default

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -22,6 +22,7 @@
 
 /* Defaults */
 #define HEARTBEAT_TIMEOUT 100
+#define INSTALL_SNAPSHOT_TIMEOUT (2 * HEARTBEAT_TIMEOUT)
 #define ELECTION_TIMEOUT 1000
 #define NETWORK_LATENCY 15
 #define DISK_LATENCY 10
@@ -925,6 +926,7 @@ static int serverInit(struct raft_fixture *f, unsigned i, struct raft_fsm *fsm)
     }
     raft_set_election_timeout(&s->raft, ELECTION_TIMEOUT);
     raft_set_heartbeat_timeout(&s->raft, HEARTBEAT_TIMEOUT);
+    raft_set_install_snapshot_timeout(&s->raft, INSTALL_SNAPSHOT_TIMEOUT);
     s->tracer.impl = (void *)&s->id;
     s->tracer.emit = emit;
     s->raft.tracer = &s->tracer;

--- a/src/progress.c
+++ b/src/progress.c
@@ -123,11 +123,8 @@ bool progressShouldReplicate(struct raft *r, unsigned i)
 
     switch (p->state) {
         case PROGRESS__SNAPSHOT:
-            /* If we have already sent a snapshot, don't send any further entry
-             * and let's wait for the target server to reply.
-             *
-             * TODO: rollback to probe if we don't hear anything for a while. */
-            result = false;
+            /* Raft will retry sending a Snapshot if the timeout has elapsed. */
+            result = now - p->last_send >= r->install_snapshot_timeout;
             break;
         case PROGRESS__PROBE:
             /* We send at most one message per heartbeat interval. */

--- a/src/raft.c
+++ b/src/raft.c
@@ -15,6 +15,7 @@
 
 #define DEFAULT_ELECTION_TIMEOUT 1000 /* One second */
 #define DEFAULT_HEARTBEAT_TIMEOUT 100 /* One tenth of a second */
+#define DEFAULT_INSTALL_SNAPSHOT_TIMEOUT (2 * DEFAULT_HEARTBEAT_TIMEOUT)
 #define DEFAULT_SNAPSHOT_THRESHOLD 1024
 #define DEFAULT_SNAPSHOT_TRAILING 2048
 
@@ -51,6 +52,7 @@ int raft_init(struct raft *r,
     r->configuration_uncommitted_index = 0;
     r->election_timeout = DEFAULT_ELECTION_TIMEOUT;
     r->heartbeat_timeout = DEFAULT_HEARTBEAT_TIMEOUT;
+    r->install_snapshot_timeout = DEFAULT_INSTALL_SNAPSHOT_TIMEOUT;
     r->commit_index = 0;
     r->last_applied = 0;
     r->last_stored = 0;
@@ -108,6 +110,11 @@ void raft_set_election_timeout(struct raft *r, const unsigned msecs)
 void raft_set_heartbeat_timeout(struct raft *r, const unsigned msecs)
 {
     r->heartbeat_timeout = msecs;
+}
+
+void raft_set_install_snapshot_timeout(struct raft *r, const unsigned msecs)
+{
+    r->install_snapshot_timeout = msecs;
 }
 
 void raft_set_snapshot_threshold(struct raft *r, unsigned n)

--- a/src/recv.c
+++ b/src/recv.c
@@ -64,6 +64,12 @@ static int recvMessage(struct raft *r, struct raft_message *message)
             rv = recvInstallSnapshot(r, message->server_id,
                                      message->server_address,
                                      &message->install_snapshot);
+            /* Already installing a snapshot, wait for it and ignore this one */
+            if (rv == RAFT_BUSY) {
+                raft_free(message->install_snapshot.data.base);
+                raft_configuration_close(&message->install_snapshot.conf);
+                rv = 0;
+            }
             break;
         case RAFT_IO_TIMEOUT_NOW:
             rv = recvTimeoutNow(r, message->server_id, message->server_address,

--- a/src/replication.c
+++ b/src/replication.c
@@ -276,6 +276,7 @@ static int sendSnapshot(struct raft *r, const unsigned i)
         goto err_after_req_alloc;
     }
 
+    progressUpdateLastSend(r, i);
     return 0;
 
 err_after_req_alloc:

--- a/src/replication.c
+++ b/src/replication.c
@@ -58,18 +58,6 @@ static void sendAppendEntriesCb(struct raft_io_send *send, const int status)
                    req->server_id, raft_strerror(status));
             /* Go back to probe mode. */
             progressToProbe(r, i);
-        } else {
-            /* Update the last_send timestamp: for a heartbeat_timeout
-             * milliseconds we'll be good and we won't need to contact followers
-             * again, since this was not an idle period.
-             *
-             * From Figure 3.1:
-             *
-             *   [Rules for Servers] Leaders: Upon election: send initial empty
-             *   AppendEntries RPCs (heartbeat) to each server; repeat during
-             * idle periods to prevent election timeouts
-             */
-            progressUpdateLastSend(r, i);
         }
     }
 
@@ -142,6 +130,7 @@ static int sendAppendEntries(struct raft *r,
         progressOptimisticNextIndex(r, i, req->index + req->n);
     }
 
+    progressUpdateLastSend(r, i);
     return 0;
 
 err_after_req_alloc:

--- a/src/replication.c
+++ b/src/replication.c
@@ -1236,7 +1236,7 @@ int replicationInstallSnapshot(struct raft *r,
      * something smarter. */
     if (r->snapshot.pending.term != 0 || r->snapshot.put.data != NULL) {
         *async = true;
-        return 0;
+        return RAFT_BUSY;
     }
 
     /* If our last snapshot is more up-to-date, this is a no-op */

--- a/src/start.c
+++ b/src/start.c
@@ -139,6 +139,8 @@ int raft_start(struct raft *r)
     assert(r->state == RAFT_UNAVAILABLE);
     assert(r->heartbeat_timeout != 0);
     assert(r->heartbeat_timeout < r->election_timeout);
+    assert(r->install_snapshot_timeout != 0);
+    assert(r->install_snapshot_timeout < r->election_timeout);
     assert(logNumEntries(&r->log) == 0);
     assert(logSnapshotIndex(&r->log) == 0);
     assert(r->last_stored == 0);


### PR DESCRIPTION
Retries the InstallSnapshot RPC after a timeout. The retries also work as "HeartBeats" during a Follower's Snapshot installation keeping the follower from converting to a candidate. In a next phase I would like to send real HeartBeat AppendEntries RPCs regardless if the follower is installing a Snapshot or not, but that requires more profound changes.

In this PR I have also changed the logic when `last_send` is updated, next to being updated when sending an AppendEntries RPC it is also updated when sending an InstallSnaphot RPC. I also update it synchronously in the tickCb, otherwise we risk sending multiple RPCs while we wait for `last_send` to be updated in the respective RPC send callbacks.