### PR TITLE
Don't send Snapshots to offline nodes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,7 +40,7 @@ jobs:
         CC: ${{ matrix.compiler }}
       run: |
           ./test/lib/fs.sh setup
-          make check CFLAGS=-O0 $(./test/lib/fs.sh detect) || (cat ./test-suite.log && false)
+          make check $(./test/lib/fs.sh detect) || (cat ./test-suite.log && false)
           ./test/lib/fs.sh teardown
 
     - name: Coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ script:
   - amalgamate.py --config=amalgamation.json --source=$(pwd)
   - $CC raft.c -c -D_GNU_SOURCE -DHAVE_LINUX_AIO_ABI_H -Wall -Wextra -Wpedantic -fpic
   - ./test/lib/fs.sh setup
-  - make check CFLAGS=-O0 $(./test/lib/fs.sh detect) || (cat ./test-suite.log && false)
+  - make check $(./test/lib/fs.sh detect) || (cat ./test-suite.log && false)
   - ./test/lib/fs.sh teardown

--- a/src/progress.c
+++ b/src/progress.c
@@ -178,6 +178,11 @@ void progressMarkRecentRecv(struct raft *r, const unsigned i)
     r->leader_state.progress[i].recent_recv = true;
 }
 
+bool progressGetRecentRecv(const struct raft *r, const unsigned i)
+{
+    return r->leader_state.progress[i].recent_recv;
+}
+
 void progressToSnapshot(struct raft *r, unsigned i)
 {
     struct raft_progress *p = &r->leader_state.progress[i];

--- a/src/progress.h
+++ b/src/progress.h
@@ -64,6 +64,9 @@ bool progressResetRecentRecv(struct raft *r, unsigned i);
  * To be called whenever we receive an AppendEntries RPC result */
 void progressMarkRecentRecv(struct raft *r, unsigned i);
 
+/* Return the value of the recent_recv flag. */
+bool progressGetRecentRecv(const struct raft *r, unsigned i);
+
 /* Convert to the i'th server to snapshot mode. */
 void progressToSnapshot(struct raft *r, unsigned i);
 


### PR DESCRIPTION
There are mentions of high CPU load in some dqlite clusters, one of the causes that has been identified is that a raft leader will try to send a snapshot to an offline node every heartbeat interval. When the snapshot is compressed and rather large, this will lead to constant high CPU load on the raft leader because the leader decompresses the snapshot and then sends it over.

This PR addresses this issue by only sending snapshots to nodes that have replied to AppendEntries RPC's, so that the leader knows they are alive.

I have also snuck in another change that speeds up the CI tests by removing the `-O0` flag.

