### PR TITLE
release: v0.11.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([raft], [0.10.1])
+AC_INIT([raft], [0.11.1])
 AC_LANG([C])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([ac])


### PR DESCRIPTION
New release for the snapshot compression changes. Accidentally already made the v0.11.0 tag, so this one becomes v0.11.1.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>