### PR TITLE
Snapshot compress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     - lcov
     - linux-libc-dev
     - libuv1-dev
+    - liblz4-dev
     - btrfs-progs
     - xfsprogs
     - zfsutils-linux

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ libraft_la_LDFLAGS = -version-info 0:7:0
 libraft_la_SOURCES = \
   src/byte.c \
   src/client.c \
+  src/compress.c \
   src/configuration.c \
   src/convert.c \
   src/election.c \
@@ -56,18 +57,31 @@ libtest_la_SOURCES = \
 
 test_unit_core_SOURCES = \
   src/byte.c \
+  src/compress.c \
   src/configuration.c \
   src/err.c \
   src/heap.c \
   src/log.c \
   test/unit/main_core.c \
   test/unit/test_byte.c \
+  test/unit/test_compress.c \
   test/unit/test_configuration.c \
   test/unit/test_err.c \
   test/unit/test_log.c \
   test/unit/test_queue.c
 test_unit_core_CFLAGS = $(AM_CFLAGS) -Wno-conversion
 test_unit_core_LDADD = libtest.la
+
+if LZ4_AVAILABLE
+test_unit_core_CFLAGS += -DLZ4_AVAILABLE
+test_unit_core_LDFLAGS = $(LZ4_LIBS)
+libraft_la_CFLAGS += -DLZ4_AVAILABLE
+libraft_la_LDFLAGS += $(LZ4_LIBS)
+endif # LZ4_AVAILABLE
+if LZ4_ENABLED
+test_unit_core_CFLAGS += -DLZ4_ENABLED
+libraft_la_CFLAGS += -DLZ4_ENABLED
+endif # LZ4_ENABLED
 
 if FIXTURE_ENABLED
 
@@ -189,6 +203,14 @@ test_integration_uv_LDFLAGS = -no-install $(UV_LIBS)
 test_integration_uv_LDADD = libtest.la
 
 AM_CFLAGS += $(UV_CFLAGS)
+
+if LZ4_AVAILABLE
+test_integration_uv_CFLAGS += -DLZ4_AVAILABLE
+test_integration_uv_LDFLAGS += $(LZ4_LIBS)
+endif # LZ4_AVAILABLE
+if LZ4_ENABLED
+test_integration_uv_CFLAGS += -DLZ4_ENABLED
+endif # LZ4_ENABLED
 
 endif # UV_ENABLED
 

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,50 @@ AS_IF([test "x$enable_uv" != "xno"],
 AS_IF([test "x$enable_uv" = "xyes" -a "x$have_uv" = "xno"], [AC_MSG_ERROR([libuv required but not found])], [])
 AM_CONDITIONAL(UV_ENABLED, test "x$have_uv" = "xyes")
 
+# The libuv raft_io implementation is built by default to compress snapshots if liblz4 is found, unless
+# explicitly disabled.
+AC_ARG_ENABLE(lz4, AS_HELP_STRING([--disable-lz4], [do not use lz4 compression]))
+
+# Thanks to the OpenVPN configure.ac file for this part.
+AS_IF([test "x$enable_lz4" != "xno"],
+      # If this fails, we will do another test next.
+      # We also add set LZ4_LIBS otherwise
+      # linker will not know about the lz4 library
+      [PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4="yes"], [LZ4_LIBS="-llz4"])])
+if test "${have_lz4}" != "yes" -a "${enable_lz4}" != "no"; then
+    AC_CHECK_HEADERS([lz4.h],
+                     [have_lz4h="yes"],
+                     [])
+    if test "${have_lz4h}" = "yes" ; then
+        AC_MSG_CHECKING([additionally if system LZ4 version >= 1.7.1])
+        AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([[
+#include <lz4.h>
+                         ]],
+                         [[
+/* Version encoding: MMNNPP (Major miNor Patch) - see lz4.h for details */
+#if LZ4_VERSION_NUMBER < 10701L
+#error LZ4 is too old
+#endif
+                         ]]
+                        )],
+         [
+             AC_MSG_RESULT([ok])
+             have_lz4="yes"
+         ],
+         [
+             AC_MSG_RESULT([system LZ4 library is too old])
+             have_lz4="no"
+         ]
+        )
+    fi
+fi
+
+AS_IF([test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xno"],
+      [AC_MSG_ERROR([liblz4 required but not found])], [])
+AM_CONDITIONAL(LZ4_AVAILABLE, test "x$have_lz4" = "xyes")
+AM_CONDITIONAL(LZ4_ENABLED, test "x$enable_lz4" != "xno")
+
 # The fake I/O implementation and associated fixture is built by default, unless
 # explicitly disabled.
 AC_ARG_ENABLE(fixture, AS_HELP_STRING([--disable-fixture], [do not build the raft_fixture test helper]))

--- a/include/raft/uv.h
+++ b/include/raft/uv.h
@@ -107,6 +107,15 @@ RAFT_API void raft_uv_set_block_size(struct raft_io *io, size_t size);
 RAFT_API void raft_uv_set_segment_size(struct raft_io *io, size_t size);
 
 /**
+ * Turn snapshot compression on or off.
+ * Returns non-0 on failure, this can e.g. happen when compression is requested
+ * while no suitable compression library is found.
+ *
+ * By default snapshots are compressed if the appropriate libraries are found.
+ */
+RAFT_API int raft_uv_set_snapshot_compression(struct raft_io *io, bool compressed);
+
+/**
  * Set how many milliseconds to wait between subsequent retries when
  * establishing a connection with another server. The default is 1000
  * milliseconds.

--- a/src/compress.c
+++ b/src/compress.c
@@ -1,0 +1,230 @@
+#include "compress.h"
+
+#ifdef LZ4_AVAILABLE
+#include <lz4frame.h>
+#endif
+#include <string.h>
+
+#include "assert.h"
+#include "err.h"
+
+#define min(a,b) ((a) < (b) ? (a) : (b))
+#define max(a,b) ((a) > (b) ? (a) : (b))
+#define MEGABYTE 1048576
+
+int Compress(struct raft_buffer bufs[], unsigned n_bufs,
+             struct raft_buffer *compressed, char *errmsg)
+{
+#ifndef LZ4_AVAILABLE
+    (void) bufs;
+    (void) n_bufs;
+    (void) compressed;
+    ErrMsgPrintf(errmsg, "LZ4 not available");
+    return RAFT_INVALID;
+#else
+    assert(bufs != NULL);
+    assert(n_bufs > 0);
+    assert(compressed != NULL);
+    assert(errmsg != NULL);
+
+    int rv = RAFT_IOERR;
+    size_t src_size = 0;
+    size_t dst_size = 0;
+    size_t src_offset = 0;
+    size_t dst_offset = 0;
+    size_t dst_size_needed = 0; /* Store minimal dst_size */
+    size_t ret = 0; /* Return value of LZ4F_XXX functions */
+    compressed->base = NULL;
+    compressed->len = 0;
+
+    /* Determine total uncompressed size */
+    for (unsigned i = 0; i < n_bufs; ++i) {
+        src_size += bufs[i].len;
+    }
+
+    /* Set LZ4 preferences */
+    LZ4F_preferences_t lz4_pref;
+    memset(&lz4_pref, 0, sizeof(lz4_pref));
+    /* Detect data corruption when decompressing */
+    lz4_pref.frameInfo.contentChecksumFlag = 1;
+    /* For allocating a suitable buffer when decompressing */
+    lz4_pref.frameInfo.contentSize = src_size;
+
+    /* Context to track compression progress */
+    LZ4F_compressionContext_t ctx;
+    ret = LZ4F_createCompressionContext(&ctx, LZ4F_VERSION);
+    if (LZ4F_isError(ret)) {
+        ErrMsgPrintf(errmsg, "LZ4F_createDecompressionContext %s",
+                     LZ4F_getErrorName(ret));
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    /* Guestimate of eventual compressed size, mainly not to allocate a huge
+     * buffer as `LZ4F_compressBound` calculates the worst case scenario. */
+    dst_size = LZ4F_compressBound(
+            max(MEGABYTE, lz4_pref.frameInfo.contentSize / 10), &lz4_pref);
+    dst_size += LZ4F_HEADER_SIZE_MAX_RAFT;
+    compressed->base = raft_malloc(dst_size);
+    if (compressed->base == NULL) {
+        rv = RAFT_NOMEM;
+        goto err_after_ctx_alloc;
+    }
+
+    /* Returns the size of the lz4 header, data should be written after the
+     * header */
+    dst_offset = LZ4F_compressBegin(ctx, compressed->base, dst_size, &lz4_pref);
+    if (LZ4F_isError(dst_offset)) {
+        ErrMsgPrintf(errmsg, "LZ4F_compressBegin %s",
+                LZ4F_getErrorName(dst_offset));
+        rv = RAFT_IOERR;
+        goto err_after_buff_alloc;
+    }
+
+    /* Compress all buffers */
+    for (unsigned i = 0; i < n_bufs; ++i) {
+        src_offset = 0;
+        while (src_offset < bufs[i].len) {
+            /* Compress in chunks of maximum 1MB and check if there is enough
+             * room in the dst buffer, if not realloc */
+            src_size = min(bufs[i].len - src_offset, (size_t)MEGABYTE);
+            dst_size_needed = LZ4F_compressBound(src_size, &lz4_pref);
+            if (dst_size - dst_offset < dst_size_needed) {
+                dst_size += max(dst_size_needed, lz4_pref.frameInfo.contentSize / 10);
+                compressed->base = raft_realloc(compressed->base, dst_size);
+                if (compressed->base == NULL) {
+                    rv = RAFT_NOMEM;
+                    goto err_after_ctx_alloc;
+                }
+            }
+            /* There is guaranteed enough room in `dst` to perform the
+             * compression */
+            ret = LZ4F_compressUpdate(ctx, (char*)compressed->base + dst_offset,
+                                      dst_size - dst_offset, (char*)bufs[i].base + src_offset,
+                                      src_size, NULL);
+            if (LZ4F_isError(ret)) {
+                ErrMsgPrintf(errmsg, "LZ4F_compressUpdate %s",
+                             LZ4F_getErrorName(ret));
+                rv = RAFT_IOERR;
+                goto err_after_buff_alloc;
+            }
+            dst_offset += ret;
+            src_offset += src_size;
+        }
+    }
+
+    /* Make sure LZ4F_compressEnd has enough room to succeed */
+    dst_size_needed = LZ4F_compressBound(0, &lz4_pref);
+    if ((dst_size - dst_offset) < dst_size_needed) {
+        dst_size += dst_size_needed;
+        compressed->base = raft_realloc(compressed->base, dst_size);
+        if (compressed->base == NULL) {
+            rv = RAFT_NOMEM;
+            goto err_after_ctx_alloc;
+        }
+    }
+
+    /* Finalize compression */
+    ret = LZ4F_compressEnd(ctx, (char*)compressed->base + dst_offset,
+                           dst_size - dst_offset, NULL);
+    if (LZ4F_isError(ret)) {
+        ErrMsgPrintf(errmsg, "LZ4F_compressEnd %s", LZ4F_getErrorName(ret));
+        rv = RAFT_IOERR;
+        goto err_after_buff_alloc;
+    }
+
+    dst_offset += ret;
+    compressed->len = dst_offset;
+
+    LZ4F_freeCompressionContext(ctx);
+    return 0;
+
+err_after_buff_alloc:
+    raft_free(compressed->base);
+    compressed->base = NULL;
+err_after_ctx_alloc:
+    LZ4F_freeCompressionContext(ctx);
+err:
+    return rv;
+#endif /* LZ4_AVAILABLE */
+}
+
+int Decompress(struct raft_buffer buf, struct raft_buffer *decompressed,
+               char *errmsg)
+{
+#ifndef LZ4_AVAILABLE
+    (void) buf;
+    (void) decompressed;
+    ErrMsgPrintf(errmsg, "LZ4 not available");
+    return RAFT_INVALID;
+#else
+    assert(decompressed != NULL);
+
+    int rv = RAFT_IOERR;
+    size_t src_offset = 0;
+    size_t dst_offset = 0;
+    size_t src_size = 0;
+    size_t dst_size = 0;
+    size_t ret = 0;
+
+    LZ4F_decompressionContext_t ctx;
+    if (LZ4F_isError(LZ4F_createDecompressionContext(&ctx, LZ4F_VERSION))) {
+        ErrMsgPrintf(errmsg, "LZ4F_createDecompressionContext");
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    src_size = buf.len;
+    LZ4F_frameInfo_t frameInfo = {0};
+    /* `src_size` will contain the size of the LZ4 Frame Header after the call,
+     * decompression must resume at that offset. */
+    ret = LZ4F_getFrameInfo(ctx, &frameInfo, buf.base, &src_size);
+    if (LZ4F_isError(ret)) {
+        ErrMsgPrintf(errmsg, "LZ4F_getFrameInfo %s", LZ4F_getErrorName(ret));
+        rv = RAFT_IOERR;
+        goto err_after_ctx_alloc;
+    }
+    src_offset = src_size;
+
+    decompressed->base = raft_malloc(frameInfo.contentSize);
+    decompressed->len = frameInfo.contentSize;
+    if (decompressed->base == NULL) {
+        rv = RAFT_NOMEM;
+        goto err_after_ctx_alloc;
+    }
+
+    ret = 1;
+    while (ret != 0) {
+        src_size = buf.len - src_offset;
+        dst_size = decompressed->len - dst_offset;
+        /* `dst_size` will contain the number of bytes written to decompressed->base,
+         * while `src_size` will contain the number of bytes consumed from
+         * buf.base */
+        ret = LZ4F_decompress(ctx, (char*)decompressed->base + dst_offset, &dst_size,
+                              (char*)buf.base + src_offset, &src_size, NULL);
+        if (LZ4F_isError(ret)) {
+            ErrMsgPrintf(errmsg, "LZ4F_decompress %s", LZ4F_getErrorName(ret));
+            rv = RAFT_IOERR;
+            goto err_after_buff_alloc;
+        }
+        src_offset += src_size;
+        dst_offset += dst_size;
+    }
+
+    if (LZ4F_freeDecompressionContext(ctx) != 0) {
+        rv = RAFT_IOERR;
+        goto err_after_buff_alloc;
+    }
+
+    return 0;
+
+err_after_buff_alloc:
+    raft_free(decompressed->base);
+    decompressed->base = NULL;
+err_after_ctx_alloc:
+    LZ4F_freeDecompressionContext(ctx);
+err:
+    return rv;
+#endif /* LZ4_AVAILABLE */
+}
+

--- a/src/compress.c
+++ b/src/compress.c
@@ -3,6 +3,7 @@
 #ifdef LZ4_AVAILABLE
 #include <lz4frame.h>
 #endif
+#include <limits.h>
 #include <string.h>
 
 #include "assert.h"
@@ -197,7 +198,11 @@ int Decompress(struct raft_buffer buf, struct raft_buffer *decompressed,
     ret = 1;
     while (ret != 0) {
         src_size = buf.len - src_offset;
-        dst_size = decompressed->len - dst_offset;
+        /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         * The next line works around a bug in an older lz4 lib where the
+         * `size_t` dst_size parameter would overflow an `int`.
+         * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+        dst_size = min(decompressed->len - dst_offset, (size_t)INT_MAX);
         /* `dst_size` will contain the number of bytes written to decompressed->base,
          * while `src_size` will contain the number of bytes consumed from
          * buf.base */

--- a/src/compress.c
+++ b/src/compress.c
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "assert.h"
+#include "byte.h"
 #include "err.h"
 
 #define min(a,b) ((a) < (b) ? (a) : (b))
@@ -228,3 +229,16 @@ err:
 #endif /* LZ4_AVAILABLE */
 }
 
+bool IsCompressed(const void *data, size_t sz)
+{
+    if (data == NULL || sz < 4) {
+        return false;
+    }
+    const void *cursor = data;
+#ifdef LZ4F_MAGICNUMBER
+#define RAFT_LZ4F_MAGICNUMBER LZ4F_MAGICNUMBER
+#else
+#define RAFT_LZ4F_MAGICNUMBER 0x184D2204U
+#endif
+    return byteGet32(&cursor) == RAFT_LZ4F_MAGICNUMBER;
+}

--- a/src/compress.h
+++ b/src/compress.h
@@ -1,0 +1,28 @@
+#ifndef COMPRESS_H_
+#define COMPRESS_H_
+
+#include "../include/raft.h"
+
+#ifdef LZ4F_HEADER_SIZE_MAX
+#define LZ4F_HEADER_SIZE_MAX_RAFT LZ4F_HEADER_SIZE_MAX
+#else
+#define LZ4F_HEADER_SIZE_MAX_RAFT 19UL
+#endif
+
+/*
+ * Compresses the content of `bufs` into a newly allocated buffer that is
+ * returned to the caller through `compressed`. Returns a non-0 value upon
+ * failure.
+ */
+int Compress(struct raft_buffer bufs[], unsigned n_bufs,
+             struct raft_buffer *compressed, char *errmsg);
+
+/*
+ * Decompresses the content of `buf` into a newly allocated buffer that is
+ * returned to the caller through `decompressed`. Returns a non-0 value upon
+ * failure.
+ */
+int Decompress(struct raft_buffer buf, struct raft_buffer *decompressed,
+               char *errmsg);
+
+#endif /* COMPRESS_H_ */

--- a/src/compress.h
+++ b/src/compress.h
@@ -25,4 +25,7 @@ int Compress(struct raft_buffer bufs[], unsigned n_bufs,
 int Decompress(struct raft_buffer buf, struct raft_buffer *decompressed,
                char *errmsg);
 
+/* Returns `true` if `data` is compressed, `false` otherwise. */
+bool IsCompressed(const void *data, size_t sz);
+
 #endif /* COMPRESS_H_ */

--- a/src/uv.c
+++ b/src/uv.c
@@ -727,6 +727,19 @@ void raft_uv_set_block_size(struct raft_io *io, size_t size)
     uv->block_size = size;
 }
 
+int raft_uv_set_snapshot_compression(struct raft_io *io, bool compressed)
+{
+    struct uv *uv;
+    uv = io->impl;
+#ifndef LZ4_AVAILABLE
+    if (compressed) {
+        return RAFT_INVALID;
+    }
+#endif
+    uv->snapshot_compression = compressed;
+    return 0;
+}
+
 void raft_uv_set_connect_retry_delay(struct raft_io *io, unsigned msecs)
 {
     struct uv *uv;

--- a/src/uv.c
+++ b/src/uv.c
@@ -646,6 +646,11 @@ int raft_uv_init(struct raft_io *io,
     uv->errored = false;
     uv->direct_io = false;
     uv->async_io = false;
+#ifdef LZ4_ENABLED
+    uv->snapshot_compression = true;
+#else
+    uv->snapshot_compression = false;
+#endif
     uv->segment_size = UV__MAX_SEGMENT_SIZE;
     uv->block_size = 0;
     QUEUE_INIT(&uv->clients);

--- a/src/uv.h
+++ b/src/uv.h
@@ -61,6 +61,7 @@ struct uv
     struct raft_tracer *tracer;          /* Debug tracing */
     raft_id id;                          /* Server ID */
     int state;                           /* Current state */
+    bool snapshot_compression;           /* If compression is enabled */
     bool errored;                        /* If a disk I/O error was hit */
     bool direct_io;                      /* Whether direct I/O is supported */
     bool async_io;                       /* Whether async I/O is supported */

--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include "assert.h"
+#include "compress.h"
 #include "err.h"
 #include "heap.h"
 #include "uv_os.h"

--- a/test/integration/test_uv_snapshot_put.c
+++ b/test/integration/test_uv_snapshot_put.c
@@ -238,6 +238,18 @@ TEST(snapshot_put, install, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
+/* Request to install a snapshot without compression. */
+TEST(snapshot_put, installNoCompression, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    raft_uv_set_snapshot_compression(&f->io, false);
+    APPEND(4, 8);
+    SNAPSHOT_PUT(0, /* trailing */
+                 1  /* index */
+    );
+    return MUNIT_OK;
+}
+
 /* Request to install a snapshot, no previous entry is present. */
 TEST(snapshot_put, installWithoutPreviousEntries, setUp, tearDown, 0, NULL)
 {

--- a/test/unit/test_compress.c
+++ b/test/unit/test_compress.c
@@ -1,0 +1,217 @@
+#include "../../src/compress.h"
+#include "../lib/munit.h"
+#include "../lib/runner.h"
+
+#include <sys/random.h>
+#ifdef LZ4_AVAILABLE
+#include <lz4frame.h>
+#endif
+
+SUITE(Compress)
+
+struct raft_buffer getBufWithRandom(size_t len)
+{
+    struct raft_buffer buf = {0};
+    buf.len = len;
+    buf.base = munit_malloc(buf.len);
+    munit_assert_ptr_not_null(buf.base);
+
+    size_t offset = 0;
+    /* Write as many random ints in buf as possible */
+    for(size_t n = buf.len / sizeof(int); n > 0; n--) {
+        *((int*)(buf.base) + offset) = rand();
+        offset += 1;
+    }
+
+    /* Fill the remaining bytes */
+    size_t rem = buf.len % sizeof(int);
+    /* Offset will now be used in char* arithmetic */
+    offset *= sizeof(int);
+    if (rem) {
+        int r_int = rand();
+        for (unsigned i = 0; i < rem; i++) {
+            *((char*)buf.base + offset) = *((char*)&r_int + i);
+            offset++;
+        }
+    }
+
+    munit_assert_ulong(offset, ==, buf.len);
+    return buf;
+}
+
+struct raft_buffer getBufWithNonRandom(size_t len)
+{
+    struct raft_buffer buf = {0};
+    buf.len = len;
+    buf.base = munit_malloc(buf.len);
+    munit_assert_ptr_not_null(buf.base);
+
+    memset(buf.base, 0xAC, buf.len);
+    return buf;
+}
+
+#ifdef LZ4_AVAILABLE
+static char* len_one_params[] = {
+/*    16B   1KB     64KB     4MB        128MB */
+      "16", "1024", "65536", "4194304", "134217728",
+/*    Around Blocksize*/
+      "65516", "65517", "65518", "65521", "65535",
+      "65537", "65551", "65555", "65556",
+/*    Ugly lengths */
+      "1", "9", "123450", "1337", "6655111",
+      NULL
+};
+
+static MunitParameterEnum random_one_params[] = {
+    { "len_one", len_one_params },
+    { NULL, NULL },
+};
+
+TEST(Compress, compressDecompressRandomOne, NULL, NULL, 0,
+     random_one_params)
+{
+    char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
+    struct raft_buffer compressed = {0};
+    struct raft_buffer decompressed = {0};
+
+    /* Fill a buffer with random data */
+    size_t len = strtoul(munit_parameters_get(params, "len_one"), NULL, 0);
+    struct raft_buffer buf = getBufWithRandom(len);
+
+    /* Assert that after compression and decompression the data is unchanged */
+    munit_assert_int(Compress(&buf, 1, &compressed, errmsg), ==, 0);
+    munit_assert_int(Decompress(compressed, &decompressed, errmsg), ==, 0);
+    munit_assert_ulong(decompressed.len, ==, len);
+    munit_assert_int(memcmp(decompressed.base, buf.base, buf.len), ==, 0);
+
+    raft_free(compressed.base);
+    raft_free(decompressed.base);
+    free(buf.base);
+    return MUNIT_OK;
+}
+
+static char* len_nonrandom_one_params[] = {
+/*    4KB     64KB     4MB        1GB           3GB */
+      "4096", "65536", "4194304", "1073741824", "3221225472",
+/*    Around Blocksize*/
+      "65516", "65517", "65518", "65521", "65535",
+      "65537", "65551", "65555", "65556",
+/*    Ugly lengths */
+      "993450", "31337", "83883825",
+      NULL
+};
+
+static MunitParameterEnum nonrandom_one_params[] = {
+    { "len_one", len_nonrandom_one_params },
+    { NULL, NULL },
+};
+
+TEST(Compress, compressDecompressNonRandomOne, NULL, NULL, 0,
+     nonrandom_one_params)
+{
+    char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
+    struct raft_buffer compressed = {0};
+    struct raft_buffer decompressed = {0};
+
+    /* Fill a buffer with non-random data */
+    size_t len = strtoul(munit_parameters_get(params, "len_one"), NULL, 0);
+    struct raft_buffer buf = getBufWithNonRandom(len);
+
+    /* Assert that after compression and decompression the data is unchanged and
+     * that the compressed data is actually smaller */
+    munit_assert_int(Compress(&buf, 1, &compressed, errmsg), ==, 0);
+    munit_assert_ulong(compressed.len, <, buf.len);
+    munit_assert_int(Decompress(compressed, &decompressed, errmsg), ==, 0);
+    munit_assert_ulong(decompressed.len, ==, len);
+    munit_assert_int(memcmp(decompressed.base, buf.base, buf.len), ==, 0);
+
+    raft_free(compressed.base);
+    raft_free(decompressed.base);
+    free(buf.base);
+    return MUNIT_OK;
+}
+
+static char* len_two_params[] = {
+      "4194304", "13373", "66",
+      NULL
+};
+
+static MunitParameterEnum random_two_params[] = {
+    { "len_one", len_one_params },
+    { "len_two", len_two_params },
+    { NULL, NULL },
+};
+
+TEST(Compress, compressDecompressRandomTwo, NULL, NULL, 0,
+     random_two_params)
+{
+    char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
+    struct raft_buffer compressed = {0};
+    struct raft_buffer decompressed = {0};
+
+    /* Fill two buffers with random data */
+    size_t len1 = strtoul(munit_parameters_get(params, "len_one"), NULL, 0);
+    struct raft_buffer buf1 = getBufWithRandom(len1);
+    size_t len2 = strtoul(munit_parameters_get(params, "len_two"), NULL, 0);
+    struct raft_buffer buf2 = getBufWithRandom(len2);
+    struct raft_buffer bufs[2] = { buf1, buf2 };
+
+    /* Assert that after compression and decompression the data is unchanged */
+    munit_assert_int(Compress(bufs, 2, &compressed, errmsg), ==, 0);
+    munit_assert_int(Decompress(compressed, &decompressed, errmsg), ==, 0);
+    munit_assert_ulong(decompressed.len, ==, buf1.len + buf2.len);
+    munit_assert_int(memcmp(decompressed.base, buf1.base, buf1.len), ==, 0);
+    munit_assert_int(memcmp((char*)decompressed.base + buf1.len,
+                            buf2.base, buf2.len), ==, 0);
+
+    raft_free(compressed.base);
+    raft_free(decompressed.base);
+    free(buf1.base);
+    free(buf2.base);
+    return MUNIT_OK;
+}
+
+TEST(Compress, compressDecompressCorruption, NULL, NULL, 0, NULL)
+{
+    char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
+    struct raft_buffer compressed = {0};
+    struct raft_buffer decompressed = {0};
+
+    /* Fill a buffer with random data */
+    size_t len = 2048;
+    struct raft_buffer buf = getBufWithRandom(len);
+
+    munit_assert_int(Compress(&buf, 1, &compressed, errmsg), ==, 0);
+
+    /* Corrupt the a data byte after the header */
+    munit_assert_ulong(LZ4F_HEADER_SIZE_MAX_RAFT, <, compressed.len);
+    ((char*)compressed.base)[LZ4F_HEADER_SIZE_MAX_RAFT] += 1;
+
+    munit_assert_int(Decompress(compressed, &decompressed, errmsg), !=, 0);
+    munit_assert_string_equal(errmsg, "LZ4F_decompress ERROR_contentChecksum_invalid");
+    munit_assert_ptr_null(decompressed.base);
+
+    raft_free(compressed.base);
+    free(buf.base);
+    return MUNIT_OK;
+}
+
+#else
+
+TEST(Compress, lz4Disabled, NULL, NULL, 0, NULL)
+{
+    char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
+    struct raft_buffer compressed = {0};
+
+    /* Fill a buffer with random data */
+    size_t len = 2048;
+    struct raft_buffer buf = getBufWithRandom(len);
+
+    munit_assert_int(Compress(&buf, 1, &compressed, errmsg), ==, RAFT_INVALID);
+    munit_assert_ptr_null(compressed.base);
+
+    free(buf.base);
+    return MUNIT_OK;
+}
+
+#endif /* LZ4_AVAILABLE */


### PR DESCRIPTION
This PR introduces snapshot compression with lz4. Next to compressing the snapshot, there's an additional data integrity check when decompressing the compressed snapshot that in practice should allow help to detect storage corruptions. 

Nodes running compression are compatible with nodes running without compression, data over the wire hasn't changed, this should deal with issues where cluster members are only updated one at a time. The compressed snapshot files are regular `lz4` files (without the .lz4 extension though) that can be decompressed with the `lz4` cli tool.

Fixes https://github.com/canonical/raft/issues/198

@stgraber If this is merged it will probably break some `lxd` builds as there will be a new dependency `liblz4-dev`.