### PR TITLE
uv_fs: More clear errmsg when UvFsProbeCapabilities fails

### DIFF
--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -779,6 +779,7 @@ int UvFsProbeCapabilities(const char *dir,
     /* Check if we can use direct I/O. */
     rv = probeDirectIO(fd, direct, errmsg);
     if (rv != 0) {
+        ErrMsgWrapf(errmsg, "probe Direct I/O");
         goto err_after_file_open;
     }
 
@@ -795,6 +796,7 @@ int UvFsProbeCapabilities(const char *dir,
     }
     rv = probeAsyncIO(fd, *direct, async, errmsg);
     if (rv != 0) {
+        ErrMsgWrapf(errmsg, "probe Async I/O");
         goto err_after_file_open;
     }
 #endif /* RWF_NOWAIT */

--- a/test/integration/test_uv_init.c
+++ b/test/integration/test_uv_init.c
@@ -160,7 +160,7 @@ TEST(init, oom, setUp, tearDown, 0, oomParams)
     return MUNIT_SKIP;
 #endif
     HEAP_FAULT_ENABLE;
-    INIT_ERROR(f->dir, RAFT_NOMEM, "out of memory");
+    INIT_ERROR(f->dir, RAFT_NOMEM, "probe Direct I/O: out of memory");
     return 0;
 }
 

--- a/test/unit/test_uv_fs.c
+++ b/test/unit/test_uv_fs.c
@@ -353,7 +353,7 @@ TEST(UvFsProbeCapabilities, noResources, DirBtrfsSetUp, DirTearDown, 0, NULL)
         return MUNIT_SKIP;
     }
     PROBE_CAPABILITIES_ERROR(dir, RAFT_IOERR,
-                             "io_setup: resource temporarily unavailable");
+                             "probe Async I/O: io_setup: resource temporarily unavailable");
     AioDestroy(ctx);
     return MUNIT_OK;
 }


### PR DESCRIPTION
Closes https://github.com/canonical/go-dqlite/issues/183

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>