### PR TITLE
uv_fs: Remove orphaned snapshot files on init

### DIFF
--- a/src/uv.h
+++ b/src/uv.h
@@ -27,9 +27,11 @@
  * creation timestamp (milliseconds since epoch). */
 #define UV__SNAPSHOT_TEMPLATE "snapshot-%llu-%llu-%llu"
 
+#define UV__SNAPSHOT_META_SUFFIX ".meta"
+
 /* Template string for snapshot metadata filenames: snapshot term,  snapshot
  * index, creation timestamp (milliseconds since epoch). */
-#define UV__SNAPSHOT_META_TEMPLATE UV__SNAPSHOT_TEMPLATE ".meta"
+#define UV__SNAPSHOT_META_TEMPLATE UV__SNAPSHOT_TEMPLATE UV__SNAPSHOT_META_SUFFIX
 
 /* State codes. */
 enum {
@@ -229,6 +231,14 @@ struct uvSnapshotInfo
 
 /* Render the filename of the data file of a snapshot */
 void uvSnapshotFilenameOf(struct uvSnapshotInfo *info, char *filename);
+
+/* Upon success `orphan` will be true if filename is a snapshot file without a
+ * sibling .meta file */
+int UvSnapshotIsOrphan(const char *dir, const char *filename, bool *orphan);
+
+/* Upon success `orphan` will be true if filename is a snapshot .meta file
+ * without a sibling snapshot file */
+int UvSnapshotMetaIsOrphan(const char *dir, const char *filename, bool *orphan);
 
 /* Append a new item to the given snapshot info list if the given filename
  * matches the pattern of a snapshot metadata file (snapshot-xxx-yyy-zzz.meta)

--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -10,9 +10,6 @@
 #include "heap.h"
 #include "uv_os.h"
 
-#define TMP_FILE_PREFIX "tmp-"
-#define TMP_FILE_FMT TMP_FILE_PREFIX "%s"
-
 int UvFsCheckDir(const char *dir, char *errmsg)
 {
     struct uv_fs_s req;
@@ -320,40 +317,6 @@ err_after_tmp_create:
     UvFsRemoveFile(dir, tmp_filename, errmsg);
     return rv;
 }
-
-int UvFsRemoveTmpFiles(const char *dir, char* errmsg)
-{
-    struct uv_fs_s req;
-    struct uv_dirent_s entry;
-    int n;
-    int i;
-    int rv;
-    int rv2;
-
-    n = uv_fs_scandir(NULL, &req, dir, 0, NULL);
-    if (n < 0) {
-        ErrMsgPrintf(errmsg, "scan data directory: %s", uv_strerror(n));
-        return RAFT_IOERR;
-    }
-
-    rv = 0;
-    for (i = 0; i < n; i++) {
-        const char *filename;
-        rv = uv_fs_scandir_next(&req, &entry);
-        assert(rv == 0); /* Can't fail in libuv */
-
-        filename = entry.name;
-        if (strncmp(filename, TMP_FILE_PREFIX, strlen(TMP_FILE_PREFIX)) == 0) {
-            rv = UvFsRemoveFile(dir, filename, errmsg);
-        }
-    }
-
-    rv2 = uv_fs_scandir_next(&req, &entry);
-    assert(rv2 == UV_EOF);
-
-    return rv;
-}
-
 
 int UvFsMakeOrOverwriteFile(const char *dir,
                             const char *filename,

--- a/src/uv_fs.h
+++ b/src/uv_fs.h
@@ -8,6 +8,9 @@
 #include "../include/raft.h"
 #include "err.h"
 
+#define TMP_FILE_PREFIX "tmp-"
+#define TMP_FILE_FMT TMP_FILE_PREFIX "%s"
+
 /* Check that the given directory can be used. */
 int UvFsCheckDir(const char *dir, char *errmsg);
 
@@ -46,11 +49,6 @@ int UvFsMakeFile(const char *dir,
                  struct raft_buffer *bufs,
                  unsigned n_bufs,
                  char *errmsg);
-
-/* UvFsMakeFile makes use of a temporary file when creating a file,
- * this function takes care of cleaning up leftover temp files after
- * e.g a crash. */
-int UvFsRemoveTmpFiles(const char *dir, char* errmsg);
 
 /* Create or overwrite a file.
  *

--- a/test/unit/test_uv_fs.c
+++ b/test/unit/test_uv_fs.c
@@ -394,35 +394,3 @@ TEST(UvFsMakeFile, exists, DirSetUp, DirTearDown, 0, NULL)
     munit_assert_int(rv, !=, 0);
     return MUNIT_OK;
 }
-
-/******************************************************************************
- *
- * UvFsRemoveTmpFiles
- *
- *****************************************************************************/
-
-SUITE(UvFsRemoveTmpFiles)
-
-TEST(UvFsRemoveTmpFiles, twoTmpFiles, DirSetUp, DirTearDown, 0, NULL)
-{
-    const char *dir = data;
-    int rv;
-    char errmsg[RAFT_ERRMSG_BUF_SIZE];
-    struct raft_buffer bufs[2] = {{0},{0}};
-    rv = UvFsMakeFile(dir, "tmp-foo1", bufs, 2, errmsg);
-    munit_assert_int(rv, ==, 0);
-    rv = UvFsMakeFile(dir, "tmp-foo2", bufs, 2, errmsg);
-    munit_assert_int(rv, ==, 0);
-    rv = UvFsMakeFile(dir, "mp-foo2", bufs, 2, errmsg);
-    munit_assert_int(rv, ==, 0);
-    rv = UvFsMakeFile(dir, "tmpp-foo3", bufs, 2, errmsg);
-    munit_assert_int(rv, ==, 0);
-
-    rv = UvFsRemoveTmpFiles(dir, errmsg);
-    munit_assert_int(rv, ==, 0);
-    munit_assert_false(DirHasFile(dir, "tmp-foo1"));
-    munit_assert_false(DirHasFile(dir, "tmp-foo2"));
-    munit_assert_true(DirHasFile(dir, "mp-foo2"));
-    munit_assert_true(DirHasFile(dir, "tmpp-foo3"));
-    return MUNIT_OK;
-}


### PR DESCRIPTION
Fixes https://github.com/canonical/dqlite/issues/289.

Snapshots could be orphaned in certain cases, leading to high disk usage. This is fixed here https://github.com/canonical/raft/pull/193.

This PR will clean up, at init, leftover `snapshot` files that don't have a matching `.meta` file at startup and will also cleanup `.meta` files that don't have a matching `snapshot` file.

