### PR TITLE
Async snapshot

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -150,6 +150,7 @@ libraft_la_SOURCES += \
   src/uv_tcp_listen.c \
   src/uv_tcp_connect.c \
   src/uv_truncate.c \
+  src/uv_work.c \
   src/uv_writer.c
 libraft_la_LDFLAGS += $(UV_LIBS)
 
@@ -198,7 +199,8 @@ test_integration_uv_SOURCES = \
   test/integration/test_uv_tcp_connect.c \
   test/integration/test_uv_tcp_listen.c \
   test/integration/test_uv_snapshot_put.c \
-  test/integration/test_uv_truncate.c
+  test/integration/test_uv_truncate.c \
+  test/integration/test_uv_work.c
 test_integration_uv_CFLAGS = $(AM_CFLAGS) -Wno-type-limits -Wno-conversion
 test_integration_uv_LDFLAGS = -no-install $(UV_LIBS)
 test_integration_uv_LDADD = libtest.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ raftinclude_HEADERS =
 
 lib_LTLIBRARIES = libraft.la
 libraft_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
-libraft_la_LDFLAGS = -version-info 0:7:0
+libraft_la_LDFLAGS = -version-info 1:0:0
 libraft_la_SOURCES = \
   src/byte.c \
   src/client.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([raft], [0.11.2])
+AC_INIT([raft], [0.12.0])
 AC_LANG([C])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([ac])

--- a/include/raft.h
+++ b/include/raft.h
@@ -418,6 +418,20 @@ struct raft_io_snapshot_get
 };
 
 /**
+ * Asynchronous work request.
+ */
+struct raft_io_async_work;
+typedef int (*raft_io_async_work_fn)(struct raft_io_async_work *req);
+typedef void (*raft_io_async_work_cb)(struct raft_io_async_work *req,
+				      int status);
+struct raft_io_async_work
+{
+    void *data;                 /* User data */
+    raft_io_async_work_fn work; /* Function to run async from the main loop */
+    raft_io_async_work_cb cb;   /* Request callback */
+};
+
+/**
  * Customizable tracer, for debugging purposes.
  */
 struct raft_tracer
@@ -499,6 +513,9 @@ struct raft_io
                         raft_io_snapshot_get_cb cb);
     raft_time (*time)(struct raft_io *io);
     int (*random)(struct raft_io *io, int min, int max);
+    int (*async_work)(struct raft_io *io,
+                      struct raft_io_async_work *req,
+                      raft_io_async_work_cb cb);
 };
 
 struct raft_fsm

--- a/include/raft.h
+++ b/include/raft.h
@@ -423,7 +423,7 @@ struct raft_io_snapshot_get
 struct raft_io_async_work;
 typedef int (*raft_io_async_work_fn)(struct raft_io_async_work *req);
 typedef void (*raft_io_async_work_cb)(struct raft_io_async_work *req,
-				      int status);
+                                      int status);
 struct raft_io_async_work
 {
     void *data;                 /* User data */
@@ -518,9 +518,41 @@ struct raft_io
                       raft_io_async_work_cb cb);
 };
 
+/*
+ * version 1:
+ * struct raft_fsm
+ * {
+ *     int version;
+ *     void *data;
+ *     int (*apply)(struct raft_fsm *fsm,
+ *                  const struct raft_buffer *buf,
+ *                  void **result);
+ *     int (*snapshot)(struct raft_fsm *fsm,
+ *                     struct raft_buffer *bufs[],
+ *                     unsigned *n_bufs);
+ *     int (*restore)(struct raft_fsm *fsm, struct raft_buffer *buf);
+ * };
+ *
+ * version 2:
+ * Adds support for async snapshots through the `snapshot_async`
+ * and `snapshot_finalize` functions.
+ * An implementation must provide either the `snapshot` method or all 3
+ * snapshot methods. When only the `snapshot` method is provided, the behavior
+ * is identical to version 1, `snapshot` will be called in the main loop and the
+ * allocated buffers will be released by raft.
+ * When all 3 methods are provided, raft will call `snapshot` in the main loop,
+ * and when successful, will call `snapshot_async` by means of the `io->async_work` method.
+ * The callback to `io->async_work` will in turn call `snapshot_finalize`
+ * in the main loop when the work has completed independent of the return value
+ * of `snapshot_async`.
+ * An implementation that does not use asynchronous snapshots MUST set
+ * `snapshot_async` and `snapshot_finalize` to NULL.
+ * All memory allocated by the snapshot routines MUST be freed by the snapshot
+ * routines themselves.
+ */
 struct raft_fsm
 {
-    int version;
+    int version; /* 1 or 2 */
     void *data;
     int (*apply)(struct raft_fsm *fsm,
                  const struct raft_buffer *buf,
@@ -529,6 +561,12 @@ struct raft_fsm
                     struct raft_buffer *bufs[],
                     unsigned *n_bufs);
     int (*restore)(struct raft_fsm *fsm, struct raft_buffer *buf);
+    int (*snapshot_async)(struct raft_fsm *fsm,
+                          struct raft_buffer *bufs[],
+                          unsigned *n_bufs);
+    int (*snapshot_finalize)(struct raft_fsm *fsm,
+                             struct raft_buffer *bufs[],
+                             unsigned *n_bufs);
 };
 
 /**

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -16,7 +16,8 @@
 enum {
     RAFT_FIXTURE_TICK = 1, /* The tick callback has been invoked */
     RAFT_FIXTURE_NETWORK,  /* A network request has been sent or received */
-    RAFT_FIXTURE_DISK      /* An I/O request has been submitted */
+    RAFT_FIXTURE_DISK,     /* An I/O request has been submitted */
+    RAFT_FIXTURE_WORK      /* A large, CPU and/or memory intensive task */
 };
 
 /**

--- a/src/replication.c
+++ b/src/replication.c
@@ -543,7 +543,7 @@ out:
 /* Submit a disk write for all entries from the given index onward. */
 static int appendLeader(struct raft *r, raft_index index)
 {
-    struct raft_entry *entries;
+    struct raft_entry *entries = NULL;
     unsigned n;
     struct appendLeader *request;
     int rv;

--- a/src/uv.c
+++ b/src/uv.c
@@ -185,6 +185,9 @@ void uvMaybeFireCloseCb(struct uv *uv)
     if (!QUEUE_IS_EMPTY(&uv->snapshot_get_reqs)) {
         return;
     }
+    if (!QUEUE_IS_EMPTY(&uv->async_work_reqs)) {
+        return;
+    }
     if (!QUEUE_IS_EMPTY(&uv->aborting)) {
         return;
     }
@@ -665,6 +668,7 @@ int raft_uv_init(struct raft_io *io,
     uv->finalize_work.data = NULL;
     uv->truncate_work.data = NULL;
     QUEUE_INIT(&uv->snapshot_get_reqs);
+    QUEUE_INIT(&uv->async_work_reqs);
     uv->snapshot_put_work.data = NULL;
     uv->timer.data = NULL;
     uv->tick_cb = NULL; /* Set by raft_io->start() */
@@ -689,6 +693,7 @@ int raft_uv_init(struct raft_io *io,
     io->send = UvSend;
     io->snapshot_put = UvSnapshotPut;
     io->snapshot_get = UvSnapshotGet;
+    io->async_work = UvAsyncWork;
     io->time = uvTime;
     io->random = uvRandom;
 

--- a/src/uv.h
+++ b/src/uv.h
@@ -83,6 +83,7 @@ struct uv
     struct uv_work_s finalize_work;      /* Resize and rename segments */
     struct uv_work_s truncate_work;      /* Execute truncate log requests */
     queue snapshot_get_reqs;             /* Inflight get snapshot requests */
+    queue async_work_reqs;               /* Inflight async work requests */
     struct uv_work_s snapshot_put_work;  /* Execute snapshot put requests */
     struct uvMetadata metadata;          /* Cache of metadata on disk */
     struct uv_timer_s timer;             /* Timer for periodic ticks */
@@ -271,6 +272,12 @@ int UvSnapshotPut(struct raft_io *io,
 int UvSnapshotGet(struct raft_io *io,
                   struct raft_io_snapshot_get *req,
                   raft_io_snapshot_get_cb cb);
+
+
+/* Implementation of raft_io->async_work (defined in uv_work.c). */
+int UvAsyncWork(struct raft_io *io,
+                struct raft_io_async_work *req,
+                raft_io_async_work_cb cb);
 
 /* Return a list of all snapshots and segments found in the data directory. Both
  * snapshots and segments are ordered by filename (closed segments come before

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -635,7 +635,7 @@ int UvAppend(struct raft_io *io,
     uv = io->impl;
     assert(!uv->closing);
 
-    append = RaftHeapMalloc(sizeof *append);
+    append = RaftHeapCalloc(1, sizeof *append);
     if (append == NULL) {
         rv = RAFT_NOMEM;
         goto err;

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -901,9 +901,9 @@ static int uvWriteClosedSegment(struct uv *uv,
                                 const struct raft_buffer *conf)
 {
     char filename[UV__FILENAME_LEN];
-    struct uvSegmentBuffer buf;
+    struct uvSegmentBuffer buf = {0};
     struct raft_buffer data;
-    struct raft_entry entry;
+    struct raft_entry entry = {0};
     size_t cap;
     char errmsg[RAFT_ERRMSG_BUF_SIZE];
     int rv;

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -634,7 +634,10 @@ int UvSnapshotPut(struct raft_io *io,
     raft_index next_index;
 
     uv = io->impl;
-    assert(!uv->closing);
+    if (uv->closing) {
+        return RAFT_CANCELED;
+    }
+
     assert(uv->snapshot_put_work.data == NULL);
 
     tracef("put snapshot at %lld, keeping %d", snapshot->index, trailing);

--- a/src/uv_work.c
+++ b/src/uv_work.c
@@ -1,0 +1,80 @@
+#include "assert.h"
+#include "heap.h"
+#include "uv.h"
+
+#define tracef(...) Tracef(uv->tracer, __VA_ARGS__)
+
+struct uvAsyncWork
+{
+    struct uv *uv;
+    struct raft_io_async_work *req;
+    struct uv_work_s work;
+    int status;
+    queue queue;
+};
+
+static void uvAsyncWorkCb(uv_work_t *work)
+{
+    struct uvAsyncWork *w = work->data;
+    assert(w != NULL);
+    int rv;
+    rv = w->req->work(w->req);
+    w->status = rv;
+}
+
+static void uvAsyncAfterWorkCb(uv_work_t *work, int status)
+{
+    struct uvAsyncWork *w = work->data;
+    struct raft_io_async_work *req = w->req;
+    int req_status = w->status;
+    struct uv *uv = w->uv;
+    assert(status == 0);
+
+    QUEUE_REMOVE(&w->queue);
+    RaftHeapFree(w);
+    req->cb(req, req_status);
+    uvMaybeFireCloseCb(uv);
+}
+
+int UvAsyncWork(struct raft_io *io,
+                struct raft_io_async_work *req,
+                raft_io_async_work_cb cb)
+{
+    struct uv *uv;
+    struct uvAsyncWork *async_work;
+    int rv;
+
+    uv = io->impl;
+    assert(!uv->closing);
+
+    async_work = RaftHeapMalloc(sizeof *async_work);
+    if (async_work == NULL) {
+        rv = RAFT_NOMEM;
+        goto err;
+    }
+
+    async_work->uv = uv;
+    async_work->req = req;
+    async_work->work.data = async_work;
+    req->cb = cb;
+
+    QUEUE_PUSH(&uv->async_work_reqs, &async_work->queue);
+    rv = uv_queue_work(uv->loop, &async_work->work, uvAsyncWorkCb,
+                       uvAsyncAfterWorkCb);
+    if (rv != 0) {
+        QUEUE_REMOVE(&async_work->queue);
+        tracef("async work: %s", uv_strerror(rv));
+        rv = RAFT_IOERR;
+        goto err_after_req_alloc;
+    }
+
+    return 0;
+
+err_after_req_alloc:
+    RaftHeapFree(async_work);
+err:
+    assert(rv != 0);
+    return rv;
+}
+
+#undef tracef

--- a/test/integration/test_fixture.c
+++ b/test/integration/test_fixture.c
@@ -26,7 +26,7 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
     int rc;
     SET_UP_HEAP;
     for (i = 0; i < N_SERVERS; i++) {
-        FsmInit(&f->fsms[i]);
+        FsmInit(&f->fsms[i], 2);
     }
 
     rc = raft_fixture_init(&f->fixture, N_SERVERS, f->fsms);

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -62,6 +62,72 @@ static void tearDown(void *data)
         }                                                             \
     }
 
+static int ioMethodSnapshotPutFail(struct raft_io *raft_io,
+                                   unsigned trailing,
+                                   struct raft_io_snapshot_put *req,
+                                   const struct raft_snapshot *snapshot,
+                                   raft_io_snapshot_put_cb cb)
+{
+    (void) raft_io;
+    (void) trailing;
+    (void) req;
+    (void) snapshot;
+    (void) cb;
+    return -1;
+}
+
+#define SET_FAULTY_SNAPSHOT_PUT()                                        \
+    {                                                                    \
+        unsigned i;                                                      \
+        for (i = 0; i < CLUSTER_N; i++) {                                \
+            CLUSTER_RAFT(i)->io->snapshot_put = ioMethodSnapshotPutFail; \
+        }                                                                \
+    }
+
+static int ioMethodAsyncWorkFail(struct raft_io *raft_io,
+                                 struct raft_io_async_work *req,
+                                 raft_io_async_work_cb cb)
+{
+    (void) raft_io;
+    (void) req;
+    (void) cb;
+    return -1;
+}
+
+#define SET_FAULTY_ASYNC_WORK()                                      \
+    {                                                                \
+        unsigned i;                                                  \
+        for (i = 0; i < CLUSTER_N; i++) {                            \
+            CLUSTER_RAFT(i)->io->async_work = ioMethodAsyncWorkFail; \
+        }                                                            \
+    }
+
+static int fsmSnapshotFail(struct raft_fsm *fsm,
+                           struct raft_buffer *bufs[],
+                           unsigned *n_bufs)
+{
+    (void) fsm;
+    (void) bufs;
+    (void) n_bufs;
+    return -1;
+}
+
+#define SET_FAULTY_SNAPSHOT_ASYNC()                                      \
+    {                                                                    \
+        unsigned i;                                                      \
+        for (i = 0; i < CLUSTER_N; i++) {                                \
+            CLUSTER_RAFT(i)->fsm->snapshot_async = fsmSnapshotFail;      \
+        }                                                                \
+    }
+
+#define SET_FAULTY_SNAPSHOT()                                            \
+    {                                                                    \
+        unsigned i;                                                      \
+        for (i = 0; i < CLUSTER_N; i++) {                                \
+            CLUSTER_RAFT(i)->fsm->snapshot = fsmSnapshotFail;            \
+        }                                                                \
+    }
+
 /******************************************************************************
  *
  * Successfully install a snapshot
@@ -475,8 +541,24 @@ TEST(snapshot, installSnapshotDuringEntriesWrite, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
+static char *fsm_snapshot_async[] = {"0", "1", NULL};
+static char *fsm_version[] = {"1", "2", NULL};
+static MunitParameterEnum fsm_snapshot_async_params[] = {
+    {CLUSTER_SS_ASYNC_PARAM, fsm_snapshot_async},
+    {CLUSTER_FSM_VERSION_PARAM, fsm_version},
+    {NULL, NULL},
+};
+
+static char *fsm_snapshot_only_async[] = {"1", NULL};
+static char *fsm_version_only_async[] = {"2", NULL};
+static MunitParameterEnum fsm_snapshot_only_async_params[] = {
+    {CLUSTER_SS_ASYNC_PARAM, fsm_snapshot_only_async},
+    {CLUSTER_FSM_VERSION_PARAM, fsm_version_only_async},
+    {NULL, NULL},
+};
+
 /* Follower receives AppendEntries RPCs while taking a snapshot */
-TEST(snapshot, takeSnapshotAppendEntries, setUp, tearDown, 0, NULL)
+TEST(snapshot, takeSnapshotAppendEntries, setUp, tearDown, 0, fsm_snapshot_async_params)
 {
     struct fixture *f = data;
     (void)params;
@@ -496,7 +578,7 @@ TEST(snapshot, takeSnapshotAppendEntries, setUp, tearDown, 0, NULL)
 
     /* Step the cluster until server 1 takes a snapshot */
     const struct raft *r = CLUSTER_RAFT(1);
-    CLUSTER_STEP_UNTIL(server_taking_snapshot, (void*) r, 2000);
+    CLUSTER_STEP_UNTIL(server_taking_snapshot, (void*) r, 3000);
 
     /* Send AppendEntries RPCs while server 1 is taking a snapshot */
     static struct raft_apply reqs[5];
@@ -510,5 +592,85 @@ TEST(snapshot, takeSnapshotAppendEntries, setUp, tearDown, 0, NULL)
     CLUSTER_MAKE_PROGRESS;
     CLUSTER_MAKE_PROGRESS;
     CLUSTER_STEP_UNTIL_APPLIED(1, 11, 5000);
+    return MUNIT_OK;
+}
+
+TEST(snapshot, takeSnapshotSnapshotPutFail, setUp, tearDown, 0, fsm_snapshot_async_params)
+{
+    struct fixture *f = data;
+    (void)params;
+
+    SET_FAULTY_SNAPSHOT_PUT();
+
+    /* Set very low threshold and trailing entries number */
+    SET_SNAPSHOT_THRESHOLD(3);
+    SET_SNAPSHOT_TRAILING(1);
+
+    /* Apply a few of entries, to force a snapshot to be taken. */
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+
+    /* No crash or leaks have occurred */
+    return MUNIT_OK;
+}
+
+TEST(snapshot, takeSnapshotAsyncWorkFail, setUp, tearDown, 0, fsm_snapshot_async_params)
+{
+    struct fixture *f = data;
+    (void)params;
+
+    SET_FAULTY_ASYNC_WORK();
+
+    /* Set very low threshold and trailing entries number */
+    SET_SNAPSHOT_THRESHOLD(3);
+    SET_SNAPSHOT_TRAILING(1);
+
+    /* Apply a few of entries, to force a snapshot to be taken. */
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+
+    /* No crash or leaks have occurred */
+    return MUNIT_OK;
+}
+
+TEST(snapshot, takeSnapshotAsyncFail, setUp, tearDown, 0, fsm_snapshot_only_async_params)
+{
+    struct fixture *f = data;
+    (void)params;
+
+    SET_FAULTY_SNAPSHOT_ASYNC();
+
+    /* Set very low threshold and trailing entries number */
+    SET_SNAPSHOT_THRESHOLD(3);
+    SET_SNAPSHOT_TRAILING(1);
+
+    /* Apply a few of entries, to force a snapshot to be taken. */
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+
+    /* No crash or leaks have occurred */
+    return MUNIT_OK;
+}
+
+TEST(snapshot, takeSnapshotFail, setUp, tearDown, 0, fsm_snapshot_async_params)
+{
+    struct fixture *f = data;
+    (void)params;
+
+    SET_FAULTY_SNAPSHOT();
+
+    /* Set very low threshold and trailing entries number */
+    SET_SNAPSHOT_THRESHOLD(3);
+    SET_SNAPSHOT_TRAILING(1);
+
+    /* Apply a few of entries, to force a snapshot to be taken. */
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+
+    /* No crash or leaks have occurred */
     return MUNIT_OK;
 }

--- a/test/integration/test_uv_work.c
+++ b/test/integration/test_uv_work.c
@@ -1,0 +1,103 @@
+#include <unistd.h>
+
+#include "../lib/dir.h"
+#include "../lib/loop.h"
+#include "../lib/runner.h"
+#include "../lib/uv.h"
+#include "../../src/uv.h"
+
+/******************************************************************************
+ *
+ * Fixture
+ *
+ *****************************************************************************/
+
+struct fixture
+{
+    FIXTURE_UV_DEPS;
+    FIXTURE_UV;
+};
+
+struct result
+{
+    int rv;      /* Indicate success or failure of the work */
+    int counter; /* Proof that work was performed */
+    bool done;   /* To check test termination */
+};
+
+/******************************************************************************
+ *
+ * Set up and tear down.
+ *
+ *****************************************************************************/
+
+static void *setUp(const MunitParameter params[], void *user_data)
+{
+    struct fixture *f = munit_malloc(sizeof *f);
+    SETUP_UV_DEPS;
+    SETUP_UV;
+    return f;
+}
+
+static void tearDownDeps(void *data)
+{
+    struct fixture *f = data;
+    if (f == NULL) {
+        return;
+    }
+    TEAR_DOWN_UV_DEPS;
+    free(f);
+}
+
+static void tearDown(void *data)
+{
+    struct fixture *f = data;
+    if (f == NULL) {
+        return;
+    }
+    TEAR_DOWN_UV;
+    tearDownDeps(f);
+}
+
+/******************************************************************************
+ *
+ * UvAsyncWork
+ *
+ *****************************************************************************/
+
+static void asyncWorkCbAssertResult(struct raft_io_async_work *req, int status)
+{
+    struct result *r = req->data;
+    munit_assert_int(status, ==, r->rv);
+    munit_assert_int(r->counter, ==, 1);
+    r->done = true;
+}
+
+static int asyncWorkFn(struct raft_io_async_work *req)
+{
+    struct result *r = req->data;
+    sleep(1);
+    r->counter = 1;
+    return r->rv;
+}
+
+SUITE(UvAsyncWork)
+
+static char* rvs[] = { "-1", "0", "1", "37", NULL };
+static MunitParameterEnum rvs_params[] = {
+    { "rv", rvs },
+    { NULL, NULL },
+};
+
+TEST(UvAsyncWork, work, setUp, tearDown, 0, rvs_params)
+{
+    struct fixture *f = data;
+    struct result res = {0};
+    struct raft_io_async_work req = {0};
+    res.rv = (int)strtol(munit_parameters_get(params, "rv"), NULL, 0);
+    req.data = &res;
+    req.work = asyncWorkFn;
+    UvAsyncWork(&f->io, &req, asyncWorkCbAssertResult);
+    LOOP_RUN_UNTIL(&res.done);
+    return MUNIT_OK;
+}

--- a/test/lib/fsm.c
+++ b/test/lib/fsm.c
@@ -8,6 +8,8 @@ struct fsm
 {
     int x;
     int y;
+    int lock;
+    void *data;
 };
 
 /* Command codes */
@@ -104,17 +106,84 @@ static int fsmSnapshot(struct raft_fsm *fsm,
     return fsmEncodeSnapshot(f->x, f->y, bufs, n_bufs);
 }
 
-void FsmInit(struct raft_fsm *fsm)
+static int fsmSnapshotInitialize(struct raft_fsm *fsm,
+	                         struct raft_buffer *bufs[],
+	                         unsigned *n_bufs)
 {
+    (void) bufs;
+    (void) n_bufs;
+    struct fsm *f = fsm->data;
+    munit_assert_int(f->lock, ==, 0);
+    f->lock = 1;
+    f->data = raft_malloc(8); /* Detect proper cleanup in finalize */
+    munit_assert_ptr_not_null(f->data);
+    return 0;
+}
+
+static int fsmSnapshotAsync(struct raft_fsm *fsm,
+	                    struct raft_buffer *bufs[],
+	                    unsigned *n_bufs)
+{
+    struct fsm *f = fsm->data;
+    return fsmEncodeSnapshot(f->x, f->y, bufs, n_bufs);
+}
+
+static int fsmSnapshotFinalize(struct raft_fsm *fsm,
+	                         struct raft_buffer *bufs[],
+	                         unsigned *n_bufs)
+{
+    (void) bufs;
+    (void) n_bufs;
+    struct fsm *f = fsm->data;
+    if (*bufs != NULL) {
+        for (unsigned i = 0; i < *n_bufs; ++i) {
+            raft_free((*bufs)[i].base);
+        }
+        raft_free(*bufs);
+    }
+    *bufs = NULL;
+    *n_bufs = 0;
+    munit_assert_int(f->lock, ==, 1);
+    f->lock = 0;
+    raft_free(f->data);
+    return 0;
+}
+
+void FsmInit(struct raft_fsm *fsm, int version)
+{
+    struct fsm *f = munit_malloc(sizeof *fsm);
+    memset(fsm, 'x', sizeof(*fsm)); /* Fill  with garbage */
+
+    f->x = 0;
+    f->y = 0;
+    f->lock = 0;
+
+    fsm->version = version;
+    fsm->data = f;
+    fsm->apply = fsmApply;
+    fsm->snapshot = fsmSnapshot;
+    fsm->restore = fsmRestore;
+    if (version > 1) {
+        fsm->snapshot_async = NULL;
+        fsm->snapshot_finalize = NULL;
+    }
+}
+
+void FsmInitAsync(struct raft_fsm *fsm, int version)
+{
+    munit_assert_int(version, >, 1);
     struct fsm *f = munit_malloc(sizeof *fsm);
 
     f->x = 0;
     f->y = 0;
+    f->lock = 0;
 
-    fsm->version = 1;
+    fsm->version = version;
     fsm->data = f;
     fsm->apply = fsmApply;
-    fsm->snapshot = fsmSnapshot;
+    fsm->snapshot = fsmSnapshotInitialize;
+    fsm->snapshot_async = fsmSnapshotAsync;
+    fsm->snapshot_finalize = fsmSnapshotFinalize;
     fsm->restore = fsmRestore;
 }
 

--- a/test/lib/fsm.h
+++ b/test/lib/fsm.h
@@ -7,7 +7,10 @@
 
 #include "../../include/raft.h"
 
-void FsmInit(struct raft_fsm *fsm);
+void FsmInit(struct raft_fsm *fsm, int version);
+
+/* Same as FsmInit but with asynchronous snapshots */
+void FsmInitAsync(struct raft_fsm *fsm, int version);
 
 void FsmClose(struct raft_fsm *fsm);
 


### PR DESCRIPTION
This PR introduces:
-  a `raft_io->async_work` method that allows raft to run any workload asynchronously from the main loop.
-  raft_fsm version 2 that introduces the `snapshot_async` and `snapshot_finalize` method. `snapshot_async` is ran through the new `async_work` interface and allows a user of raft to run snapshots out of the main loop.

Updated `version-info` according to https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html 