### PR TITLE
uv_os: Perform a runtime check on file and dir lengths when joining

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -175,6 +175,7 @@ test_unit_uv_SOURCES = \
   src/uv_writer.c \
   test/unit/main_uv.c \
   test/unit/test_uv_fs.c \
+  test/unit/test_uv_os.c \
   test/unit/test_uv_writer.c
 test_unit_uv_LDFLAGS = $(UV_LIBS)
 test_unit_uv_CFLAGS = $(AM_CFLAGS) -Wno-conversion

--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -78,7 +78,10 @@ int UvFsFileExists(const char *dir,
     char path[UV__PATH_SZ];
     int rv;
 
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
 
     rv = UvOsStat(path, &sb);
     if (rv != 0) {
@@ -106,7 +109,10 @@ int UvFsFileSize(const char *dir,
     char path[UV__PATH_SZ];
     int rv;
 
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
 
     rv = UvOsStat(path, &sb);
     if (rv != 0) {
@@ -144,7 +150,10 @@ static int uvFsOpenFile(const char *dir,
 {
     char path[UV__PATH_SZ];
     int rv;
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
     rv = UvOsOpen(path, flags, mode, fd);
     if (rv != 0) {
         UvOsErrMsg(errmsg, "open", rv);
@@ -160,8 +169,12 @@ int UvFsOpenFileForReading(const char *dir,
 {
     char path[UV__PATH_SZ];
     int flags = O_RDONLY;
+    int rv;
 
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
 
     return uvFsOpenFile(dir, filename, flags, 0, fd, errmsg);
 }
@@ -176,7 +189,10 @@ int UvFsAllocateFile(const char *dir,
     int flags = O_WRONLY | O_CREAT | O_EXCL; /* Common open flags */
     int rv = 0;
 
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
 
     /* TODO: use RWF_DSYNC instead, if available. */
     flags |= O_DSYNC;
@@ -297,8 +313,14 @@ int UvFsMakeFile(const char *dir,
     /* Rename the temp file. Remark that there is a race between the existence
      * check and the rename, there is no `renameat2` equivalent in libuv.
      * However, in the current implementation this should pose no problems.*/
-    UvOsJoin(dir, tmp_filename, tmp_path);
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, tmp_filename, tmp_path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
     rv = UvOsRename(tmp_path, path);
     if (rv != 0) {
         UvOsErrMsg(errmsg, "rename", rv);
@@ -331,7 +353,10 @@ int UvFsMakeOrOverwriteFile(const char *dir,
     uv_file fd;
     int rv;
 
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
 
 open:
     rv = UvOsOpen(path, flags, mode, &fd);
@@ -418,7 +443,10 @@ int UvFsReadFile(const char *dir,
     uv_file fd;
     int rv;
 
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
 
     rv = UvOsStat(path, &sb);
     if (rv != 0) {
@@ -466,7 +494,10 @@ int UvFsReadFileInto(const char *dir,
     uv_file fd;
     int rv;
 
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
 
     rv = uvFsOpenFile(dir, filename, O_RDONLY, 0, &fd, errmsg);
     if (rv != 0) {
@@ -492,7 +523,10 @@ int UvFsRemoveFile(const char *dir, const char *filename, char *errmsg)
 {
     char path[UV__PATH_SZ];
     int rv;
-    UvOsJoin(dir, filename, path);
+    rv = UvOsJoin(dir, filename, path);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
     rv = UvOsUnlink(path);
     if (rv != 0) {
         UvOsErrMsg(errmsg, "unlink", rv);
@@ -512,8 +546,14 @@ int UvFsTruncateAndRenameFile(const char *dir,
     uv_file fd;
     int rv;
 
-    UvOsJoin(dir, filename1, path1);
-    UvOsJoin(dir, filename2, path2);
+    rv = UvOsJoin(dir, filename1, path1);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
+    rv = UvOsJoin(dir, filename2, path2);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
 
     /* Truncate and rename. */
     rv = UvOsOpen(path1, UV_FS_O_RDWR, 0, &fd);

--- a/src/uv_os.c
+++ b/src/uv_os.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <libgen.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/eventfd.h>
@@ -142,13 +143,15 @@ int UvOsRename(const char *path1, const char *path2)
     return uv_fs_rename(NULL, &req, path1, path2, NULL);
 }
 
-void UvOsJoin(const char *dir, const char *filename, char *path)
+int UvOsJoin(const char *dir, const char *filename, char *path)
 {
-    assert(UV__DIR_HAS_VALID_LEN(dir));
-    assert(UV__FILENAME_HAS_VALID_LEN(filename));
+    if (!UV__DIR_HAS_VALID_LEN(dir) || !UV__FILENAME_HAS_VALID_LEN(filename)) {
+        return -1;
+    }
     strcpy(path, dir);
     strcat(path, "/");
     strcat(path, filename);
+    return 0;
 }
 
 int UvOsIoSetup(unsigned nr, aio_context_t *ctxp)

--- a/src/uv_os.h
+++ b/src/uv_os.h
@@ -102,7 +102,7 @@ int UvOsUnlink(const char *path);
 int UvOsRename(const char *path1, const char *path2);
 
 /* Join dir and filename into a full OS path. */
-void UvOsJoin(const char *dir, const char *filename, char *path);
+int UvOsJoin(const char *dir, const char *filename, char *path);
 
 /* TODO: figure a portable abstraction. */
 int UvOsIoSetup(unsigned nr, aio_context_t *ctxp);

--- a/test/unit/test_uv_os.c
+++ b/test/unit/test_uv_os.c
@@ -1,0 +1,82 @@
+#include "../../src/uv_os.h"
+#include "../lib/runner.h"
+
+SUITE(UvOsJoin)
+
+/* dir and filename have sensible lengths */
+TEST(UvOsJoin, basic, NULL, NULL, 0, NULL)
+{
+    int rv;
+    const char *dir = "/home";
+    const char *filename = "testfile";
+    char path[UV__PATH_SZ];
+    rv = UvOsJoin(dir, filename, path);
+    munit_assert_int(rv, ==, 0);
+    munit_assert_string_equal(path, "/home/testfile");
+    return MUNIT_OK;
+}
+
+TEST(UvOsJoin, dirTooLong, NULL, NULL, 0, NULL)
+{
+    int rv;
+    char path[UV__PATH_SZ];
+    char dir[UV__DIR_LEN+2]; /* Room for '\0' and then 1 char over limit. */
+    memset((char*)dir, '/', sizeof(dir));
+    dir[sizeof(dir)-1] = '\0';
+    const char *filename = "testfile";
+
+    rv = UvOsJoin(dir, filename, path);
+    munit_assert_int(rv, !=, 0);
+    return MUNIT_OK;
+}
+
+TEST(UvOsJoin, filenameTooLong, NULL, NULL, 0, NULL)
+{
+    int rv;
+    char path[UV__PATH_SZ];
+    const char *dir = "testdir";
+    char filename[UV__FILENAME_LEN+2];
+    memset((char*)filename, 'a', sizeof(filename));
+    filename[sizeof(filename)-1] = '\0';
+
+    rv = UvOsJoin(dir, filename, path);
+    munit_assert_int(rv, !=, 0);
+    return MUNIT_OK;
+}
+
+TEST(UvOsJoin, dirAndFilenameTooLong, NULL, NULL, 0, NULL)
+{
+    int rv;
+    char path[UV__PATH_SZ];
+    char dir[UV__DIR_LEN+2];
+    memset((char*)dir, '/', sizeof(dir));
+    dir[sizeof(dir)-1] = '\0';
+
+    char filename[UV__FILENAME_LEN+2];
+    memset((char*)filename, 'a', sizeof(filename));
+    filename[sizeof(filename)-1] = '\0';
+
+    rv = UvOsJoin(dir, filename, path);
+    munit_assert_int(rv, !=, 0);
+    return MUNIT_OK;
+}
+
+TEST(UvOsJoin, dirAndFilenameMax, NULL, NULL, 0, NULL)
+{
+    int rv;
+    char path[UV__PATH_SZ];
+    char dir[UV__DIR_LEN+1];
+    memset((char*)dir, '/', sizeof(dir));
+    dir[sizeof(dir)-1] = '\0';
+
+    char filename[UV__FILENAME_LEN+1];
+    memset((char*)filename, 'a', sizeof(filename));
+    filename[sizeof(filename)-1] = '\0';
+
+    rv = UvOsJoin(dir, filename, path);
+    munit_assert_int(rv, ==, 0);
+    char cmp_path[UV__DIR_LEN + UV__FILENAME_LEN + 1 + 1];
+    snprintf(cmp_path, UV__DIR_LEN + UV__FILENAME_LEN + 1 + 1, "%s/%s", dir, filename);
+    munit_assert_string_equal(path, cmp_path);
+    return MUNIT_OK;
+}

--- a/test/unit/test_uv_writer.c
+++ b/test/unit/test_uv_writer.c
@@ -194,7 +194,8 @@ static void *setUpDeps(const MunitParameter params[], void *user_data)
     rv = UvFsProbeCapabilities(f->dir, &f->direct_io, &f->async_io, errmsg);
     munit_assert_int(rv, ==, 0);
     f->block_size = f->direct_io != 0 ? f->direct_io : 4096;
-    UvOsJoin(f->dir, "foo", path);
+    rv = UvOsJoin(f->dir, "foo", path);
+    munit_assert_int(rv, ==, 0);
     rv = UvOsOpen(path, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR, &f->fd);
     munit_assert_int(rv, ==, 0);
     rv = UvOsFallocate(f->fd, 0, f->block_size * N_BLOCKS);


### PR DESCRIPTION
Eliminates some Coverity issues.