### PR TITLE
test_compress: Mix in 0 length buffers in tests

### DIFF
--- a/src/compress.c
+++ b/src/compress.c
@@ -44,6 +44,16 @@ int Compress(struct raft_buffer bufs[], unsigned n_bufs,
         src_size += bufs[i].len;
     }
 
+    /* Work around a bug in liblz4 on bionic, in practice raft should only
+     * Compress non-0 length buffers, so this should be fine.
+     * https://github.com/lz4/lz4/issues/157
+     * */
+    if (src_size == 0) {
+        ErrMsgPrintf(errmsg, "total size must be larger then 0");
+        rv = RAFT_INVALID;
+        goto err;
+    }
+
     /* Set LZ4 preferences */
     LZ4F_preferences_t lz4_pref;
     memset(&lz4_pref, 0, sizeof(lz4_pref));

--- a/test/unit/test_byte.c
+++ b/test/unit/test_byte.c
@@ -151,6 +151,21 @@ TEST(byteSha1, abc, NULL, NULL, 0, NULL)
     return MUNIT_OK;
 }
 
+TEST(byteSha1, abcWithZeroLen, NULL, NULL, 0, NULL)
+{
+    struct byteSha1 sha1;
+    uint8_t text[] = "abc";
+    uint8_t garbage[] = "garbage";
+    uint8_t value[20];
+    byteSha1Init(&sha1);
+    byteSha1Update(&sha1, text, sizeof text - 1);
+    /* Update with 0 length buffer doesn't change digest */
+    byteSha1Update(&sha1, garbage, 0);
+    byteSha1Digest(&sha1, value);
+    ASSERT_SHA1(value, "A9993E364706816ABA3E25717850C26C9CD0D89D");
+    return MUNIT_OK;
+}
+
 TEST(byteSha1, abcbd, NULL, NULL, 0, NULL)
 {
     struct byteSha1 sha1;


### PR DESCRIPTION
`dqlite` snapshots will start to present buffers to raft that can have 0 length and contain a base pointer that is NULL because the WAL will be contained in a separate buffer during a snapshot and the WAL can have 0 size, so ensure these cases are tested.

An added constraint in this PR is that the total size of buffers that will be compressed must be larger than 0, this is a workaround for a bug in `liblz4` on bionic.