### PR TITLE
replication: Leader step down if non-voter in Cnew

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1380,8 +1380,8 @@ static void applyChange(struct raft *r, const raft_index index)
          *   steps down once the Cnew entry is committed.
          */
         server = configurationGet(&r->configuration, r->id);
-        if (server == NULL) {
-            tracef("leader removed from config");
+        if (server == NULL || server->role != RAFT_VOTER) {
+            tracef("leader removed from config or no longer voter server: %p", (void*)server);
             convertToFollower(r);
         }
 

--- a/test/integration/test_assign.c
+++ b/test/integration/test_assign.c
@@ -432,14 +432,26 @@ TEST(raft_assign, demoteToStandBy, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-/* The leader can be demoted to stand-by and still act as leader, although it
- * won't have any voting right. */
+/* The leader can be demoted to stand-by and will no longer act as leader */
 TEST(raft_assign, demoteLeader, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     ASSIGN_SUBMIT(0, 1, RAFT_STANDBY);
     munit_assert_int(CLUSTER_LEADER, ==, 0);
     ASSIGN_WAIT;
+    CLUSTER_STEP_UNTIL_HAS_LEADER(5000);
+    munit_assert_int(CLUSTER_LEADER, =!, 0);
+    return MUNIT_OK;
+}
+
+/* The leader can be demoted to spare and will no longer act as leader */
+TEST(raft_assign, demoteLeaderToSpare, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    ASSIGN_SUBMIT(0, 1, RAFT_SPARE);
     munit_assert_int(CLUSTER_LEADER, ==, 0);
+    ASSIGN_WAIT;
+    CLUSTER_STEP_UNTIL_HAS_LEADER(5000);
+    munit_assert_int(CLUSTER_LEADER, =!, 0);
     return MUNIT_OK;
 }

--- a/test/integration/test_transfer.c
+++ b/test/integration/test_transfer.c
@@ -185,9 +185,7 @@ TEST(raft_transfer, afterDemotion, setUp, tearDown, 0, NULL)
     rv = raft_assign(raft, &req, raft->id, RAFT_SPARE, NULL);
     munit_assert_int(rv, ==, 0);
     CLUSTER_STEP_UNTIL_APPLIED(0, 4, 1000);
-    TRANSFER(0, 2);
-    CLUSTER_STEP_UNTIL_HAS_LEADER(1000);
-    munit_assert_int(CLUSTER_LEADER, ==, 1);
+    TRANSFER_ERROR(0, 2, RAFT_NOTLEADER, "server is not the leader");
     return MUNIT_OK;
 }
 


### PR DESCRIPTION
A leader that is no longer a voter in a newly committed configuration will step down.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>

closes https://github.com/canonical/raft/issues/234
fixes https://github.com/canonical/dqlite/issues/323