### PR TITLE
Revert munit changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,12 @@ before_script:
 
 script:
   - autoreconf -i
-  - ./configure --enable-example --enable-debug --enable-code-coverage --enable-sanitize
+  - |
+    if [ $TRAVIS_CPU_ARCH = "s390x" ] || [ $TRAVIS_CPU_ARCH = "arm64" ]; then
+      ./configure --enable-example --enable-debug --enable-code-coverage
+    else
+      ./configure --enable-example --enable-debug --enable-code-coverage --enable-sanitize
+    fi
   - amalgamate.py --config=amalgamation.json --source=$(pwd)
   - $CC raft.c -c -D_GNU_SOURCE -DHAVE_LINUX_AIO_ABI_H -Wall -Wextra -Wpedantic -fpic
   - ./test/lib/fs.sh setup

--- a/Makefile.am
+++ b/Makefile.am
@@ -227,7 +227,6 @@ if SANITIZE_ENABLED
 endif
 
 if CODE_COVERAGE_ENABLED
-AM_CFLAGS += -DCODE_COVERAGE_ENABLED
 
 include $(top_srcdir)/aminclude_static.am
 

--- a/test/lib/munit.c
+++ b/test/lib/munit.c
@@ -143,10 +143,6 @@
 #  define MUNIT_NO_BUFFER
 #endif
 
-#if defined(CODE_COVERAGE_ENABLED)
-extern void __gcov_flush(void);
-#endif
-
 /*** Logging ***/
 
 static MunitLogLevel munit_log_level_visible = MUNIT_LOG_INFO;
@@ -1392,9 +1388,6 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
           if (stderr_buf != NULL) {
             munit_log_errno(MUNIT_LOG_ERROR, stderr, "unable to write to pipe");
           }
-#if defined(CODE_COVERAGE_ENABLED)
-          __gcov_flush();
-#endif
           _exit(EXIT_FAILURE);
         }
         bytes_written += write_res;
@@ -1404,9 +1397,6 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
         fclose(stderr_buf);
       close(pipefd[1]);
 
-#if defined(CODE_COVERAGE_ENABLED)
-      __gcov_flush();
-#endif
       _exit(EXIT_SUCCESS);
     } else if (fork_pid == -1) {
       close(pipefd[0]);

--- a/test/lib/munit.c
+++ b/test/lib/munit.c
@@ -1388,7 +1388,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
           if (stderr_buf != NULL) {
             munit_log_errno(MUNIT_LOG_ERROR, stderr, "unable to write to pipe");
           }
-          _exit(EXIT_FAILURE);
+          exit(EXIT_FAILURE);
         }
         bytes_written += write_res;
       } while ((size_t) bytes_written < sizeof(report));
@@ -1397,7 +1397,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
         fclose(stderr_buf);
       close(pipefd[1]);
 
-      _exit(EXIT_SUCCESS);
+      exit(EXIT_SUCCESS);
     } else if (fork_pid == -1) {
       close(pipefd[0]);
       close(pipefd[1]);


### PR DESCRIPTION
While trying to fix the extremely slow CI tests on arm64 and s390x I broke the sanitizer functionality. This PR reverts those changes and fixes the hanging by not enabling sanitizers for arm64 and s390x.

The hanging/slow tests are probably caused by https://github.com/google/sanitizers/issues/1331. Will need to look deeper into this, but for now the sanitizer should at least be functional again.