### PR TITLE
uv: Set start_index correctly when no closed segments present

### DIFF
--- a/src/uv.c
+++ b/src/uv.c
@@ -391,7 +391,7 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
         }
         if (segments != NULL) {
             if (segments[0].is_open) {
-                *start_index = 1;
+                *start_index = (*snapshot)->index + 1;
             } else {
                 *start_index = segments[0].first_index;
             }

--- a/test/integration/test_uv_load.c
+++ b/test/integration/test_uv_load.c
@@ -850,6 +850,29 @@ TEST(load, openSegmentWithEntriesBehindSnapshot, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
+/* The data directory contains a snapshot and an open segment containing a valid
+ * entry, and no closed segments. */
+TEST(load, openSegmentNoClosedSegmentsSnapshotPresent, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    struct snapshot snapshot = {
+        1, /* term */
+        3, /* index */
+        1  /* data */
+    };
+    SNAPSHOT_PUT(1, 3, 1);
+    APPEND(1, 4);
+    UNFINALIZE(4, 4, 1);
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         &snapshot, /* snapshot */
+         4,         /* start index */
+         4,         /* data for first loaded entry */
+         1          /* n entries */
+    );
+    return MUNIT_OK;
+}
+
 /* The data directory has several closed segments, all with entries compatible
  * with the snapshot. */
 TEST(load, closedSegmentsOverlappingWithSnapshot, setUp, tearDown, 0, NULL)


### PR DESCRIPTION
This issue came up while running the jepsen tests, steps are roughly:
- Node receives snapshot install and deletes all closed segments
preceding the snapshot.
- After installing the snapshot, the node receives AppendEntries and
adds the entries to an open segment.
- Node gets killed.
- Node boots and UvLoad closes the open segment using start_index 1,
ignoring the index of the snapshot that is present in the data dir.
- Node fails to start because the newly closed segment and the snapshot are
inconsistent with a message
`raft_start(): io: last entry on disk has index 383, which is behind
last snapshot's index 3072"`

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>