### PR TITLE
uv: barrier before every snapshot

### DIFF
--- a/src/uv.h
+++ b/src/uv.h
@@ -323,6 +323,7 @@ typedef void (*UvBarrierCb)(struct UvBarrier *req);
 struct UvBarrier
 {
     void *data;     /* User data */
+    bool blocking;  /* Whether this barrier should block future writes */
     UvBarrierCb cb; /* Completion callback */
 };
 
@@ -335,7 +336,7 @@ struct UvBarrier
  *   that will be appended will have the new index.
  *
  * - Execution of new writes for subsequent append requests will be blocked
- *   until UvUnblock is called.
+ *   until UvUnblock is called when the barrier is blocking.
  *
  * - Wait for all currently pending and inflight append requests against all
  *   open segments to complete, and for those open segments to be finalized,

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -326,9 +326,9 @@ start:
         return 0;
     }
 
-    /* If there's a barrier in progress, and it's not waiting for this segment
+    /* If there's a blocking barrier in progress, and it's not waiting for this segment
      * to be finalized, let's wait. */
-    if (uv->barrier != NULL && segment->barrier != uv->barrier) {
+    if (uv->barrier != NULL && segment->barrier != uv->barrier && uv->barrier->blocking) {
         return 0;
     }
 
@@ -773,7 +773,6 @@ int UvBarrier(struct uv *uv,
 
 void UvUnblock(struct uv *uv)
 {
-    assert(uv->barrier != NULL);
     uv->barrier = NULL;
     if (uv->closing) {
         uvMaybeFireCloseCb(uv);

--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -160,6 +160,7 @@ int UvTruncate(struct raft_io *io, raft_index index)
     truncate->uv = uv;
     truncate->index = index;
     truncate->barrier.data = truncate;
+    truncate->barrier.blocking = true;
 
     /* Make sure that we wait for any inflight writes to finish and then close
      * the current segment. */

--- a/test/lib/tracer.h
+++ b/test/lib/tracer.h
@@ -6,7 +6,7 @@
 #include "../../include/raft.h"
 
 #define FIXTURE_TRACER struct raft_tracer tracer
-#define SET_UP_TRACER f->tracer.emit = TracerEmit
+#define SET_UP_TRACER f->tracer.emit = TracerEmit; f->tracer.enabled = true
 #define TEAR_DOWN_TRACER
 
 void TracerEmit(struct raft_tracer *t,


### PR DESCRIPTION
This solves a bug that came up during jepsen tests, it occurs when:
- a server is killed ungracefully (leading to a written open segment in
the directory when the system restarts)
- a snapshot file exists
- no closed segments exist

Because open segments are not closed before writing a snapshot, raft,
when starting up and reading the files in the data directory,
erroneously assumes that all the entries in the open segment are newer
than the entries in the snapshot, while in reality the entries are
already contained in the snapshot, leading to a wrong state.

Closing the current open segments before writing the snapshot ensures
that no old entries can mistakenly be identified as new entries, all
entries in the open segments will be newer than the snapshot.

To close the open segments before making a snapshot, we perform a `barrier`
request, but we need to make a distinction between a 'blocking' and a 'non-blocking'
barrier in order to save performance.
Both barriers close all current open segments before firing the barrier
callback, but a 'non-blocking' barrier allows writes to go through to newly
created open-segments. This non-blocking barrier is used when raft is creating
a snapshot  during regular operation, the blocking barrier is used when installing
snapshots and truncating the log.