### PR TITLE
uv_segment: Fix double-free errors

### DIFF
--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -521,6 +521,7 @@ static int uvLoadOpenSegment(struct uv *uv,
                 tracef("remove zeroed open segment %s", info->filename);
                 remove = true;
                 HeapFree(buf.base);
+                buf.base = NULL;
                 goto done;
             }
         }
@@ -572,6 +573,7 @@ static int uvLoadOpenSegment(struct uv *uv,
 
     if (n_batches == 0) {
         HeapFree(buf.base);
+        buf.base = NULL;
         remove = true;
     }
 
@@ -616,7 +618,9 @@ err_after_batch_load:
     raft_free(tmp_entries);
 
 err_after_read:
-    HeapFree(buf.base);
+    if (buf.base != NULL) {
+        HeapFree(buf.base);
+    }
 
 err:
     assert(rv != 0);


### PR DESCRIPTION
Fixes https://github.com/canonical/dqlite/issues/301

Path to double-free occurring in LXD CI tests.

https://github.com/canonical/raft/blob/1636e2ec20a8bdf83b50a687ce1b677b2693b5fa/src/uv_segment.c#L523
https://github.com/canonical/raft/blob/1636e2ec20a8bdf83b50a687ce1b677b2693b5fa/src/uv_segment.c#L586
https://github.com/canonical/raft/blob/1636e2ec20a8bdf83b50a687ce1b677b2693b5fa/src/uv_segment.c#L619

The function itself is pretty complex with a lot of `goto`'s , decided not to refactor right now, but could use a refactoring.