### PR TITLE
Raft transfer disrupt

### DIFF
--- a/src/election.c
+++ b/src/election.c
@@ -127,7 +127,7 @@ int electionStart(struct raft *r)
     /* During pre-vote we don't actually increment term or persist vote, however
      * we reset any vote that we previously granted since we have timed out and
      * that vote is no longer valid. */
-    if (r->candidate_state.in_pre_vote) {
+    if (r->candidate_state.in_pre_vote && !r->candidate_state.disrupt_leader) {
         /* Reset vote */
         rv = r->io->set_vote(r->io, 0);
         if (rv != 0) {

--- a/src/recv_request_vote.c
+++ b/src/recv_request_vote.c
@@ -65,7 +65,7 @@ int recvRequestVote(struct raft *r,
 
     /* If this is a pre-vote request, don't actually increment our term or
      * persist the vote. */
-    if (args->pre_vote) {
+    if (args->pre_vote && !args->disrupt_leader) {
         recvCheckMatchingTerms(r, args->term, &match);
     } else {
         rv = recvEnsureMatchingTerms(r, args->term, &match);

--- a/test/integration/test_transfer.c
+++ b/test/integration/test_transfer.c
@@ -190,3 +190,22 @@ TEST(raft_transfer, afterDemotion, setUp, tearDown, 0, NULL)
     munit_assert_int(CLUSTER_LEADER, ==, 1);
     return MUNIT_OK;
 }
+
+static char *cluster_pre_vote[] = {"0", "1", NULL};
+static char *cluster_heartbeat[] = {"1", "100", NULL};
+
+static MunitParameterEnum _params[] = {
+    {CLUSTER_PRE_VOTE_PARAM, cluster_pre_vote},
+    {CLUSTER_HEARTBEAT_PARAM, cluster_heartbeat},
+    {NULL, NULL},
+};
+
+/* It's possible to transfer leadership also when pre-vote is active */
+TEST(raft_transfer, preVote, setUp, tearDown, 0, _params)
+{
+    struct fixture *f = data;
+    TRANSFER(0, 2);
+    CLUSTER_STEP_UNTIL_HAS_LEADER(1000);
+    munit_assert_int(CLUSTER_LEADER, ==, 1);
+    return MUNIT_OK;
+}

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -24,6 +24,7 @@
     do {                                                                     \
         unsigned _n = DEFAULT_N;                                             \
         bool _pre_vote = false;                                              \
+        unsigned _hb = 0;                                                    \
         unsigned _i;                                                         \
         int _rv;                                                             \
         if (munit_parameters_get(params, CLUSTER_N_PARAM) != NULL) {         \
@@ -33,6 +34,10 @@
             _pre_vote =                                                      \
                 atoi(munit_parameters_get(params, CLUSTER_PRE_VOTE_PARAM));  \
         }                                                                    \
+        if (munit_parameters_get(params, CLUSTER_HEARTBEAT_PARAM) != NULL) { \
+            _hb =                                                            \
+                atoi(munit_parameters_get(params, CLUSTER_HEARTBEAT_PARAM)); \
+        }                                                                    \
         munit_assert_int(_n, >, 0);                                          \
         for (_i = 0; _i < _n; _i++) {                                        \
             FsmInit(&f->fsms[_i]);                                           \
@@ -41,6 +46,10 @@
         munit_assert_int(_rv, ==, 0);                                        \
         for (_i = 0; _i < _n; _i++) {                                        \
             raft_set_pre_vote(raft_fixture_get(&f->cluster, _i), _pre_vote); \
+            if (_hb) {                                                       \
+                raft_set_heartbeat_timeout(raft_fixture_get(&f->cluster, _i),\
+                                           _hb);                             \
+            }                                                                \
         }                                                                    \
     } while (0)
 
@@ -62,6 +71,9 @@
 
 /* Munit parameter for enabling pre-vote */
 #define CLUSTER_PRE_VOTE_PARAM "cluster-pre-vote"
+
+/* Munit parameter for setting HeartBeat timeout */
+#define CLUSTER_HEARTBEAT_PARAM "cluster-heartbeat"
 
 /* Get the number of servers in the cluster. */
 #define CLUSTER_N raft_fixture_n(&f->cluster)


### PR DESCRIPTION
Fixes https://github.com/canonical/raft/issues/203.

Skip pre-vote logic when `disrupt_leader` is set. Without this fix a leadership transfer could fail when a `HeartBeat` arrives at a node that has just become `Candidate` as the result of a `raft_transfer`.