### PR TITLE
Rename Heap*() to RaftHeap*() for Windows compatibility.

### DIFF
--- a/src/election.c
+++ b/src/election.c
@@ -51,7 +51,7 @@ bool electionTimerExpired(struct raft *r)
 static void sendRequestVoteCb(struct raft_io_send *send, int status)
 {
     (void)status;
-    HeapFree(send);
+    RaftHeapFree(send);
 }
 
 /* Send a RequestVote RPC to the given server. */
@@ -81,7 +81,7 @@ static int electionSend(struct raft *r, const struct raft_server *server)
     message.server_id = server->id;
     message.server_address = server->address;
 
-    send = HeapMalloc(sizeof *send);
+    send = RaftHeapMalloc(sizeof *send);
     if (send == NULL) {
         return RAFT_NOMEM;
     }
@@ -90,7 +90,7 @@ static int electionSend(struct raft *r, const struct raft_server *server)
 
     rv = r->io->send(r->io, send, &message, sendRequestVoteCb);
     if (rv != 0) {
-        HeapFree(send);
+        RaftHeapFree(send);
         return rv;
     }
 

--- a/src/heap.c
+++ b/src/heap.c
@@ -52,12 +52,12 @@ static struct raft_heap defaultHeap = {
 
 static struct raft_heap *currentHeap = &defaultHeap;
 
-void *HeapMalloc(size_t size)
+void *RaftHeapMalloc(size_t size)
 {
     return currentHeap->malloc(currentHeap->data, size);
 }
 
-void HeapFree(void *ptr)
+void RaftHeapFree(void *ptr)
 {
     if (ptr == NULL) {
         return;
@@ -65,34 +65,34 @@ void HeapFree(void *ptr)
     currentHeap->free(currentHeap->data, ptr);
 }
 
-void *HeapCalloc(size_t nmemb, size_t size)
+void *RaftHeapCalloc(size_t nmemb, size_t size)
 {
     return currentHeap->calloc(currentHeap->data, nmemb, size);
 }
 
-void *HeapRealloc(void *ptr, size_t size)
+void *RaftHeapRealloc(void *ptr, size_t size)
 {
     return currentHeap->realloc(currentHeap->data, ptr, size);
 }
 
 void *raft_malloc(size_t size)
 {
-    return HeapMalloc(size);
+    return RaftHeapMalloc(size);
 }
 
 void raft_free(void *ptr)
 {
-    HeapFree(ptr);
+    RaftHeapFree(ptr);
 }
 
 void *raft_calloc(size_t nmemb, size_t size)
 {
-    return HeapCalloc(nmemb, size);
+    return RaftHeapCalloc(nmemb, size);
 }
 
 void *raft_realloc(void *ptr, size_t size)
 {
-    return HeapRealloc(ptr, size);
+    return RaftHeapRealloc(ptr, size);
 }
 
 void *raft_aligned_alloc(size_t alignment, size_t size)

--- a/src/heap.h
+++ b/src/heap.h
@@ -5,12 +5,12 @@
 
 #include <stddef.h>
 
-void *HeapMalloc(size_t size);
+void *RaftHeapMalloc(size_t size);
 
-void *HeapCalloc(size_t nmemb, size_t size);
+void *RaftHeapCalloc(size_t nmemb, size_t size);
 
-void *HeapRealloc(void *ptr, size_t size);
+void *RaftHeapRealloc(void *ptr, size_t size);
 
-void HeapFree(void *ptr);
+void RaftHeapFree(void *ptr);
 
 #endif /* HEAP_H_ */

--- a/src/raft.c
+++ b/src/raft.c
@@ -41,7 +41,7 @@ int raft_init(struct raft *r,
 
     r->id = id;
     /* Make a copy of the address */
-    r->address = HeapMalloc(strlen(address) + 1);
+    r->address = RaftHeapMalloc(strlen(address) + 1);
     if (r->address == NULL) {
         rv = RAFT_NOMEM;
         goto err;
@@ -78,7 +78,7 @@ int raft_init(struct raft *r,
     return 0;
 
 err_after_address_alloc:
-    HeapFree(r->address);
+    RaftHeapFree(r->address);
 err:
     assert(rv != 0);
     return rv;

--- a/src/recv.c
+++ b/src/recv.c
@@ -208,9 +208,9 @@ int recvUpdateLeader(struct raft *r, const raft_id id, const char *address)
     }
 
     if (r->follower_state.current_leader.address != NULL) {
-        HeapFree(r->follower_state.current_leader.address);
+        RaftHeapFree(r->follower_state.current_leader.address);
     }
-    r->follower_state.current_leader.address = HeapMalloc(strlen(address) + 1);
+    r->follower_state.current_leader.address = RaftHeapMalloc(strlen(address) + 1);
     if (r->follower_state.current_leader.address == NULL) {
         return RAFT_NOMEM;
     }

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -14,7 +14,7 @@
 static void recvSendAppendEntriesResultCb(struct raft_io_send *req, int status)
 {
     (void)status;
-    HeapFree(req);
+    RaftHeapFree(req);
 }
 
 int recvAppendEntries(struct raft *r,
@@ -143,7 +143,7 @@ reply:
     message.server_id = id;
     message.server_address = address;
 
-    req = HeapMalloc(sizeof *req);
+    req = RaftHeapMalloc(sizeof *req);
     if (req == NULL) {
         return RAFT_NOMEM;
     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -784,7 +784,7 @@ out:
 static void sendAppendEntriesResultCb(struct raft_io_send *req, int status)
 {
     (void)status;
-    HeapFree(req);
+    RaftHeapFree(req);
 }
 
 static void sendAppendEntriesResult(

--- a/src/uv.c
+++ b/src/uv.c
@@ -358,7 +358,7 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
     /* Load the most recent snapshot, if any. */
     if (snapshots != NULL) {
         char snapshot_filename[UV__FILENAME_LEN];
-        *snapshot = HeapMalloc(sizeof **snapshot);
+        *snapshot = RaftHeapMalloc(sizeof **snapshot);
         if (*snapshot == NULL) {
             rv = RAFT_NOMEM;
             goto err;
@@ -366,13 +366,13 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
         rv = UvSnapshotLoad(uv, &snapshots[n_snapshots - 1], *snapshot,
                             uv->io->errmsg);
         if (rv != 0) {
-            HeapFree(*snapshot);
+            RaftHeapFree(*snapshot);
             *snapshot = NULL;
             goto err;
         }
         uvSnapshotFilenameOf(&snapshots[n_snapshots - 1], snapshot_filename);
         tracef("most recent snapshot at %lld", (*snapshot)->index);
-        HeapFree(snapshots);
+        RaftHeapFree(snapshots);
         snapshots = NULL;
 
         /* Update the start index. If there are closed segments on disk let's

--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -83,7 +83,7 @@ static void uvFinalizeAfterWorkCb(uv_work_t *work, int status)
     if (segment->status != 0) {
         uv->errored = true;
     }
-    HeapFree(segment);
+    RaftHeapFree(segment);
 
     /* If we have no more dismissed segments to close, check if there's a
      * barrier to unblock or if we are done closing. */
@@ -102,7 +102,7 @@ static void uvFinalizeAfterWorkCb(uv_work_t *work, int status)
 
     rv = uvFinalizeStart(segment);
     if (rv != 0) {
-        HeapFree(segment);
+        RaftHeapFree(segment);
         uv->errored = true;
     }
 }
@@ -143,7 +143,7 @@ int UvFinalize(struct uv *uv,
         assert(last_index >= first_index);
     }
 
-    segment = HeapMalloc(sizeof *segment);
+    segment = RaftHeapMalloc(sizeof *segment);
     if (segment == NULL) {
         return RAFT_NOMEM;
     }
@@ -163,7 +163,7 @@ int UvFinalize(struct uv *uv,
 
     rv = uvFinalizeStart(segment);
     if (rv != 0) {
-        HeapFree(segment);
+        RaftHeapFree(segment);
         return rv;
     }
 

--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -433,7 +433,7 @@ int UvFsReadFile(const char *dir,
     }
 
     buf->len = (size_t)sb.st_size;
-    buf->base = HeapMalloc(buf->len);
+    buf->base = RaftHeapMalloc(buf->len);
     if (buf->base == NULL) {
         ErrMsgOom(errmsg);
         rv = RAFT_NOMEM;
@@ -450,7 +450,7 @@ int UvFsReadFile(const char *dir,
     return 0;
 
 err_after_buf_alloc:
-    HeapFree(buf->base);
+    RaftHeapFree(buf->base);
 err_after_open:
     UvOsClose(fd);
 err:

--- a/src/uv_prepare.c
+++ b/src/uv_prepare.c
@@ -102,7 +102,7 @@ static void uvPrepareConsume(struct uv *uv, uv_file *fd, uvCounter *counter)
     QUEUE_REMOVE(&segment->queue);
     *fd = segment->fd;
     *counter = segment->counter;
-    HeapFree(segment);
+    RaftHeapFree(segment);
 }
 
 /* Finish the oldest pending prepare request using the next available prepared
@@ -147,7 +147,7 @@ static int uvPrepareStart(struct uv *uv)
     assert(uv->prepare_inflight == NULL);
     assert(uvPrepareCount(uv) < UV__TARGET_POOL_SIZE);
 
-    segment = HeapMalloc(sizeof *segment);
+    segment = RaftHeapMalloc(sizeof *segment);
     if (segment == NULL) {
         rv = RAFT_NOMEM;
         goto err;
@@ -178,7 +178,7 @@ static int uvPrepareStart(struct uv *uv)
     return 0;
 
 err_after_segment_alloc:
-    HeapFree(segment);
+    RaftHeapFree(segment);
 err:
     assert(rv != 0);
     return rv;
@@ -204,7 +204,7 @@ static void uvPrepareAfterWorkCb(uv_work_t *work, int status)
             UvFsRemoveFile(uv->dir, segment->filename, errmsg);
         }
         tracef("canceled creation of %s", segment->filename);
-        HeapFree(segment);
+        RaftHeapFree(segment);
         uvMaybeFireCloseCb(uv);
         return;
     }
@@ -221,7 +221,7 @@ static void uvPrepareAfterWorkCb(uv_work_t *work, int status)
             uvPrepareFinishAllRequests(uv, segment->status);
         }
         uv->errored = true;
-        HeapFree(segment);
+        RaftHeapFree(segment);
         return;
     }
 
@@ -328,7 +328,7 @@ void UvPrepareClose(struct uv *uv)
         segment = QUEUE_DATA(head, struct uvIdleSegment, queue);
         QUEUE_REMOVE(&segment->queue);
         uvPrepareDiscard(uv, segment->fd, segment->counter);
-        HeapFree(segment);
+        RaftHeapFree(segment);
     }
 }
 

--- a/src/uv_recv.c
+++ b/src/uv_recv.c
@@ -63,7 +63,7 @@ static int uvServerInit(struct uvServer *s,
 {
     s->uv = uv;
     s->id = id;
-    s->address = HeapMalloc(strlen(address) + 1);
+    s->address = RaftHeapMalloc(strlen(address) + 1);
     if (s->address == NULL) {
         return RAFT_NOMEM;
     }
@@ -89,10 +89,10 @@ static void uvServerDestroy(struct uvServer *s)
 
     if (s->header.base != NULL) {
         /* This means we were interrupted while reading the header. */
-        HeapFree(s->header.base);
+        RaftHeapFree(s->header.base);
         switch (s->message.type) {
             case RAFT_IO_APPEND_ENTRIES:
-                HeapFree(s->message.append_entries.entries);
+                RaftHeapFree(s->message.append_entries.entries);
                 break;
             case RAFT_IO_INSTALL_SNAPSHOT:
                 configurationClose(&s->message.install_snapshot.conf);
@@ -101,10 +101,10 @@ static void uvServerDestroy(struct uvServer *s)
     }
     if (s->payload.base != NULL) {
         /* This means we were interrupted while reading the payload. */
-        HeapFree(s->payload.base);
+        RaftHeapFree(s->payload.base);
     }
-    HeapFree(s->address);
-    HeapFree(s->stream);
+    RaftHeapFree(s->address);
+    RaftHeapFree(s->stream);
 }
 
 /* Invoked to initialize the read buffer for the next asynchronous read on the
@@ -137,7 +137,7 @@ static void uvServerAllocCb(uv_handle_t *handle,
         if (s->payload.len == 0) {
             assert(s->header.len > 0);
             assert(s->header.base == NULL);
-            s->header.base = HeapMalloc(s->header.len);
+            s->header.base = RaftHeapMalloc(s->header.len);
             if (s->header.base == NULL) {
                 /* Setting all buffer fields to 0 will make read_cb fail with
                  * ENOBUFS. */
@@ -150,7 +150,7 @@ static void uvServerAllocCb(uv_handle_t *handle,
 
         /* If we get here we should be expecting the payload. */
         assert(s->payload.len > 0);
-        s->payload.base = HeapMalloc(s->payload.len);
+        s->payload.base = RaftHeapMalloc(s->payload.len);
         if (s->payload.base == NULL) {
             /* Setting all buffer fields to 0 will make read_cb fail with
              * ENOBUFS. */
@@ -172,7 +172,7 @@ static void uvServerStreamCloseCb(uv_handle_t *handle)
     struct uvServer *s = handle->data;
     struct uv *uv = s->uv;
     uvServerDestroy(s);
-    HeapFree(s);
+    RaftHeapFree(s);
     uvMaybeFireCloseCb(uv);
 }
 
@@ -340,7 +340,7 @@ static int uvAddServer(struct uv *uv,
     int rv;
 
     /* Initialize the new connection */
-    server = HeapMalloc(sizeof *server);
+    server = RaftHeapMalloc(sizeof *server);
     if (server == NULL) {
         rv = RAFT_NOMEM;
         goto err;
@@ -379,7 +379,7 @@ static void uvRecvAcceptCb(struct raft_uv_transport *transport,
     rv = uvAddServer(uv, id, address, stream);
     if (rv != 0) {
         tracef("add server: %s", errCodeToString(rv));
-        uv_close((struct uv_handle_s *)stream, (uv_close_cb)HeapFree);
+        uv_close((struct uv_handle_s *)stream, (uv_close_cb)RaftHeapFree);
     }
 }
 

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -170,7 +170,7 @@ static int uvReadSegmentFile(struct uv *uv,
     }
     if (buf->len < 8) {
         ErrMsgPrintf(uv->io->errmsg, "file has only %zu bytes", buf->len);
-        HeapFree(buf->base);
+        RaftHeapFree(buf->base);
         return RAFT_IOERR;
     }
     *format = byteFlip64(*(uint64_t *)buf->base);
@@ -322,7 +322,7 @@ static int uvLoadEntriesBatch(struct uv *uv,
     return 0;
 
 err_after_header_decode:
-    HeapFree(*entries);
+    RaftHeapFree(*entries);
 err:
     *entries = NULL;
     *n_entries = 0;
@@ -437,11 +437,11 @@ err_after_batch_load:
 
 err_after_extend_entries:
     if (*entries != NULL) {
-        HeapFree(*entries);
+        RaftHeapFree(*entries);
     }
 
 err_after_read:
-    HeapFree(buf.base);
+    RaftHeapFree(buf.base);
 
 err:
     assert(rv != 0);
@@ -519,7 +519,7 @@ static int uvLoadOpenSegment(struct uv *uv,
                  * segment. */
                 tracef("remove zeroed open segment %s", info->filename);
                 remove = true;
-                HeapFree(buf.base);
+                RaftHeapFree(buf.base);
                 buf.base = NULL;
                 goto done;
             }
@@ -571,7 +571,7 @@ static int uvLoadOpenSegment(struct uv *uv,
     }
 
     if (n_batches == 0) {
-        HeapFree(buf.base);
+        RaftHeapFree(buf.base);
         buf.base = NULL;
         remove = true;
     }
@@ -628,7 +628,7 @@ err_after_batch_load:
 
 err_after_read:
     if (buf.base != NULL) {
-        HeapFree(buf.base);
+        RaftHeapFree(buf.base);
     }
 
 err:

--- a/src/uv_send.c
+++ b/src/uv_send.c
@@ -68,12 +68,12 @@ static void uvSendDestroy(struct uvSend *s)
     if (s->bufs != NULL) {
         /* Just release the first buffer. Further buffers are entry or snapshot
          * payloads, which we were passed but we don't own. */
-        HeapFree(s->bufs[0].base);
+        RaftHeapFree(s->bufs[0].base);
 
         /* Release the buffers array. */
-        HeapFree(s->bufs);
+        RaftHeapFree(s->bufs);
     }
-    HeapFree(s);
+    RaftHeapFree(s);
 }
 
 /* Initialize a new client associated with the given server. */
@@ -90,7 +90,7 @@ static int uvClientInit(struct uvClient *c,
     c->old_stream = NULL;   /* Set after closing the current connection */
     c->n_connect_attempt = 0;
     c->id = id;
-    c->address = HeapMalloc(strlen(address) + 1);
+    c->address = RaftHeapMalloc(strlen(address) + 1);
     if (c->address == NULL) {
         return RAFT_NOMEM;
     }
@@ -138,8 +138,8 @@ static void uvClientMaybeDestroy(struct uvClient *c)
     QUEUE_REMOVE(&c->queue);
 
     assert(c->address != NULL);
-    HeapFree(c->address);
-    HeapFree(c);
+    RaftHeapFree(c->address);
+    RaftHeapFree(c);
 
     uvMaybeFireCloseCb(uv);
 }
@@ -153,7 +153,7 @@ static void uvClientDisconnectCloseCb(struct uv_handle_s *handle)
     assert(c->old_stream != NULL);
     assert(c->stream == NULL);
     assert(handle == (struct uv_handle_s *)c->old_stream);
-    HeapFree(c->old_stream);
+    RaftHeapFree(c->old_stream);
     c->old_stream = NULL;
     if (c->closing) {
         uvClientMaybeDestroy(c);
@@ -427,7 +427,7 @@ static int uvGetClient(struct uv *uv,
     }
 
     /* Initialize the new connection */
-    *client = HeapMalloc(sizeof **client);
+    *client = RaftHeapMalloc(sizeof **client);
     if (*client == NULL) {
         rv = RAFT_NOMEM;
         goto err;
@@ -444,7 +444,7 @@ static int uvGetClient(struct uv *uv,
     return 0;
 
 err_after_client_alloc:
-    HeapFree(*client);
+    RaftHeapFree(*client);
 err:
     assert(rv != 0);
     return rv;
@@ -463,7 +463,7 @@ int UvSend(struct raft_io *io,
     assert(!uv->closing);
 
     /* Allocate a new request object. */
-    send = HeapMalloc(sizeof *send);
+    send = RaftHeapMalloc(sizeof *send);
     if (send == NULL) {
         rv = RAFT_NOMEM;
         goto err;

--- a/src/uv_tcp_connect.c
+++ b/src/uv_tcp_connect.c
@@ -44,7 +44,7 @@ static int uvTcpEncodeHandshake(raft_id id, const char *address, uv_buf_t *buf)
                sizeof(uint64_t) + /* Server ID. */
                sizeof(uint64_t) /* Size of the address buffer */;
     buf->len += address_len;
-    buf->base = HeapMalloc(buf->len);
+    buf->base = RaftHeapMalloc(buf->len);
     if (buf->base == NULL) {
         return RAFT_NOMEM;
     }
@@ -64,7 +64,7 @@ static void uvTcpConnectFinish(struct uvTcpConnect *connect)
     struct raft_uv_connect *req = connect->req;
     int status = connect->status;
     QUEUE_REMOVE(&connect->queue);
-    HeapFree(connect->handshake.base);
+    RaftHeapFree(connect->handshake.base);
     raft_free(connect);
     req->cb(req, stream, status);
 }
@@ -77,7 +77,7 @@ static void uvTcpConnectUvCloseCb(struct uv_handle_s *handle)
     struct UvTcp *t = connect->t;
     assert(connect->status != 0);
     assert(handle == (struct uv_handle_s *)connect->tcp);
-    HeapFree(connect->tcp);
+    RaftHeapFree(connect->tcp);
     connect->tcp = NULL;
     uvTcpConnectFinish(connect);
     UvTcpMaybeFireCloseCb(t);
@@ -166,7 +166,7 @@ static int uvTcpConnectStart(struct uvTcpConnect *r, const char *address)
         goto err;
     }
 
-    r->tcp = HeapMalloc(sizeof *r->tcp);
+    r->tcp = RaftHeapMalloc(sizeof *r->tcp);
     if (r->tcp == NULL) {
         ErrMsgOom(t->transport->errmsg);
         rv = RAFT_NOMEM;
@@ -191,9 +191,9 @@ static int uvTcpConnectStart(struct uvTcpConnect *r, const char *address)
     return 0;
 
 err_after_tcp_init:
-    uv_close((uv_handle_t *)r->tcp, (uv_close_cb)HeapFree);
+    uv_close((uv_handle_t *)r->tcp, (uv_close_cb)RaftHeapFree);
 err_after_encode_handshake:
-    HeapFree(r->handshake.base);
+    RaftHeapFree(r->handshake.base);
 err:
     return rv;
 }
@@ -211,7 +211,7 @@ int UvTcpConnect(struct raft_uv_transport *transport,
     assert(!t->closing);
 
     /* Create and initialize a new TCP connection request object */
-    r = HeapMalloc(sizeof *r);
+    r = RaftHeapMalloc(sizeof *r);
     if (r == NULL) {
         rv = RAFT_NOMEM;
         ErrMsgOom(transport->errmsg);
@@ -238,7 +238,7 @@ int UvTcpConnect(struct raft_uv_transport *transport,
 
 err_after_alloc:
     QUEUE_REMOVE(&r->queue);
-    HeapFree(r);
+    RaftHeapFree(r);
 err:
     return rv;
 }

--- a/src/uv_tcp_listen.c
+++ b/src/uv_tcp_listen.c
@@ -52,7 +52,7 @@ static int uvTcpDecodePreamble(struct uvTcpHandshake *h)
         return RAFT_MALFORMED;
     }
     h->address.len = (size_t)byteFlip64(h->preamble[2]);
-    h->address.base = HeapMalloc(h->address.len);
+    h->address.base = RaftHeapMalloc(h->address.len);
     if (h->address.base == NULL) {
         return RAFT_NOMEM;
     }
@@ -69,10 +69,10 @@ static void uvTcpIncomingCloseCb(struct uv_handle_s *handle)
     struct UvTcp *t = incoming->t;
     QUEUE_REMOVE(&incoming->queue);
     if (incoming->handshake.address.base != NULL) {
-        HeapFree(incoming->handshake.address.base);
+        RaftHeapFree(incoming->handshake.address.base);
     }
-    HeapFree(incoming->tcp);
-    HeapFree(incoming);
+    RaftHeapFree(incoming->tcp);
+    RaftHeapFree(incoming);
     UvTcpMaybeFireCloseCb(t);
 }
 
@@ -142,8 +142,8 @@ static void uvTcpIncomingReadCbAddress(uv_stream_t *stream,
     QUEUE_REMOVE(&incoming->queue);
     incoming->t->accept_cb(incoming->t->transport, id, address,
                            (struct uv_stream_s *)incoming->tcp);
-    HeapFree(incoming->handshake.address.base);
-    HeapFree(incoming);
+    RaftHeapFree(incoming->handshake.address.base);
+    RaftHeapFree(incoming);
 }
 
 /* Read the preamble of the handshake. */
@@ -211,7 +211,7 @@ static int uvTcpIncomingStart(struct uvTcpIncoming *incoming)
     int rv;
     memset(&incoming->handshake, 0, sizeof incoming->handshake);
 
-    incoming->tcp = HeapMalloc(sizeof *incoming->tcp);
+    incoming->tcp = RaftHeapMalloc(sizeof *incoming->tcp);
     if (incoming->tcp == NULL) {
         return RAFT_NOMEM;
     }
@@ -234,7 +234,7 @@ static int uvTcpIncomingStart(struct uvTcpIncoming *incoming)
     return 0;
 
 err_after_tcp_init:
-    uv_close((uv_handle_t *)incoming->tcp, (uv_close_cb)HeapFree);
+    uv_close((uv_handle_t *)incoming->tcp, (uv_close_cb)RaftHeapFree);
     return rv;
 }
 
@@ -252,7 +252,7 @@ static void uvTcpListenCb(struct uv_stream_s *stream, int status)
         goto err;
     }
 
-    incoming = HeapMalloc(sizeof *incoming);
+    incoming = RaftHeapMalloc(sizeof *incoming);
     if (incoming == NULL) {
         rv = RAFT_NOMEM;
         goto err;
@@ -270,7 +270,7 @@ static void uvTcpListenCb(struct uv_stream_s *stream, int status)
 
 err_after_accept_alloc:
     QUEUE_REMOVE(&incoming->queue);
-    HeapFree(incoming);
+    RaftHeapFree(incoming);
 err:
     assert(rv != 0);
 }

--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -39,7 +39,7 @@ static void uvTruncateWorkCb(uv_work_t *work)
         goto err;
     }
     if (snapshots != NULL) {
-        HeapFree(snapshots);
+        RaftHeapFree(snapshots);
     }
     assert(segments != NULL);
 
@@ -86,13 +86,13 @@ static void uvTruncateWorkCb(uv_work_t *work)
         goto err_after_list;
     }
 
-    HeapFree(segments);
+    RaftHeapFree(segments);
     truncate->status = 0;
 
     return;
 
 err_after_list:
-    HeapFree(segments);
+    RaftHeapFree(segments);
 err:
     assert(rv != 0);
     truncate->status = rv;
@@ -107,7 +107,7 @@ static void uvTruncateAfterWorkCb(uv_work_t *work, int status)
         uv->errored = true;
     }
     uv->truncate_work.data = NULL;
-    HeapFree(truncate);
+    RaftHeapFree(truncate);
     UvUnblock(uv);
 }
 
@@ -119,7 +119,7 @@ static void uvTruncateBarrierCb(struct UvBarrier *barrier)
 
     /* If we're closing, don't perform truncation at all and abort here. */
     if (uv->closing) {
-        HeapFree(truncate);
+        RaftHeapFree(truncate);
         return;
     }
 
@@ -152,7 +152,7 @@ int UvTruncate(struct raft_io *io, raft_index index)
     assert(index > 0);
     assert(index < uv->append_next_index);
 
-    truncate = HeapMalloc(sizeof *truncate);
+    truncate = RaftHeapMalloc(sizeof *truncate);
     if (truncate == NULL) {
         rv = RAFT_NOMEM;
         goto err;
@@ -171,7 +171,7 @@ int UvTruncate(struct raft_io *io, raft_index index)
     return 0;
 
 err_after_req_alloc:
-    HeapFree(truncate);
+    RaftHeapFree(truncate);
 err:
     assert(rv != 0);
     return rv;

--- a/src/uv_writer.c
+++ b/src/uv_writer.c
@@ -271,7 +271,7 @@ int UvWriterInit(struct UvWriter *w,
     }
 
     /* Initialize the array of re-usable event objects. */
-    w->events = HeapCalloc(w->n_events, sizeof *w->events);
+    w->events = RaftHeapCalloc(w->n_events, sizeof *w->events);
     if (w->events == NULL) {
         /* UNTESTED: todo */
         ErrMsgOom(errmsg);
@@ -324,7 +324,7 @@ int UvWriterInit(struct UvWriter *w,
 err_after_event_fd:
     UvOsClose(w->event_fd);
 err_after_events_alloc:
-    HeapFree(w->events);
+    RaftHeapFree(w->events);
 err_after_io_setup:
     UvOsIoDestroy(w->ctx);
 err:
@@ -337,7 +337,7 @@ static void uvWriterCleanUpAndFireCloseCb(struct UvWriter *w)
     assert(w->closing);
 
     UvOsClose(w->fd);
-    HeapFree(w->events);
+    RaftHeapFree(w->events);
     UvOsIoDestroy(w->ctx);
 
     if (w->close_cb != NULL) {


### PR DESCRIPTION
I'd like to make some progress on #119 , and the renaming of the heap functions take up a large part of that PR. Merging it separately is an easy win and makes that work more straightforward and easy to review.