### PR TITLE
Debugtrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ compressed snapshots offer additional data integrity checks in the form of a
 to detect corruptions that occurred during storage. It is therefore recommended to not disable
 lz4 compression by means of the ```--disable-lz4``` configure flag.
 
+Detailed tracing will be enabled when the environment variable `LIBRAFT_TRACE` is set upon startup.
+
 Notable users
 -------------
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -417,6 +417,11 @@ struct raft_tracer
     void *impl;
 
     /**
+     * Whether this tracer should emit messages.
+     */
+    bool enabled;
+
+    /**
      * Emit the given trace message, possibly decorating it with the provided
      * metadata.
      */

--- a/src/client.c
+++ b/src/client.c
@@ -10,12 +10,7 @@
 #include "request.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 int raft_apply(struct raft *r,
                struct raft_apply *req,
@@ -182,7 +177,7 @@ int raft_add(struct raft *r,
         return rv;
     }
 
-    tracef("add server: id %d, address %s", id, address);
+    tracef("add server: id %llu, address %s", id, address);
 
     /* Make a copy of the current configuration, and add the new server to
      * it. */
@@ -305,7 +300,7 @@ int raft_assign(struct raft *r,
     rv = replicationProgress(r, server_index);
     if (rv != 0 && rv != RAFT_NOCONNECTION) {
         /* This error is not fatal. */
-        tracef("failed to send append entries to server %u: %s (%d)",
+        tracef("failed to send append entries to server %llu: %s (%d)",
                server->id, raft_strerror(rv), rv);
     }
 
@@ -336,7 +331,7 @@ int raft_remove(struct raft *r,
         goto err;
     }
 
-    tracef("remove server: id %d", id);
+    tracef("remove server: id %llu", id);
 
     /* Make a copy of the current configuration, and remove the given server
      * from it. */

--- a/src/client.c
+++ b/src/client.c
@@ -28,6 +28,7 @@ int raft_apply(struct raft *r,
     if (r->state != RAFT_LEADER || r->transfer != NULL) {
         rv = RAFT_NOTLEADER;
         ErrMsgFromCode(r->errmsg, rv);
+        tracef("raft_apply not leader");
         goto err;
     }
 
@@ -221,6 +222,7 @@ int raft_assign(struct raft *r,
     raft_index last_index;
     int rv;
 
+    tracef("raft_assign to id:%llu the role:%d", id, role);
     if (role != RAFT_STANDBY && role != RAFT_VOTER && role != RAFT_SPARE) {
         rv = RAFT_BADROLE;
         ErrMsgFromCode(r->errmsg, rv);
@@ -282,6 +284,7 @@ int raft_assign(struct raft *r,
 
         rv = clientChangeConfiguration(r, req, &r->configuration);
         if (rv != 0) {
+            tracef("clientChangeConfiguration failed %d", rv);
             r->configuration.servers[server_index].role = old_role;
             return rv;
         }
@@ -398,7 +401,9 @@ int raft_transfer(struct raft *r,
     unsigned i;
     int rv;
 
+    tracef("transfer to %llu", id);
     if (r->state != RAFT_LEADER || r->transfer != NULL) {
+        tracef("transfer error - state:%d", r->state);
         rv = RAFT_NOTLEADER;
         ErrMsgFromCode(r->errmsg, rv);
         goto err;

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -2,9 +2,11 @@
 
 #include "assert.h"
 #include "byte.h"
+#include "tracing.h"
 
 /* Current encoding format version. */
 #define ENCODING_FORMAT 1
+
 
 void configurationInit(struct raft_configuration *c)
 {
@@ -329,3 +331,22 @@ int configurationDecode(const struct raft_buffer *buf,
 
     return 0;
 }
+
+#define tracef(...) Tracef(r->tracer, __VA_ARGS__)
+void configurationTrace(const struct raft *r, struct raft_configuration *c, const char *msg)
+{
+    if (!r->tracer->enabled || r == NULL || c == NULL) {
+        return;
+    }
+
+    tracef("%s", msg);
+    tracef("=== CONFIG START ===");
+    unsigned i;
+    struct raft_server *s;
+    for (i = 0; i < c->n; i++) {
+        s = &c->servers[i];
+        tracef("id:%llu address:%s role:%d", s->id, s->address, s->role);
+    }
+    tracef("=== CONFIG END ===");
+}
+#undef tracef

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -61,4 +61,6 @@ int configurationEncode(const struct raft_configuration *c,
 int configurationDecode(const struct raft_buffer *buf,
                         struct raft_configuration *c);
 
+/* Output the configuration to the raft tracer */
+void configurationTrace(const struct raft *r, struct raft_configuration *c, const char *msg);
 #endif /* CONFIGURATION_H_ */

--- a/src/convert.c
+++ b/src/convert.c
@@ -19,6 +19,7 @@ static void convertSetState(struct raft *r, unsigned short new_state)
     /* Check that the transition is legal, see Figure 3.3. Note that with
      * respect to the paper we have an additional "unavailable" state, which is
      * the initial or final state. */
+    tracef("old_state:%u new_state:%u", r->state, new_state);
     assert((r->state == RAFT_UNAVAILABLE && new_state == RAFT_FOLLOWER) ||
            (r->state == RAFT_FOLLOWER && new_state == RAFT_CANDIDATE) ||
            (r->state == RAFT_CANDIDATE && new_state == RAFT_FOLLOWER) ||
@@ -33,6 +34,7 @@ static void convertSetState(struct raft *r, unsigned short new_state)
 /* Clear follower state. */
 static void convertClearFollower(struct raft *r)
 {
+    tracef("clear follower state");
     r->follower_state.current_leader.id = 0;
     if (r->follower_state.current_leader.address != NULL) {
         raft_free(r->follower_state.current_leader.address);
@@ -43,6 +45,7 @@ static void convertClearFollower(struct raft *r)
 /* Clear candidate state. */
 static void convertClearCandidate(struct raft *r)
 {
+    tracef("clear candidate state");
     if (r->candidate_state.votes != NULL) {
         raft_free(r->candidate_state.votes);
         r->candidate_state.votes = NULL;
@@ -73,6 +76,7 @@ static void convertFailChange(struct raft_change *req)
 /* Clear leader state. */
 static void convertClearLeader(struct raft *r)
 {
+    tracef("clear leader state");
     if (r->leader_state.progress != NULL) {
         raft_free(r->leader_state.progress);
         r->leader_state.progress = NULL;

--- a/src/convert.c
+++ b/src/convert.c
@@ -8,13 +8,9 @@
 #include "progress.h"
 #include "queue.h"
 #include "request.h"
+#include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 /* Convenience for setting a new state value and asserting that the transition
  * is valid. */

--- a/src/election.c
+++ b/src/election.c
@@ -6,12 +6,7 @@
 #include "log.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 /* Common fields between follower and candidate state.
  *

--- a/src/election.c
+++ b/src/election.c
@@ -126,6 +126,7 @@ int electionStart(struct raft *r)
         /* Reset vote */
         rv = r->io->set_vote(r->io, 0);
         if (rv != 0) {
+            tracef("set_vote failed %d", rv);
             goto err;
         }
         /* Update our cache too. */
@@ -135,12 +136,14 @@ int electionStart(struct raft *r)
         term = r->current_term + 1;
         rv = r->io->set_term(r->io, term);
         if (rv != 0) {
+            tracef("set_term failed %d", rv);
             goto err;
         }
 
         /* Vote for self */
         rv = r->io->set_vote(r->io, r->id);
         if (rv != 0) {
+            tracef("set_vote self failed %d", rv);
             goto err;
         }
 
@@ -259,6 +262,7 @@ grant_vote:
     if (!args->pre_vote) {
         rv = r->io->set_vote(r->io, args->candidate_id);
         if (rv != 0) {
+            tracef("set_vote failed %d", rv);
             return rv;
         }
         r->voted_for = args->candidate_id;
@@ -267,6 +271,7 @@ grant_vote:
         r->election_timer_start = r->io->time(r->io);
     }
 
+    tracef("vote granted to %llu", args->candidate_id);
     *granted = true;
 
     return 0;

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -13,12 +13,7 @@
 #include "snapshot.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 /* Defaults */
 #define HEARTBEAT_TIMEOUT 100

--- a/src/progress.c
+++ b/src/progress.c
@@ -5,12 +5,7 @@
 #include "log.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 #ifndef max
 #define max(a, b) ((a) < (b) ? (b) : (a))

--- a/src/progress.c
+++ b/src/progress.c
@@ -121,6 +121,7 @@ bool progressShouldReplicate(struct raft *r, unsigned i)
         case PROGRESS__SNAPSHOT:
             /* Snapshot timed out, move to PROBE */
             if (now - p->snapshot_last_send >= r->install_snapshot_timeout) {
+                tracef("snapshot timed out for index:%u", i);
                 result = true;
                 progressAbortSnapshot(r, i);
             } else {

--- a/src/raft.c
+++ b/src/raft.c
@@ -35,7 +35,10 @@ int raft_init(struct raft *r,
     r->io = io;
     r->io->data = r;
     r->fsm = fsm;
-    r->tracer = &NoopTracer;
+
+    r->tracer = &StderrTracer;
+    raft_tracer_maybe_enable(r->tracer, true);
+
     r->id = id;
     /* Make a copy of the address */
     r->address = HeapMalloc(strlen(address) + 1);

--- a/src/recv.c
+++ b/src/recv.c
@@ -73,8 +73,7 @@ static int recvMessage(struct raft *r, struct raft_message *message)
     };
 
     if (rv != 0 && rv != RAFT_NOCONNECTION) {
-        /* tracef("recv: %s: %s", message_descs[message->type - 1],
-                 raft_strerror(rv)); */
+        tracef("recv: %d: %s", message->type, raft_strerror(rv));
         return rv;
     }
 
@@ -166,6 +165,7 @@ int recvEnsureMatchingTerms(struct raft *r, raft_term term, int *match)
     recvCheckMatchingTerms(r, term, match);
 
     if (*match == -1) {
+        tracef("old term - current_term:%llu other_term:%llu", r->current_term, term);
         return 0;
     }
 
@@ -186,6 +186,7 @@ int recvEnsureMatchingTerms(struct raft *r, raft_term term, int *match)
     if (*match == 1) {
         rv = recvBumpCurrentTerm(r, term);
         if (rv != 0) {
+            tracef("recvBumpCurrentTerm failed %d", rv);
             return rv;
         }
     }

--- a/src/recv.c
+++ b/src/recv.c
@@ -15,12 +15,7 @@
 #include "string.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 /* Dispatch a single RPC message to the appropriate handler. */
 static int recvMessage(struct raft *r, struct raft_message *message)

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -33,6 +33,8 @@ int recvAppendEntries(struct raft *r,
     assert(id > 0);
     assert(args != NULL);
     assert(address != NULL);
+    tracef("self:%llu from:%llu@%s leader_commit:%llu n_entries:%d prev_log_index:%llu prev_log_term:%llu, term:%llu",
+            r->id, id, address, args->leader_commit, args->n_entries, args->prev_log_index, args->prev_log_term, args->term);
 
     result->rejected = args->prev_log_index;
     result->last_log_index = logLastIndex(&r->log);

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -9,12 +9,7 @@
 #include "replication.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 static void recvSendAppendEntriesResultCb(struct raft_io_send *req, int status)
 {

--- a/src/recv_append_entries_result.c
+++ b/src/recv_append_entries_result.c
@@ -21,6 +21,9 @@ int recvAppendEntriesResult(struct raft *r,
     assert(address != NULL);
     assert(result != NULL);
 
+    tracef("self:%llu from:%llu@%s last_log_index:%llu rejected:%llu term:%llu",
+            r->id, id, address, result->last_log_index, result->rejected, result->term);
+
     if (r->state != RAFT_LEADER) {
         tracef("local server is not leader -> ignore");
         return 0;

--- a/src/recv_append_entries_result.c
+++ b/src/recv_append_entries_result.c
@@ -5,12 +5,7 @@
 #include "recv.h"
 #include "replication.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 int recvAppendEntriesResult(struct raft *r,
                             const raft_id id,

--- a/src/recv_install_snapshot.c
+++ b/src/recv_install_snapshot.c
@@ -28,6 +28,8 @@ int recvInstallSnapshot(struct raft *r,
     bool async;
 
     assert(address != NULL);
+    tracef("self:%llu from:%llu@%s conf_index:%llu last_index:%llu last_term:%llu term:%llu",
+            r->id, id, address, args->conf_index, args->last_index, args->last_term, args->term);
 
     result->rejected = args->last_index;
     result->last_log_index = logLastIndex(&r->log);
@@ -59,6 +61,7 @@ int recvInstallSnapshot(struct raft *r,
 
     rv = replicationInstallSnapshot(r, args, &result->rejected, &async);
     if (rv != 0) {
+        tracef("replicationInstallSnapshot failed %d", rv);
         return rv;
     }
 

--- a/src/recv_install_snapshot.c
+++ b/src/recv_install_snapshot.c
@@ -7,12 +7,7 @@
 #include "replication.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 static void installSnapshotSendCb(struct raft_io_send *req, int status)
 {

--- a/src/recv_request_vote.c
+++ b/src/recv_request_vote.c
@@ -29,6 +29,10 @@ int recvRequestVote(struct raft *r,
     assert(id > 0);
     assert(args != NULL);
 
+    tracef("self:%llu from:%llu@%s candidate_id:%llu disrupt_leader:%d last_log_index:%llu"
+           "last_log_term:%llu pre_vote:%d term:%llu",
+           r->id, id, address, args->candidate_id, args->disrupt_leader, args->last_log_index,
+           args->last_log_term, args->pre_vote, args->term);
     result->vote_granted = false;
 
     /* Reject the request if we have a leader.
@@ -84,6 +88,7 @@ int recvRequestVote(struct raft *r,
      * same as the request term (otherwise we would have rejected the request or
      * bumped our term). */
     if (!args->pre_vote) {
+        tracef("no pre_vote: current_term:%llu term:%llu", r->current_term, args->term);
         assert(r->current_term == args->term);
     }
 

--- a/src/recv_request_vote.c
+++ b/src/recv_request_vote.c
@@ -5,12 +5,7 @@
 #include "recv.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 static void requestVoteSendCb(struct raft_io_send *req, int status)
 {

--- a/src/recv_request_vote_result.c
+++ b/src/recv_request_vote_result.c
@@ -8,12 +8,7 @@
 #include "replication.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 int recvRequestVoteResult(struct raft *r,
                           raft_id id,

--- a/src/recv_request_vote_result.c
+++ b/src/recv_request_vote_result.c
@@ -24,6 +24,7 @@ int recvRequestVoteResult(struct raft *r,
     assert(r != NULL);
     assert(id > 0);
 
+    tracef("self:%llu from:%llu@%s term:%llu vote_granted:%d", r->id, id, address, result->term, result->vote_granted);
     votes_index = configurationIndexOfVoter(&r->configuration, id);
     if (votes_index == r->configuration.n) {
         tracef("non-voting or unknown server -> reject");

--- a/src/recv_timeout_now.c
+++ b/src/recv_timeout_now.c
@@ -7,12 +7,7 @@
 #include "recv.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 int recvTimeoutNow(struct raft *r,
                    const raft_id id,

--- a/src/recv_timeout_now.c
+++ b/src/recv_timeout_now.c
@@ -26,9 +26,11 @@ int recvTimeoutNow(struct raft *r,
 
     (void)address;
 
+    tracef("self:%llu from:%llu@%s last_log_index:%llu last_log_term:%llu term:%llu", r->id, id, address, args->last_log_index, args->last_log_term, args->term);
     /* Ignore the request if we are not voters. */
     local_server = configurationGet(&r->configuration, r->id);
     if (local_server == NULL || local_server->role != RAFT_VOTER) {
+        tracef("non-voter");
         return 0;
     }
 
@@ -36,6 +38,7 @@ int recvTimeoutNow(struct raft *r,
      * leader. */
     if (r->state != RAFT_FOLLOWER ||
         r->follower_state.current_leader.id != id) {
+        tracef("Ignore - r->state:%d current_leader.id:%llu", r->state, r->follower_state.current_leader.id);
         return 0;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -18,12 +18,7 @@
 #include "snapshot.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 #ifndef max
 #define max(a, b) ((a) < (b) ? (b) : (a))
@@ -54,7 +49,7 @@ static void sendAppendEntriesCb(struct raft_io_send *send, const int status)
 
     if (r->state == RAFT_LEADER && i < r->configuration.n) {
         if (status != 0) {
-            tracef("failed to send append entries to server %u: %s",
+            tracef("failed to send append entries to server %llu: %s",
                    req->server_id, raft_strerror(status));
             /* Go back to probe mode. */
             progressToProbe(r, i);
@@ -100,7 +95,7 @@ static int sendAppendEntries(struct raft *r,
      */
     args->leader_commit = r->commit_index;
 
-    tracef("send %u entries starting at %llu to server %u (last index %llu)",
+    tracef("send %u entries starting at %llu to server %llu (last index %llu)",
            args->n_entries, args->prev_log_index, server->id,
            logLastIndex(&r->log));
 
@@ -227,7 +222,7 @@ static void sendSnapshotGetCb(struct raft_io_snapshot_get *get,
     req->snapshot = snapshot;
     req->send.data = req;
 
-    tracef("sending snapshot with last index %llu to %u", snapshot->index,
+    tracef("sending snapshot with last index %llu to %llu", snapshot->index,
            server->id);
 
     rv = r->io->send(r->io, &req->send, &message, sendInstallSnapshotCb);
@@ -388,7 +383,7 @@ static int triggerAll(struct raft *r)
         rv = replicationProgress(r, i);
         if (rv != 0 && rv != RAFT_NOCONNECTION) {
             /* This is not a critical failure, let's just log it. */
-            tracef("failed to send append entries to server %u: %s (%d)",
+            tracef("failed to send append entries to server %llu: %s (%d)",
                    server->id, raft_strerror(rv), rv);
         }
     }
@@ -693,7 +688,7 @@ int replicationUpdate(struct raft *r,
                                        result->last_log_index);
         if (retry) {
             /* Retry, ignoring errors. */
-            tracef("log mismatch -> send old entries to %u", server->id);
+            tracef("log mismatch -> send old entries to %llu", server->id);
             replicationProgress(r, i);
         }
         return 0;

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -9,12 +9,7 @@
 #include "log.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 void snapshotClose(struct raft_snapshot *s)
 {

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -43,6 +43,7 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
     configurationClose(&r->configuration);
     r->configuration = snapshot->configuration;
     r->configuration_index = snapshot->configuration_index;
+    configurationTrace(r, &r->configuration, "configuration restore from snapshot");
 
     r->commit_index = snapshot->index;
     r->last_applied = snapshot->index;

--- a/src/start.c
+++ b/src/start.c
@@ -10,12 +10,7 @@
 #include "tick.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 /* Restore the most recent configuration. */
 static int restoreMostRecentConfiguration(struct raft *r,

--- a/src/start.c
+++ b/src/start.c
@@ -65,7 +65,7 @@ static int restoreEntries(struct raft *r,
                           size_t n)
 {
     struct raft_entry *conf = NULL;
-    raft_index conf_index;
+    raft_index conf_index = 0;
     size_t i;
     int rv;
     logStart(&r->log, snapshot_index, snapshot_term, start_index);

--- a/src/start.c
+++ b/src/start.c
@@ -25,6 +25,7 @@ static int restoreMostRecentConfiguration(struct raft *r,
         raft_configuration_close(&configuration);
         return rv;
     }
+    configurationTrace(r, &configuration, "restore most recent configuration");
     raft_configuration_close(&r->configuration);
     r->configuration = configuration;
     r->configuration_index = index;
@@ -147,6 +148,8 @@ int raft_start(struct raft *r)
         return rv;
     }
     assert(start_index >= 1);
+    tracef("current_term:%llu voted_for:%llu start_index:%llu n_entries:%lu",
+           r->current_term, r->voted_for, start_index, n_entries);
 
     /* If we have a snapshot, let's restore it. */
     if (snapshot != NULL) {
@@ -188,6 +191,7 @@ int raft_start(struct raft *r)
      * received. */
     rv = r->io->start(r->io, r->heartbeat_timeout, tickCb, recvCb);
     if (rv != 0) {
+        tracef("io start failed %d", rv);
         return rv;
     }
 

--- a/src/tick.c
+++ b/src/tick.c
@@ -166,6 +166,7 @@ static int tickLeader(struct raft *r)
         /* Abort the promotion if we are at the 10'th round and it's still
          * taking too long, or if the server is unresponsive. */
         if (is_too_slow || is_unresponsive) {
+            tracef("server_index:%d is_too_slow:%d is_unresponsive:%d", server_index, is_too_slow, is_unresponsive);
             struct raft_change *change;
 
             r->leader_state.promotee_id = 0;

--- a/src/tick.c
+++ b/src/tick.c
@@ -8,12 +8,7 @@
 #include "replication.h"
 #include "tracing.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 /* Apply time-dependent rules for followers (Figure 3.1). */
 static int tickFollower(struct raft *r)

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -1,6 +1,7 @@
+#include <stdlib.h>
+
 #include "tracing.h"
 
-/* No-op trace emit function. */
 static inline void noopTracerEmit(struct raft_tracer *t,
                                   const char *file,
                                   int line,
@@ -11,6 +12,22 @@ static inline void noopTracerEmit(struct raft_tracer *t,
     (void)line;
     (void)message;
 }
+struct raft_tracer NoopTracer = {.impl = NULL, .enabled = false, .emit = noopTracerEmit};
 
-/* Default no-op tracer. */
-struct raft_tracer NoopTracer = {.impl = NULL, .emit = noopTracerEmit};
+
+static inline void stderrTracerEmit(struct raft_tracer *t,
+                                    const char *file,
+                                    int line,
+                                    const char *message)
+{
+    (void)t;
+    fprintf(stderr, "LIBRAFT %s:%d %s\n", file, line, message);
+}
+struct raft_tracer StderrTracer = {.impl = NULL, .enabled = false, .emit = stderrTracerEmit};
+
+void raft_tracer_maybe_enable(struct raft_tracer *tracer, bool enabled)
+{
+    if (getenv(LIBRAFT_TRACE) != NULL) {
+        tracer->enabled = enabled;
+    }
+}

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -3,17 +3,27 @@
 #ifndef TRACING_H_
 #define TRACING_H_
 
+/* If an env var with this name is found, tracing can be enabled */
+#define LIBRAFT_TRACE "LIBRAFT_TRACE"
+
 #include "../include/raft.h"
 
-/* Default no-op tracer. */
 extern struct raft_tracer NoopTracer;
 
+/* Default stderr tracer. */
+extern struct raft_tracer StderrTracer;
+
 /* Emit a debug message with the given tracer. */
-#define Tracef(TRACER, ...)                             \
-    do {                                                \
-        char _msg[1024];                                \
-        snprintf(_msg, sizeof _msg, __VA_ARGS__);       \
-        TRACER->emit(TRACER, __FILE__, __LINE__, _msg); \
+#define Tracef(TRACER, ...)                                              \
+    do {                                                                 \
+        if (TRACER != NULL && TRACER->emit != NULL && TRACER->enabled) { \
+            static char _msg[1024];                                      \
+            snprintf(_msg, sizeof _msg, __VA_ARGS__);                    \
+            TRACER->emit(TRACER, __FILE__, __LINE__, _msg);              \
+        }                                                                \
     } while (0)
+
+/* Enable the tracer if the env variable is set or disable the tracer */
+void raft_tracer_maybe_enable(struct raft_tracer *tracer, bool enabled);
 
 #endif /* TRACING_H_ */

--- a/src/uv.c
+++ b/src/uv.c
@@ -19,12 +19,7 @@
 #include "uv_encoding.h"
 #include "uv_os.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
-#define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
+#define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
 
 /* Retry to connect to peer servers every second.
  *

--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -4,11 +4,7 @@
 #include "uv.h"
 #include "uv_os.h"
 
-#if 0
-#define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
+#define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
 
 /* Metadata about an open segment not used anymore and that should be closed or
  * remove (if not written at all). */

--- a/src/uv_list.c
+++ b/src/uv_list.c
@@ -3,11 +3,7 @@
 #include "assert.h"
 #include "uv.h"
 
-#if 0
 #define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 static const char *uvListIgnored[] = {".", "..", "metadata1", "metadata2",
                                       NULL};

--- a/src/uv_prepare.c
+++ b/src/uv_prepare.c
@@ -6,11 +6,7 @@
 #include "uv.h"
 #include "uv_os.h"
 
-#if 0
-#define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
+#define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
 
 /* The happy path for UvPrepare is:
  *

--- a/src/uv_recv.c
+++ b/src/uv_recv.c
@@ -9,11 +9,7 @@
 #include "uv.h"
 #include "uv_encoding.h"
 
-#if 0
-#define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
+#define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
 
 /* The happy path for a receiving an RPC message is:
  *

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -13,11 +13,7 @@
 #include "uv.h"
 #include "uv_encoding.h"
 
-#if 0
-#define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
+#define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
 
 /* Check if the given filename matches the one of a closed segment (xxx-yyy), or
  * of an open segment (open-xxx), and fill the given info structure if so.

--- a/src/uv_send.c
+++ b/src/uv_send.c
@@ -6,12 +6,7 @@
 #include "uv.h"
 #include "uv_encoding.h"
 
-/* Set to 1 to enable tracing. */
-#if 0
 #define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
 
 /* The happy path for an raft_io_send request is:
  *
@@ -239,7 +234,7 @@ static void uvClientSendPending(struct uvClient *c)
 {
     int rv;
     assert(c->stream != NULL);
-    tracef(c, "send pending messages");
+    tracef("send pending messages");
     while (!QUEUE_IS_EMPTY(&c->pending)) {
         queue *head;
         struct uvSend *send;

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -12,11 +12,7 @@
 #include "uv_encoding.h"
 #include "uv_os.h"
 
-#if 0
-#define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
+#define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
 
 /* Arbitrary maximum configuration size. Should be practically be enough */
 #define UV__META_MAX_CONFIGURATION_SIZE 1024 * 1024
@@ -602,7 +598,6 @@ static void uvSnapshotPutBarrierCb(struct UvBarrier *barrier)
 {
     struct uvSnapshotPut *put = barrier->data;
     if (put == NULL) {
-        tracef("uvSnapshotPutBarrierCb already fired, wait for UvUnblock\n");
         return;
     }
 

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -330,6 +330,7 @@ static int uvSnapshotLoadData(struct uv *uv,
         struct raft_buffer decompressed = {0};
         rv = Decompress(buf, &decompressed, errmsg);
         if (rv != 0) {
+            tracef("decompress failed rv:%d", rv);
             goto err_after_read_file;
         }
         HeapFree(buf.base);
@@ -504,6 +505,7 @@ static void uvSnapshotPutWorkCb(uv_work_t *work)
 
     rv = UvFsMakeFile(uv->dir, metadata, put->meta.bufs, 2, put->errmsg);
     if (rv != 0) {
+        tracef("snapshot.meta creation failed %d", rv);
         ErrMsgWrapf(put->errmsg, "write %s", metadata);
         put->status = RAFT_IOERR;
         return;
@@ -521,6 +523,7 @@ static void uvSnapshotPutWorkCb(uv_work_t *work)
     }
 
     if (rv != 0) {
+        tracef("snapshot creation failed %d", rv);
         ErrMsgWrapf(put->errmsg, "write %s", snapshot);
         UvFsRemoveFile(uv->dir, metadata, errmsg);
         UvFsRemoveFile(uv->dir, snapshot, errmsg);

--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -7,11 +7,7 @@
 #include "uv.h"
 #include "uv_encoding.h"
 
-#if 0
-#define tracef(...) Tracef(c->uv->tracer, __VA_ARGS__)
-#else
-#define tracef(...)
-#endif
+#define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
 
 /* Track a truncate request. */
 struct uvTruncate


### PR DESCRIPTION
First stab at adding tracing to raft when `LIBRAFT_TRACE` is set on startup. Will probably have to refine the messages a bit and also wire up the libuv tracing, but having these messages would already be helpful when debugging some cases.