### PR TITLE
uv_append: Don't finalize segment if there are writes in-flight

### DIFF
--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -270,11 +270,11 @@ out:
         if (rv != 0) {
             uv->errored = true;
         }
-    } else if (s->finalize) {
-        /* If there are no more append_pending_reqs, this segment
-         * must be finalized here in case we don't receive AppendEntries
-         * RPCs anymore (could happen during a Snapshot install, causing
-         * the BarrierCb to never fire) */
+    } else if (s->finalize && (s->pending_last_index == s->last_index)) {
+        /* If there are no more append_pending_reqs or write requests in flight,
+         * this segment must be finalized here in case we don't receive
+         * AppendEntries RPCs anymore (could happen during a Snapshot install,
+         * causing the BarrierCb to never fire) */
         uvAliveSegmentFinalize(s);
     }
 }


### PR DESCRIPTION
calling `uvAliveSegmentFinalize(s)` while there are writes against the alive segment in flight could lead to `uvWriterClose` being called twice, leading to a triggered assertion  `src/uv_writer.c:393: UvWriterClose: Assertion '!w->closing' failed.`

This can happen when e.g.:
- write against open segment completes in `uvAliveSegmentWriteCb`
- write triggers a checkpoint 
- checkpoint triggers a raft apply command
- triggers a write against the open segment
- adds write to `poll_queue`
- raft apply command triggers a snapshot
- snapshot triggers finalization of open segment
- causes `uvAliveSegmentFinalize(s)` to be called [here](https://github.com/canonical/raft/blob/ca8b466734e57f3f4e30f2f29da9f5ae02a7efc8/src/uv_append.c#L278)
- leading to the cancellation of requests in the `poll_queue`
- leading to a failed write and `UvWriterClose` being called again.

To avoid this, no longer finalize the alive segment if there is a write in-flight, checked by comparing `pending_last_index` & `last_index` on the segment. When the in-flight write completes, the segment will be finalized.