### PR TITLE
uv_segment: Initialize buf

### DIFF
--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -481,7 +481,7 @@ static int uvLoadOpenSegment(struct uv *uv,
     uint64_t format;                /* Format version */
     size_t n_batches = 0;           /* Number of loaded batches */
     struct raft_entry *tmp_entries; /* Entries in current batch */
-    struct raft_buffer buf;         /* Segment file content */
+    struct raft_buffer buf = {0};   /* Segment file content */
     size_t offset;                  /* Content read cursor */
     unsigned tmp_n_entries;         /* Number of entries in current batch */
     int i;


### PR DESCRIPTION
Fix coverity issue

*** CID 349299:  Memory - illegal accesses  (UNINIT)
/home/runner/work/raft/raft/src/uv_segment.c: 621 in uvLoadOpenSegment()
615     
616     err_after_batch_load:
617         raft_free(tmp_entries[0].batch);
618         raft_free(tmp_entries);
619     
620     err_after_read:
>>>     CID 349299:  Memory - illegal accesses  (UNINIT)
>>>     Using uninitialized value "buf.base".
621         if (buf.base != NULL) {
622             HeapFree(buf.base);
623         }
624     
625     err:
626         assert(rv != 0);