### PR TITLE
Leader removal

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -21,6 +21,8 @@ int raft_apply(struct raft *r,
     raft_index index;
     int rv;
 
+    tracef("raft_apply n %d", n);
+
     assert(r != NULL);
     assert(bufs != NULL);
     assert(n > 0);

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -925,6 +925,7 @@ static int serverInit(struct raft_fixture *f, unsigned i, struct raft_fsm *fsm)
     s->tracer.impl = (void *)&s->id;
     s->tracer.emit = emit;
     s->raft.tracer = &s->tracer;
+    raft_tracer_maybe_enable(&s->tracer, true);
     return 0;
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -496,9 +496,6 @@ static void appendLeaderCb(struct raft_io_append *req, int status)
         goto out;
     }
 
-    /* If Check if we have reached a quorum. */
-    server_index = configurationIndexOf(&r->configuration, r->id);
-
     /* Only update the next index if we are part of the current
      * configuration. The only case where this is not true is when we were
      * asked to remove ourselves from the cluster.
@@ -509,11 +506,9 @@ static void appendLeaderCb(struct raft_io_append *req, int status)
      *   leader can manage a cluster that does not include itself; it
      *   replicates log entries but does not count itself in majorities.
      */
+    server_index = configurationIndexOf(&r->configuration, r->id);
     if (server_index < r->configuration.n) {
         r->leader_state.progress[server_index].match_index = r->last_stored;
-    } else {
-        const struct raft_entry *entry = logGet(&r->log, r->last_stored);
-        assert(entry->type == RAFT_CHANGE);
     }
 
     /* Check if we can commit some new entries. */

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -200,9 +200,7 @@ TEST(raft_remove, self, setup, tear_down, 0, NULL)
     struct fixture *f = data;
     REMOVE(0, 1, 0);
     CLUSTER_STEP_UNTIL_APPLIED(0, 2, 2000);
-    /* TODO: the second server does not get notified */
-    return MUNIT_SKIP;
-    // CLUSTER_STEP_UNTIL_APPLIED(1, 2, 2000);
+    CLUSTER_STEP_UNTIL_APPLIED(1, 2, 10000);
     return MUNIT_OK;
 }
 

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -75,6 +75,23 @@ static void tear_down(void *data)
         munit_assert_int(rv_, ==, RV);                         \
     }
 
+struct result
+{
+    int status;
+    bool done;
+};
+
+/* Submit an apply request. */
+#define APPLY_SUBMIT(I)                                                      \
+    struct raft_buffer _buf;                                                 \
+    struct raft_apply _req;                                                  \
+    struct result _result = {0, false};                                      \
+    int _rv;                                                                 \
+    FsmEncodeSetX(123, &_buf);                                               \
+    _req.data = &_result;                                                    \
+    _rv = raft_apply(CLUSTER_RAFT(I), &_req, &_buf, 1, NULL);                \
+    munit_assert_int(_rv, ==, 0);
+
 /******************************************************************************
  *
  * Assertions
@@ -201,6 +218,64 @@ TEST(raft_remove, self, setup, tear_down, 0, NULL)
     REMOVE(0, 1, 0);
     CLUSTER_STEP_UNTIL_APPLIED(0, 2, 2000);
     CLUSTER_STEP_UNTIL_APPLIED(1, 2, 10000);
+    return MUNIT_OK;
+}
+
+/* A leader gets a request to remove itself from a 3-node cluster */
+TEST(raft_remove, selfThreeNodeClusterReplicate, setup, tear_down, 0, NULL)
+{
+    struct fixture *f = data;
+    /* Add a third node */
+    GROW;
+    ADD(0, 3, 0);
+    CLUSTER_STEP_UNTIL_APPLIED(0, 2, 2000);
+    ASSIGN(0, 3, RAFT_VOTER);
+    CLUSTER_STEP_UNTIL_APPLIED(0, 3, 2000);
+
+    /* Verify node with id 1 is the leader */
+    raft_id leader_id = 0xDEADBEEF;
+    const char *leader_address = NULL;
+    raft_leader(CLUSTER_RAFT(0), &leader_id, &leader_address);
+    munit_assert_ulong(leader_id, ==, 1);
+    munit_assert_ptr_not_null(leader_address);
+
+    /* The leader is requested to remove itself from the configuration */
+    REMOVE(0, 1, 0);
+
+    /* The - removed - leader should still replicate entries.
+     *
+     * Raft dissertation 4.2.2
+     * `First, there will be a period of time (while it is committing Cnew) when
+     * a leader can manage a cluster that does not include itself; it replicates
+     * log entries but does not count itself in majorities.`
+     *
+     * */
+    APPLY_SUBMIT(0)
+
+    /* The removed leader eventually steps down */
+    CLUSTER_STEP_UNTIL_HAS_NO_LEADER(5000);
+    raft_leader(CLUSTER_RAFT(0), &leader_id, &leader_address);
+    munit_assert_ulong(leader_id, ==, 0);
+    munit_assert_ptr_null(leader_address);
+
+    /* Every node should have all entries */
+    CLUSTER_STEP_UNTIL_APPLIED(0, 4, 10000);
+    CLUSTER_STEP_UNTIL_APPLIED(1, 4, 10000);
+    CLUSTER_STEP_UNTIL_APPLIED(2, 4, 10000);
+
+    /* The removed leader eventually steps down */
+    CLUSTER_STEP_UNTIL_HAS_LEADER(5000);
+
+    /* The removed leader doesn't know who the leader is */
+    raft_leader(CLUSTER_RAFT(0), &leader_id, &leader_address);
+    munit_assert_ulong(leader_id, ==, 0);
+    munit_assert_ptr_null(leader_address);
+
+    /* The new configuration has a leader */
+    raft_leader(CLUSTER_RAFT(1), &leader_id, &leader_address);
+    munit_assert_ulong(leader_id, !=, 0);
+    munit_assert_ulong(leader_id, !=, 1);
+    munit_assert_ptr_not_null(leader_address);
     return MUNIT_OK;
 }
 


### PR DESCRIPTION
Fixes https://github.com/canonical/dqlite/issues/324

A `raft_barrier` came in after the leader with id 1 was removed from the configuration, triggering the assertion that the last log entry of a removed leader's log should be a `RAFT_CHANGE` entry.

### Event trace
```
LIBRAFT src/client.c:337 remove server: id 1
LIBRAFT src/replication.c:98 send 1 entries starting at 31 to server 2 (last index 32)
LIBDQLITE 1633012650556145281 gateway__handle:991 gateway handle
LIBDQLITE 1633012650556164550 handle_query_sql:537 handle query sql
LIBDQLITE 1633012650556353278 leader__barrier:473 leader barrier
LIBRAFT src/client.c:87 barrier starting at 33
LIBRAFT src/replication.c:98 send 1 entries starting at 32 to server 2 (last index 33)
LIBRAFT src/replication.c:472 leader: written 1 entries starting at 32: status 0
LIBRAFT src/replication.c:472 leader: written 1 entries starting at 33: status 0
lxd: src/replication.c:516: appendLeaderCb: Assertion `entry->type == RAFT_CHANGE' failed.
```

According to paragraph 4.2.2 of the raft dissertation, a leader that has been removed from the configuration, should still replicate entries, the assert is therefore incorrect.

### Paragraph 4.2.2
> ... First, there will be a period of time (while it is committing Cnew) when a
> leader can manage a cluster that does not include itself; it replicates log entries but does not count
> itself in majorities. ...
  
Another change introduced in this PR is that upon self-election, the newly, self-elected leader of a single voter cluster applies and commits all its stored log entries.

### Future improvements
* Transfer leadership to another voter if a leader is asked to remove itself.
* *or* Fix unimplemented part of paragraph 4.2.2
> Second, a server that is not part of its own latest configuration should still start
> new elections, as it might still be needed until the Cnew entry is committed (as in Figure 4.6). It does
> not count its own vote in elections unless it is part of its latest configuration. 

I believe this is currently not implemented, see https://github.com/canonical/raft/blob/33a5bafdad7a44650d6fe8d507fc0fc07c195aca/src/tick.c#L24