### PR TITLE
Mbordere/timeout connection attempts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([raft], [0.10.0])
+AC_INIT([raft], [0.11.0])
 AC_LANG([C])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([ac])

--- a/include/raft/uv.h
+++ b/include/raft/uv.h
@@ -114,6 +114,12 @@ RAFT_API void raft_uv_set_segment_size(struct raft_io *io, size_t size);
 RAFT_API void raft_uv_set_connect_retry_delay(struct raft_io *io, unsigned msecs);
 
 /**
+ * Set how many attempts should be made to connect with another server.
+ * The default is 100 attempts.
+ */
+RAFT_API void raft_uv_set_connect_attempts(struct raft_io *io, unsigned attempts);
+
+/**
  * Emit low-level debug messages using the given tracer.
  */
 RAFT_API void raft_uv_set_tracer(struct raft_io *io,

--- a/src/uv.c
+++ b/src/uv.c
@@ -30,6 +30,7 @@
  *
  * TODO: implement an exponential backoff instead.  */
 #define CONNECT_RETRY_DELAY 1000
+#define CONNECT_ATTEMPTS 100
 
 /* Implementation of raft_io->config. */
 static int uvInit(struct raft_io *io, raft_id id, const char *address)
@@ -594,6 +595,7 @@ int raft_uv_init(struct raft_io *io,
     QUEUE_INIT(&uv->clients);
     QUEUE_INIT(&uv->servers);
     uv->connect_retry_delay = CONNECT_RETRY_DELAY;
+    uv->connect_attempts = CONNECT_ATTEMPTS;
     uv->prepare_inflight = NULL;
     QUEUE_INIT(&uv->prepare_reqs);
     QUEUE_INIT(&uv->prepare_pool);
@@ -670,6 +672,13 @@ void raft_uv_set_connect_retry_delay(struct raft_io *io, unsigned msecs)
     struct uv *uv;
     uv = io->impl;
     uv->connect_retry_delay = msecs;
+}
+
+void raft_uv_set_connect_attempts(struct raft_io *io, unsigned attempts)
+{
+    struct uv *uv;
+    uv = io->impl;
+    uv->connect_attempts = attempts;
 }
 
 void raft_uv_set_tracer(struct raft_io *io, struct raft_tracer *tracer)

--- a/src/uv.h
+++ b/src/uv.h
@@ -67,6 +67,7 @@ struct uv
     queue clients;                       /* Outbound connections */
     queue servers;                       /* Inbound connections */
     unsigned connect_retry_delay;        /* Client connection retry delay */
+    unsigned connect_attempts;           /* Client connection attempts */
     void *prepare_inflight;              /* Segment being prepared */
     queue prepare_reqs;                  /* Pending prepare requests. */
     queue prepare_pool;                  /* Prepared open segments */

--- a/test/integration/test_uv_send.c
+++ b/test/integration/test_uv_send.c
@@ -288,6 +288,22 @@ TEST(send, changeToUnconnectedAddress, setUp, tearDownDeps, 0, NULL)
     return MUNIT_OK;
 }
 
+/* The send eventually times out and the client connection is aborted. */
+TEST(send, timeOut, setUp, tearDownDeps, 0, NULL)
+{
+    struct fixture *f = data;
+
+    /* Send a message to an unconnected address and assert it times out. */
+    MESSAGE(0)->server_address = "127.0.0.2:1";
+    SEND_SUBMIT(0 /* message */, 0 /* rv */, RAFT_CANCELED /* status */);
+
+    /* Wait for the send to timeout  */
+    SEND_WAIT(0);
+
+    TEAR_DOWN_UV;
+    return MUNIT_OK;
+}
+
 /* The message has an invalid type. */
 TEST(send, badMessage, setUp, tearDown, 0, NULL)
 {

--- a/test/integration/test_uv_send.c
+++ b/test/integration/test_uv_send.c
@@ -109,6 +109,7 @@ static void *setUp(const MunitParameter params[], void *user_data)
     unsigned i;
     SETUP_UV;
     raft_uv_set_connect_retry_delay(&f->io, 1);
+    raft_uv_set_connect_attempts(&f->io, 5);
     for (i = 0; i < N_MESSAGES; i++) {
         struct raft_message *message = &f->messages[i];
         message->type = RAFT_IO_REQUEST_VOTE;
@@ -288,7 +289,8 @@ TEST(send, changeToUnconnectedAddress, setUp, tearDownDeps, 0, NULL)
     return MUNIT_OK;
 }
 
-/* The send eventually times out and the client connection is aborted. */
+/* The send eventually times out after a number of attempts and the
+ * client connection is aborted. */
 TEST(send, timeOut, setUp, tearDownDeps, 0, NULL)
 {
     struct fixture *f = data;


### PR DESCRIPTION
This will cleanup clients in the client queue to which we cannot connect, instead of retrying to connect to them forever. If raft would attempt to connect to such an unreachable client again, a new uvClient struct will be created and the retry cycle restarts.

This is an attempt to cleanup connections in the case where multiple servers are added and removed from the configuration over time and that cannot be reached anymore. Ideally I want to actively cleanup the connection to a server when the server is no longer part of the configuration, but that requires some more refactoring. What are your thoughts @freeekanayaka ?