### PR TITLE
travis: Run ppc64le arch test on PR instead of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ jobs:
     dist: bionic
     arch: arm64
 
-  - if: type != pull_request
+  # Coverity issue is interfering with ppc64le master build
+  - if: type == pull_request
     compiler: clang
     dist: bionic
     arch: ppc64le


### PR DESCRIPTION
Coverity issue is interfering with the master build.
see
https://travis-ci.community/t/non-amd64-builds-timing-out-if-script-does-exit-0/10996

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>