### PR TITLE
release: 0.10.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([raft], [0.9.24])
+AC_INIT([raft], [0.10.0])
 AC_LANG([C])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([ac])


### PR DESCRIPTION
Forgot to bump the library minor version when extending the API.

- Add raft_set_install_snapshot_timeout to API

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>