### PR TITLE
Bugfixes

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -339,11 +339,13 @@ int replicationProgress(struct raft *r, unsigned i)
             assert(prev_index < snapshot_index);
             tracef("missing entry at index %lld -> send snapshot", prev_index);
             goto send_snapshot;
-        } else if (prev_term == 0 && progress_state_is_snapshot) {
-            /* The entry is not in the log, but the peer is installing a
-             * snapshot, send an empty AppendEntries RPC */
-            prev_index = 0;
         }
+    }
+
+    /* Send empty AppendEntries RPC when installing a snaphot */
+    if (progress_state_is_snapshot) {
+        prev_index = logLastIndex(&r->log);
+        prev_term = logLastTerm(&r->log);
     }
 
     return sendAppendEntries(r, i, prev_index, prev_term);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1074,7 +1074,7 @@ int replicationAppend(struct raft *r,
      */
     if (n == 0) {
         if (args->leader_commit > r->commit_index) {
-            r->commit_index = min(args->leader_commit, logLastIndex(&r->log));
+            r->commit_index = min(args->leader_commit, r->last_stored);
             rv = replicationApply(r);
             if (rv != 0) {
                 return rv;

--- a/src/replication.c
+++ b/src/replication.c
@@ -33,6 +33,11 @@
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
+static inline bool snapshotInstallBusy(struct raft *r)
+{
+    return r->last_stored == 0 && r->snapshot.put.data != NULL;
+}
+
 /* Context of a RAFT_IO_APPEND_ENTRIES request that was submitted with
  * raft_io_>send(). */
 struct sendAppendEntries
@@ -848,6 +853,12 @@ static void appendFollowerCb(struct raft_io_append *req, int status)
         goto out;
     }
 
+    /* We received an InstallSnapshot RCP while these entries were being
+     * persisted to disk */
+    if (snapshotInstallBusy(r)) {
+        goto out;
+    }
+
     i = updateLastStored(r, request->index, args->entries, args->n_entries);
 
     /* If none of the entries that we persisted is present anymore in our
@@ -1064,7 +1075,9 @@ int replicationAppend(struct raft *r,
     n = args->n_entries - i; /* Number of new entries */
 
     /* If this is an empty AppendEntries, there's nothing to write. However we
-     * still want to check if we can commit some entry.
+     * still want to check if we can commit some entry. However, don't commit
+     * anything while a snapshot install is busy, r->last_stored will be 0 in
+     * that case.
      *
      * From Figure 3.1:
      *
@@ -1073,7 +1086,7 @@ int replicationAppend(struct raft *r,
      *   entry).
      */
     if (n == 0) {
-        if (args->leader_commit > r->commit_index) {
+        if ((args->leader_commit > r->commit_index) && !snapshotInstallBusy(r)) {
             r->commit_index = min(args->leader_commit, r->last_stored);
             rv = replicationApply(r);
             if (rv != 0) {


### PR DESCRIPTION
- There was an issue with sending AppendEntries RPC's containing entries while a snapshot was being installed by a follower. Now, we will always send empty AppendEntries RPC's to a follower that is installing a snapshot. This should fix most of @morphis his scaling issues together with https://github.com/lxc/lxd/pull/8629. 

- Protect against an InstallSnapshot RPC that arrives while entries are being saved to disk and could lead to inconsistent state.

- Don't commit entries when handling a HeartBeat while we are installing a snapshot.
