### PR TITLE
Remove leader

### DIFF
--- a/src/fixture.c
+++ b/src/fixture.c
@@ -925,6 +925,7 @@ static int serverInit(struct raft_fixture *f, unsigned i, struct raft_fsm *fsm)
     s->tracer.impl = (void *)&s->id;
     s->tracer.emit = emit;
     s->raft.tracer = &s->tracer;
+    raft_tracer_maybe_enable(&s->tracer, true);
     return 0;
 }
 

--- a/src/membership.c
+++ b/src/membership.c
@@ -13,10 +13,18 @@
 int membershipCanChangeConfiguration(struct raft *r)
 {
     int rv;
+    const struct raft_server *server;
 
     if (r->state != RAFT_LEADER || r->transfer != NULL) {
         tracef("NOT LEADER");
         rv = RAFT_NOTLEADER;
+        goto err;
+    }
+
+    server = configurationGet(&r->configuration, r->id);
+    if (server == NULL) {
+        tracef("leader no longer part of configuration");
+        rv = RAFT_CANTCHANGE;
         goto err;
     }
 

--- a/src/state.c
+++ b/src/state.c
@@ -11,6 +11,8 @@ int raft_state(struct raft *r)
 
 void raft_leader(struct raft *r, raft_id *id, const char **address)
 {
+    const struct raft_server *server;
+
     switch (r->state) {
         case RAFT_UNAVAILABLE:
         case RAFT_CANDIDATE:
@@ -23,6 +25,13 @@ void raft_leader(struct raft *r, raft_id *id, const char **address)
             return;
         case RAFT_LEADER:
             if (r->transfer != NULL) {
+                *id = 0;
+                *address = NULL;
+                return;
+            }
+            server = configurationGet(&r->configuration, r->id);
+            /* Leader no longer part of configuration */
+            if (server == NULL) {
                 *id = 0;
                 *address = NULL;
                 return;

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -200,9 +200,7 @@ TEST(raft_remove, self, setup, tear_down, 0, NULL)
     struct fixture *f = data;
     REMOVE(0, 1, 0);
     CLUSTER_STEP_UNTIL_APPLIED(0, 2, 2000);
-    /* TODO: the second server does not get notified */
-    return MUNIT_SKIP;
-    // CLUSTER_STEP_UNTIL_APPLIED(1, 2, 2000);
+    CLUSTER_STEP_UNTIL_APPLIED(1, 2, 10000);
     return MUNIT_OK;
 }
 


### PR DESCRIPTION
Fixes https://github.com/canonical/dqlite/issues/324

This was the trace, a `raft_barrier` came in after the leader with id 1 was removed from the configuration.
I think a leader shouldn't be allowed to handle requests anymore once it's removed from the configuration @freeekanayaka what do you think?
  
```
LIBRAFT src/client.c:337 remove server: id 1
LIBRAFT src/replication.c:98 send 1 entries starting at 31 to server 2 (last index 32)
LIBDQLITE 1633012650556145281 gateway__handle:991 gateway handle
LIBDQLITE 1633012650556164550 handle_query_sql:537 handle query sql
LIBDQLITE 1633012650556353278 leader__barrier:473 leader barrier
LIBRAFT src/client.c:87 barrier starting at 33
LIBRAFT src/replication.c:98 send 1 entries starting at 32 to server 2 (last index 33)
LIBRAFT src/replication.c:472 leader: written 1 entries starting at 32: status 0
LIBRAFT src/replication.c:472 leader: written 1 entries starting at 33: status 0
lxd: src/replication.c:516: appendLeaderCb: Assertion `entry->type == RAFT_CHANGE' failed.
```
Another change introduced in this PR is that upon self-election, the newly, self-elected leader of a single voter cluster applies and commits all its stored log entries.

I think the PR is an improvement of the current situation, I'm just a bit worried of corner cases where a leader removes itself from the config, somehow can't replicate the config to the other voters, can't accept any commands anymore because it has been removed from the config but keeps sending HeartBeats resulting in the other voters not starting a new election.
I wonder if's not easier/cleaner/safer to just disallow a leader from removing itself from the configuration.
