### PR TITLE
Add raft_uv_tcp_set_bind_address().

### DIFF
--- a/include/raft/uv.h
+++ b/include/raft/uv.h
@@ -243,4 +243,19 @@ RAFT_API int raft_uv_tcp_init(struct raft_uv_transport *t,
  */
 RAFT_API void raft_uv_tcp_close(struct raft_uv_transport *t);
 
+/**
+ * Set the IP address and port that the listening socket will bind to.
+ *
+ * By default the socket will bind to the address provided in
+ * raft_init(), which may be inconvenient if running your application in a
+ * container, for example.
+ *
+ * The @address argument must be an IPv4 dotted quad IP address and port, e.g.
+ * "0.0.0.0:8080". If you do not provide a port, the default of 8080 will be
+ * used. The port given here *must* match the port given to raft_init().
+ *
+ * Must be called before raft_init().
+ */
+RAFT_API int raft_uv_tcp_set_bind_address(struct raft_uv_transport *t, const char *address);
+
 #endif /* RAFT_UV_H */

--- a/src/uv_tcp.h
+++ b/src/uv_tcp.h
@@ -20,6 +20,7 @@ struct UvTcp
     queue aborting;                      /* Connections being aborted */
     bool closing;                        /* True after close() is called */
     raft_uv_transport_close_cb close_cb; /* Call when it's safe to free us */
+    char *bind_address;                  /* Optional address:port to bind to */
 };
 
 /* Implementation of raft_uv_transport->listen. */

--- a/src/uv_tcp_listen.c
+++ b/src/uv_tcp_listen.c
@@ -284,7 +284,11 @@ int UvTcpListen(struct raft_uv_transport *transport, raft_uv_accept_cb cb)
     t = transport->impl;
     t->accept_cb = cb;
 
-    rv = uvIpParse(t->address, &addr);
+    if (t->bind_address == NULL) {
+        rv = uvIpParse(t->address, &addr);
+    } else {
+        rv = uvIpParse(t->bind_address, &addr);
+    }
     if (rv != 0) {
         return rv;
     }


### PR DESCRIPTION
This allows an application to choose which network interface the
listening socket will bind to.

Closes #273.

Signed-off-by: Roger A. Light <roger@atchoo.org>