### PR TITLE
uv: seed the PRNG

### DIFF
--- a/src/uv.c
+++ b/src/uv.c
@@ -594,7 +594,12 @@ static raft_time uvTime(struct raft_io *io)
 /* Implementation of raft_io->random. */
 static int uvRandom(struct raft_io *io, int min, int max)
 {
-    (void)io;
+    static bool initialized = false;
+    if (!initialized) {
+        struct uv *uv = io->impl;
+        srand((unsigned)uv_now(uv->loop) + (unsigned)uv->id);
+        initialized = true;
+    }
     return min + (abs(rand()) % (max - min));
 }
 


### PR DESCRIPTION
The PRNG of `rand` was not seeded, causing it to be seeded with 1 every time (see https://linux.die.net/man/3/rand) depending on the implementation of `rand` on the platform, this can result in the same random sequence obtained from `rand` on all nodes,  causing the election timeout to fire at the same moment for all nodes and a cluster that cannot make progress. This would be especially problematic if all nodes start up at the same time.

In a future PR I also want to adapt the election timeout mechanism. At the moment, every tick we check if the random timeout has passed. But the value of the tick is quite large (in case of dqlite 500ms) and there are only so many ticks in an election timeout interval, meaning that the randomness of the election timeout is significantly reduced, potentially resulting in slow leader election and an unresponsive cluster.