### PR TITLE
Include pre_vote field in RequestVoteResponse

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -72,6 +72,16 @@ struct raft_buffer
 };
 
 /**
+ * A type for storing unknown bools.
+ */
+typedef enum {
+    raft_tribool_unknown,
+    raft_tribool_true,
+    raft_tribool_false,
+} raft_tribool;
+#define TO_RAFT_TRIBOOL(b)  ((b) ? raft_tribool_true : raft_tribool_false)
+
+/**
  * Server role codes.
  */
 
@@ -252,8 +262,9 @@ struct raft_request_vote
  */
 struct raft_request_vote_result
 {
-    raft_term term;    /* Receiver's current term (candidate updates itself). */
-    bool vote_granted; /* True means candidate received vote. */
+    raft_term term;        /* Receiver's current term (candidate updates itself). */
+    bool vote_granted;     /* True means candidate received vote. */
+    raft_tribool pre_vote; /* The response to a pre-vote RequestVote or not. */
 };
 
 /**

--- a/src/recv_request_vote.c
+++ b/src/recv_request_vote.c
@@ -29,11 +29,12 @@ int recvRequestVote(struct raft *r,
     assert(id > 0);
     assert(args != NULL);
 
-    tracef("self:%llu from:%llu@%s candidate_id:%llu disrupt_leader:%d last_log_index:%llu"
+    tracef("self:%llu from:%llu@%s candidate_id:%llu disrupt_leader:%d last_log_index:%llu "
            "last_log_term:%llu pre_vote:%d term:%llu",
            r->id, id, address, args->candidate_id, args->disrupt_leader, args->last_log_index,
            args->last_log_term, args->pre_vote, args->term);
     result->vote_granted = false;
+    result->pre_vote = TO_RAFT_TRIBOOL(args->pre_vote);
 
     /* Reject the request if we have a leader.
      *

--- a/src/recv_request_vote_result.c
+++ b/src/recv_request_vote_result.c
@@ -51,6 +51,12 @@ int recvRequestVoteResult(struct raft *r,
         }
     }
 
+    /* Converted to follower as a result of seeing a higher term. */
+    if (r->state != RAFT_CANDIDATE) {
+        tracef("no longer candidate -> ignore");
+        return 0;
+    }
+
     if (match < 0) {
         /* If the term in the result is older than ours, this is an old message
          * we should ignore, because the node who voted for us would have
@@ -83,9 +89,7 @@ int recvRequestVoteResult(struct raft *r,
             if (result->term > r->current_term + 1) {
                 assert(!result->vote_granted);
                 rv = recvBumpCurrentTerm(r, result->term);
-                if (rv != 0) {
-                    return rv;
-                }
+                return rv;
             }
         }
     } else {

--- a/test/integration/test_uv_recv.c
+++ b/test/integration/test_uv_recv.c
@@ -310,6 +310,7 @@ TEST(recv, requestVoteResult, setUp, tearDown, 0, NULL)
     message.type = RAFT_IO_REQUEST_VOTE_RESULT;
     message.request_vote_result.term = 3;
     message.request_vote_result.vote_granted = true;
+    message.request_vote_result.pre_vote = raft_tribool_false;
     PEER_SEND(&message);
     RECV(&message);
     return MUNIT_OK;


### PR DESCRIPTION
Fixes the rest of https://github.com/canonical/raft/issues/196, where a Candidate could count the vote in a pre-vote RequestVoteResult RPC as a real vote.

Also included a minor fix where we were accessing a `candidate_state` union after converting to `Follower`, this could lead to weird bugs because we could potentially be overwriting the `candidate_state` members by setting fields in `follower_state`.