### PR TITLE
Revive arm64 and ppc64le CI tests

### DIFF
--- a/test/lib/munit.c
+++ b/test/lib/munit.c
@@ -1388,7 +1388,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
           if (stderr_buf != NULL) {
             munit_log_errno(MUNIT_LOG_ERROR, stderr, "unable to write to pipe");
           }
-          exit(EXIT_FAILURE);
+          _exit(EXIT_FAILURE);
         }
         bytes_written += write_res;
       } while ((size_t) bytes_written < sizeof(report));
@@ -1397,7 +1397,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
         fclose(stderr_buf);
       close(pipefd[1]);
 
-      exit(EXIT_SUCCESS);
+      _exit(EXIT_SUCCESS);
     } else if (fork_pid == -1) {
       close(pipefd[0]);
       close(pipefd[1]);


### PR DESCRIPTION
the `exit` library call is causing a hang, replaced by `_exit` system call which is according to https://stackoverflow.com/questions/5422831/what-is-the-difference-between-using-exit-exit-in-a-conventional-linux-fo the correct way to exit from a child that hasn't `exec`'d (like in our case).

Will open a PR to fix munit.