### PR TITLE
uv_writer: Handle negative rv of UvOsIoGetevents

### DIFF
--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -684,6 +684,11 @@ static int probeAsyncIO(int fd, size_t size, bool *ok, char *errmsg)
     /* Fetch the response: will block until done. */
     n_events = UvOsIoGetevents(ctx, 1, 1, &event, NULL);
     assert(n_events == 1);
+    if (n_events != 1) {
+        /* UNTESTED */
+        UvOsErrMsg(errmsg, "UvOsIoGetevents", n_events);
+        return RAFT_IOERR;
+    }
 
     /* Release the write buffer. */
     raft_aligned_free(size, buf);


### PR DESCRIPTION
`UvOsIoGetevents` can return a negative value or another unexpected value that is not handled when asserts are turned off and could lead to erroneous behavior at runtime.

The error paths are untested, currently there's no good way to test these error paths. I could look into a way to mock some of the functions to return errors so that these (and a lot of other) error paths can be tested. The code after the `fail_requests` label should be safe, compiled and ran it with a different version of `uvWriterPollCb` that introduces an error.