### PR TITLE
Fix code coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -227,6 +227,7 @@ if SANITIZE_ENABLED
 endif
 
 if CODE_COVERAGE_ENABLED
+AM_CFLAGS += -DCODE_COVERAGE_ENABLED
 
 include $(top_srcdir)/aminclude_static.am
 

--- a/test/lib/munit.c
+++ b/test/lib/munit.c
@@ -143,6 +143,10 @@
 #  define MUNIT_NO_BUFFER
 #endif
 
+#if defined(CODE_COVERAGE_ENABLED)
+extern void __gcov_flush(void);
+#endif
+
 /*** Logging ***/
 
 static MunitLogLevel munit_log_level_visible = MUNIT_LOG_INFO;
@@ -1388,6 +1392,9 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
           if (stderr_buf != NULL) {
             munit_log_errno(MUNIT_LOG_ERROR, stderr, "unable to write to pipe");
           }
+#if defined(CODE_COVERAGE_ENABLED)
+          __gcov_flush();
+#endif
           _exit(EXIT_FAILURE);
         }
         bytes_written += write_res;
@@ -1397,6 +1404,9 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
         fclose(stderr_buf);
       close(pipefd[1]);
 
+#if defined(CODE_COVERAGE_ENABLED)
+      __gcov_flush();
+#endif
       _exit(EXIT_SUCCESS);
     } else if (fork_pid == -1) {
       close(pipefd[0]);


### PR DESCRIPTION
`__gcov_flush()` is normally called by the exit handlers that are called in response to `exit`, `exit` however was causing hangs on arm64 and ppc64le, and was replaced with `_exit` in munit. Because `_exit` doesn't call exit handlers, we need to call `__gcov_flush()` ourselves when compiling with code coverage enabled.

~~edit: Will just double-check if ASAN still works as expected with the `exit` --> `_exit` change~~ ASAN still works 