### PR TITLE
uv_append: Check if segment wasn't closed in write request cb

### DIFF
--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -270,11 +270,14 @@ out:
         if (rv != 0) {
             uv->errored = true;
         }
-    } else if (s->finalize && (s->pending_last_index == s->last_index)) {
+    } else if (s->finalize
+               && (s->pending_last_index == s->last_index)
+               && !s->writer.closing) {
         /* If there are no more append_pending_reqs or write requests in flight,
          * this segment must be finalized here in case we don't receive
          * AppendEntries RPCs anymore (could happen during a Snapshot install,
-         * causing the BarrierCb to never fire) */
+         * causing the BarrierCb to never fire), but check that the callbacks that
+         * fired after completion of this write didn't already close the segment. */
         uvAliveSegmentFinalize(s);
     }
 }


### PR DESCRIPTION
Fixes an instance of https://github.com/canonical/raft/issues/245.

The callback of the append request being fired by the write completing, could trigger a new append that finalized the segment that was just written to, leading to the assertion being triggered. I was able to reproduce this in a couple of longer running tests, with this fix, the issue disappeared.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>