### PR TITLE
uv_encoding: Free correct entries pointer

### DIFF
--- a/src/uv_encoding.c
+++ b/src/uv_encoding.c
@@ -368,7 +368,8 @@ int uvDecodeBatchHeader(const void *batch,
     return 0;
 
 err_after_alloc:
-    raft_free(entries);
+    raft_free(*entries);
+    *entries = NULL;
 
 err:
     assert(rv != 0);


### PR DESCRIPTION
Fixes https://github.com/canonical/raft/issues/219.

In https://github.com/canonical/raft/blob/4c71b9417072b338d885c484a8cfbc9275df21d6/src/uv_encoding.c#L343 `*entries` is allocated but `entries` gets freed instead of `*entries`.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>