### PR TITLE
Bugfix/compress build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,3 +52,68 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         verbose: true
+
+  build-and-test-nolz4:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-18.04
+          - ubuntu-20.04
+        compiler:
+          - gcc
+          - clang
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dependencies
+      run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq lcov linux-libc-dev libuv1-dev btrfs-progs xfsprogs zfsutils-linux
+
+    - name: Build
+      env:
+        CC: ${{ matrix.compiler }}
+      run: |
+          git clone --depth 1 https://github.com/edlund/amalgamate.git
+          export PATH=$PATH:$PWD/amalgamate
+          autoreconf -i
+          ./configure --enable-example --enable-debug --enable-code-coverage --enable-sanitize --disable-lz4
+          amalgamate.py --config=amalgamation.json --source=$(pwd)
+          $CC raft.c -c -D_GNU_SOURCE -DHAVE_LINUX_AIO_ABI_H -Wall -Wextra -Wpedantic -fpic
+
+    - name: Test
+      env:
+        CC: ${{ matrix.compiler }}
+      run: |
+          ./test/lib/fs.sh setup
+          make check CFLAGS=-O0 $(./test/lib/fs.sh detect) || (cat ./test-suite.log && false)
+          ./test/lib/fs.sh teardown
+
+    - name: Coverage
+      env:
+        CC: ${{ matrix.compiler }}
+      run: if [ "${CC}" = "gcc" ]; then make code-coverage-capture; fi
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        verbose: true
+
+  build-nolz4-fail:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dependencies
+      run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq lcov linux-libc-dev libuv1-dev btrfs-progs xfsprogs zfsutils-linux
+
+    # Expect the configure step to fail
+    - name: Build
+      env:
+        CC: gcc
+      run: |
+          autoreconf -i
+          ! ./configure --enable-example --enable-debug --enable-code-coverage --enable-sanitize

--- a/configure.ac
+++ b/configure.ac
@@ -24,12 +24,10 @@ AM_CONDITIONAL(UV_ENABLED, test "x$have_uv" = "xyes")
 AC_ARG_ENABLE(lz4, AS_HELP_STRING([--disable-lz4], [do not use lz4 compression]))
 
 # Thanks to the OpenVPN configure.ac file for this part.
-AS_IF([test "x$enable_lz4" != "xno"],
-      # If this fails, we will do another test next.
-      # We also add set LZ4_LIBS otherwise
-      # linker will not know about the lz4 library
-      [PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4="yes"], [LZ4_LIBS="-llz4"])])
-if test "${have_lz4}" != "yes" -a "${enable_lz4}" != "no"; then
+# If this fails, we will do another test next.
+# We also add set LZ4_LIBS otherwise linker will not know about the lz4 library
+PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4="yes"], [LZ4_LIBS="-llz4"])
+if test "${have_lz4}" != "yes" ; then
     AC_CHECK_HEADERS([lz4.h],
                      [have_lz4h="yes"],
                      [])
@@ -58,10 +56,14 @@ if test "${have_lz4}" != "yes" -a "${enable_lz4}" != "no"; then
     fi
 fi
 
-AS_IF([test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xno"],
+AS_IF([test "x$enable_lz4" != "xno" -a "x$have_lz4" != "xyes"],
       [AC_MSG_ERROR([liblz4 required but not found])], [])
+# LZ4 Can be available without being enabled, this allows a user to activate
+# it at a later stage through an API call.
 AM_CONDITIONAL(LZ4_AVAILABLE, test "x$have_lz4" = "xyes")
-AM_CONDITIONAL(LZ4_ENABLED, test "x$enable_lz4" != "xno")
+# `LZ4_ENABLED` will cause the libuv snapshot implementation to use lz4
+# compression by default.
+AM_CONDITIONAL(LZ4_ENABLED, test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xyes")
 
 # The fake I/O implementation and associated fixture is built by default, unless
 # explicitly disabled.


### PR DESCRIPTION
- Fix build that was not failing when liblz4 was enabled but not found
- Don't define LZ4_ENABLED when liblz4 is not found.
This is an extra precaution, build should have failed in that case.
- Set LZ4_AVAILABLE when liblz4 is found but is disabled. This allows
users to enable lz4 compression later, through the api call.