### PR TITLE
Dont load partial snapshots

### DIFF
--- a/src/uv.c
+++ b/src/uv.c
@@ -54,6 +54,11 @@ static int uvInit(struct raft_io *io, raft_id id, const char *address)
     uv->direct_io = direct_io != 0;
     uv->block_size = direct_io != 0 ? direct_io : 4096;
 
+    rv = UvFsRemoveTmpFiles(uv->dir, io->errmsg);
+    if (rv != 0) {
+        return rv;
+    }
+
     rv = uvMetadataLoad(uv->dir, &metadata, io->errmsg);
     if (rv != 0) {
         return rv;

--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -10,7 +10,8 @@
 #include "heap.h"
 #include "uv_os.h"
 
-#define TMP_FILE_FMT "tmp-%s"
+#define TMP_FILE_PREFIX "tmp-"
+#define TMP_FILE_FMT TMP_FILE_PREFIX "%s"
 
 int UvFsCheckDir(const char *dir, char *errmsg)
 {
@@ -319,6 +320,40 @@ err_after_tmp_create:
     UvFsRemoveFile(dir, tmp_filename, errmsg);
     return rv;
 }
+
+int UvFsRemoveTmpFiles(const char *dir, char* errmsg)
+{
+    struct uv_fs_s req;
+    struct uv_dirent_s entry;
+    int n;
+    int i;
+    int rv;
+    int rv2;
+
+    n = uv_fs_scandir(NULL, &req, dir, 0, NULL);
+    if (n < 0) {
+        ErrMsgPrintf(errmsg, "scan data directory: %s", uv_strerror(n));
+        return RAFT_IOERR;
+    }
+
+    rv = 0;
+    for (i = 0; i < n; i++) {
+        const char *filename;
+        rv = uv_fs_scandir_next(&req, &entry);
+        assert(rv == 0); /* Can't fail in libuv */
+
+        filename = entry.name;
+        if (strncmp(filename, TMP_FILE_PREFIX, strlen(TMP_FILE_PREFIX)) == 0) {
+            rv = UvFsRemoveFile(dir, filename, errmsg);
+        }
+    }
+
+    rv2 = uv_fs_scandir_next(&req, &entry);
+    assert(rv2 == UV_EOF);
+
+    return rv;
+}
+
 
 int UvFsMakeOrOverwriteFile(const char *dir,
                             const char *filename,

--- a/src/uv_fs.h
+++ b/src/uv_fs.h
@@ -47,6 +47,11 @@ int UvFsMakeFile(const char *dir,
                  unsigned n_bufs,
                  char *errmsg);
 
+/* UvFsMakeFile makes use of a temporary file when creating a file,
+ * this function takes care of cleaning up leftover temp files after
+ * e.g a crash. */
+int UvFsRemoveTmpFiles(const char *dir, char* errmsg);
+
 /* Create or overwrite a file.
  *
  * If the file does not exists yet, it gets created, the given content written

--- a/test/unit/test_uv_fs.c
+++ b/test/unit/test_uv_fs.c
@@ -359,3 +359,39 @@ TEST(UvFsProbeCapabilities, noResources, DirBtrfsSetUp, DirTearDown, 0, NULL)
 }
 
 #endif /* RWF_NOWAIT */
+
+
+/******************************************************************************
+ *
+ * UvFsMakeFile
+ *
+ *****************************************************************************/
+
+SUITE(UvFsMakeFile)
+
+/* If the file does not exist, the function succeeds. */
+TEST(UvFsMakeFile, notExists, DirSetUp, DirTearDown, 0, NULL)
+{
+    const char *dir = data;
+    int rv;
+    char errmsg[RAFT_ERRMSG_BUF_SIZE];
+    struct raft_buffer bufs[2] = {0};
+    rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
+    munit_assert_int(rv, ==, 0);
+    return MUNIT_OK;
+}
+
+/* If the file exists, the function does not succeed. */
+TEST(UvFsMakeFile, exists, DirSetUp, DirTearDown, 0, NULL)
+{
+    const char *dir = data;
+    int rv;
+    char errmsg[RAFT_ERRMSG_BUF_SIZE];
+    struct raft_buffer bufs[2] = {0};
+    rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
+    munit_assert_int(rv, ==, 0);
+    rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
+    munit_assert_int(rv, !=, 0);
+    return MUNIT_OK;
+}
+

--- a/test/unit/test_uv_fs.c
+++ b/test/unit/test_uv_fs.c
@@ -395,3 +395,34 @@ TEST(UvFsMakeFile, exists, DirSetUp, DirTearDown, 0, NULL)
     return MUNIT_OK;
 }
 
+/******************************************************************************
+ *
+ * UvFsRemoveTmpFiles
+ *
+ *****************************************************************************/
+
+SUITE(UvFsRemoveTmpFiles)
+
+TEST(UvFsRemoveTmpFiles, twoTmpFiles, DirSetUp, DirTearDown, 0, NULL)
+{
+    const char *dir = data;
+    int rv;
+    char errmsg[RAFT_ERRMSG_BUF_SIZE];
+    struct raft_buffer bufs[2] = {0};
+    rv = UvFsMakeFile(dir, "tmp-foo1", bufs, 2, errmsg);
+    munit_assert_int(rv, ==, 0);
+    rv = UvFsMakeFile(dir, "tmp-foo2", bufs, 2, errmsg);
+    munit_assert_int(rv, ==, 0);
+    rv = UvFsMakeFile(dir, "mp-foo2", bufs, 2, errmsg);
+    munit_assert_int(rv, ==, 0);
+    rv = UvFsMakeFile(dir, "tmpp-foo3", bufs, 2, errmsg);
+    munit_assert_int(rv, ==, 0);
+
+    rv = UvFsRemoveTmpFiles(dir, errmsg);
+    munit_assert_int(rv, ==, 0);
+    munit_assert_false(DirHasFile(dir, "tmp-foo1"));
+    munit_assert_false(DirHasFile(dir, "tmp-foo2"));
+    munit_assert_true(DirHasFile(dir, "mp-foo2"));
+    munit_assert_true(DirHasFile(dir, "tmpp-foo3"));
+    return MUNIT_OK;
+}


### PR DESCRIPTION
This would resolve https://github.com/canonical/raft/issues/183. A follower can crash if it receives an incomplete snapshot from a leader. The tmp-file approach in this PR tries to ensure only fully written snapshot are ever read and sent to a follower.