### PR TITLE
Startup recovery

### DIFF
--- a/include/raft/uv.h
+++ b/include/raft/uv.h
@@ -129,6 +129,12 @@ RAFT_API void raft_uv_set_tracer(struct raft_io *io,
                                  struct raft_tracer *tracer);
 
 /**
+ * Enable or disable auto-recovery on startup. Default enabled.
+ */
+RAFT_API void raft_uv_set_auto_recovery(struct raft_io *io,
+                                        bool flag);
+
+/**
  * Callback invoked by the transport implementation when a new incoming
  * connection has been established.
  *

--- a/src/uv.c
+++ b/src/uv.c
@@ -454,7 +454,6 @@ static int uvLoad(struct raft_io *io,
                   size_t *n_entries)
 {
     struct uv *uv;
-    raft_index last_index;
     int rv;
     uv = io->impl;
 
@@ -472,10 +471,8 @@ static int uvLoad(struct raft_io *io,
         tracef("no snapshot");
     }
 
-    last_index = *start_index + *n_entries - 1;
-
     /* Set the index of the next entry that will be appended. */
-    uv->append_next_index = last_index + 1;
+    uv->append_next_index = *start_index + *n_entries;
 
     return 0;
 }

--- a/src/uv.c
+++ b/src/uv.c
@@ -669,6 +669,7 @@ int raft_uv_init(struct raft_io *io,
     QUEUE_INIT(&uv->aborting);
     uv->closing = false;
     uv->close_cb = NULL;
+    uv->auto_recovery = true;
 
     /* Set the raft_io implementation. */
     io->version = 1; /* future-proof'ing */
@@ -745,6 +746,13 @@ void raft_uv_set_tracer(struct raft_io *io, struct raft_tracer *tracer)
     struct uv *uv;
     uv = io->impl;
     uv->tracer = tracer;
+}
+
+void raft_uv_set_auto_recovery(struct raft_io *io, bool flag)
+{
+    struct uv *uv;
+    uv = io->impl;
+    uv->auto_recovery = flag;
 }
 
 #undef tracef

--- a/src/uv.h
+++ b/src/uv.h
@@ -91,6 +91,7 @@ struct uv
     queue aborting;                      /* Cleanups upon errors or shutdown */
     bool closing;                        /* True if we are closing */
     raft_io_close_cb close_cb;           /* Invoked when finishing closing */
+    bool auto_recovery;                  /* Try to recover from corrupt segments */
 };
 
 /* Implementation of raft_io->truncate. */

--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -535,6 +535,33 @@ int UvFsRemoveFile(const char *dir, const char *filename, char *errmsg)
     return 0;
 }
 
+int UvFsRenameFile(const char *dir,
+		   const char *filename1,
+		   const char *filename2,
+		   char *errmsg)
+{
+    char path1[UV__PATH_SZ];
+    char path2[UV__PATH_SZ];
+    int rv;
+
+    rv = UvOsJoin(dir, filename1, path1);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
+    rv = UvOsJoin(dir, filename2, path2);
+    if (rv != 0) {
+        return RAFT_INVALID;
+    }
+
+    rv = UvOsRename(path1, path2);
+    if (rv != 0) {
+        UvOsErrMsg(errmsg, "rename", rv);
+        return rv;
+    }
+
+    return 0;
+}
+
 int UvFsTruncateAndRenameFile(const char *dir,
                               size_t size,
                               const char *filename1,

--- a/src/uv_fs.h
+++ b/src/uv_fs.h
@@ -97,6 +97,12 @@ int UvFsTruncateAndRenameFile(const char *dir,
                               const char *filename2,
                               char *errmsg);
 
+/* Synchronously rename a file. */
+int UvFsRenameFile(const char *dir,
+		   const char *filename1,
+		   const char *filename2,
+		   char *errmsg);
+
 /* Return information about the I/O capabilities of the underlying file
  * system.
  *

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -466,7 +466,7 @@ static bool uvContentHasOnlyTrailingZeros(const struct raft_buffer *buf,
 }
 
 /* Load all entries contained in an open segment. */
-static int uvLoadOpenSegment(struct uv *uv,
+static int uvSegmentLoadOpen(struct uv *uv,
                              struct uvSegmentInfo *info,
                              struct raft_entry *entries[],
                              size_t *n,
@@ -828,7 +828,7 @@ int uvSegmentLoadAll(struct uv *uv,
         tracef("load segment %s", info->filename);
 
         if (info->is_open) {
-            rv = uvLoadOpenSegment(uv, info, entries, n_entries, &next_index);
+            rv = uvSegmentLoadOpen(uv, info, entries, n_entries, &next_index);
             ErrMsgWrapf(uv->io->errmsg, "load open segment %s", info->filename);
             if (rv != 0) {
                 goto err;

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -895,7 +895,7 @@ int uvSegmentLoadAll(struct uv *uv,
             rv = uvSegmentLoadOpen(uv, info, entries, n_entries, &next_index);
             ErrMsgWrapf(uv->io->errmsg, "load open segment %s", info->filename);
             if (rv != 0) {
-                if (rv == RAFT_CORRUPT) {
+                if (rv == RAFT_CORRUPT && uv->auto_recovery) {
                     uvRecoverFromCorruptSegment(uv, i, infos, n_infos);
                 }
                 goto err;
@@ -919,7 +919,7 @@ int uvSegmentLoadAll(struct uv *uv,
             if (rv != 0) {
                 ErrMsgWrapf(uv->io->errmsg, "load closed segment %s",
                             info->filename);
-                if (rv == RAFT_CORRUPT) {
+                if (rv == RAFT_CORRUPT && uv->auto_recovery) {
                     uvRecoverFromCorruptSegment(uv, i, infos, n_infos);
                 }
                 goto err;

--- a/test/integration/test_uv_load.c
+++ b/test/integration/test_uv_load.c
@@ -277,6 +277,17 @@ struct snapshot
         munit_assert_string_equal(f->io.errmsg, ERRMSG);          \
     } while (0)
 
+#define LOAD_ERROR_NO_RECOVER(RV, ERRMSG)                         \
+    do {                                                          \
+        LOAD_VARS;                                                \
+        SETUP_UV;                                                 \
+        raft_uv_set_auto_recovery(&f->io, false);                 \
+        _rv = f->io.load(&f->io, &_term, &_voted_for, &_snapshot, \
+                         &_start_index, &_entries, &_n);          \
+        munit_assert_int(_rv, ==, RV);                            \
+        munit_assert_string_equal(f->io.errmsg, ERRMSG);          \
+    } while (0)
+
 #define _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)              \
         _rv = f->io.load(&f->io, &_term, &_voted_for, &_snapshot,             \
                          &_start_index, &_entries, &_n);                      \
@@ -327,6 +338,18 @@ struct snapshot
         unsigned _i;                                                          \
         SETUP_UV;                                                             \
         _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)              \
+    } while (0)
+
+/* Same as LOAD but with auto_recovery set to false */
+#define LOAD_NO_RECOVER(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, ENTRIES_DATA, N_ENTRIES) \
+    do {                                                                                 \
+        LOAD_VARS;                                                                       \
+        void *_batch = NULL;                                                             \
+        uint64_t _data = ENTRIES_DATA;                                                   \
+        unsigned _i;                                                                     \
+        SETUP_UV;                                                                        \
+        raft_uv_set_auto_recovery(&f->io, false);                                        \
+        _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)                         \
     } while (0)
 
 /* Same as LOAD without SETUP_UV */
@@ -637,26 +660,42 @@ TEST(load, twoOpenSegmentsFirstCorrupt, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
+    /* Load is successful and equals pristine condition. */
+    LOAD(0,    /* term                           */
+	 0,    /* voted for                      */
+	 NULL, /* snapshot                       */
+	 1,    /* start index                    */
+	 0,    /* data for first loaded entry    */
+	 0     /* n entries                      */
+    );
 
     /* The open segments are renamed, and there is no closed segment. */
     munit_assert_false(HAS_OPEN_SEGMENT_FILE(1));
     munit_assert_false(HAS_OPEN_SEGMENT_FILE(2));
     munit_assert_false(HAS_CLOSED_SEGMENT_FILE(1, 1));
 
-    /* Second load is successful and equals pristine condition. */
-    LOAD_NO_SETUP(0,    /* term                                              */
-	          0,    /* voted for                                         */
-	          NULL, /* snapshot                                          */
-	          1,    /* start index                                       */
-	          0,    /* data for first loaded entry    */
-	          0     /* n entries                                         */
-    );
-
     return MUNIT_OK;
 }
 
+/* The data directory has two open segments, the first one has a corrupt header. */
+TEST(load, twoOpenSegmentsFirstCorruptNoRecovery, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND(1, 1);
+    UNFINALIZE(1, 1, 1);
+    DirWriteFileWithZeros(f->dir, "open-2", SEGMENT_SIZE);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
+
+    /* The open segments are renamed, and there is no closed segment. */
+    munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
+    munit_assert_true(HAS_OPEN_SEGMENT_FILE(2));
+    return MUNIT_OK;
+}
 
 /* The data directory has a valid open segment. */
 TEST(load, openSegment, setUp, tearDown, 0, NULL)
@@ -872,15 +911,51 @@ TEST(load, openSegmentWithEntriesPastSnapshot, setUp, tearDown, 0, NULL)
 
 /* The data directory has a closed segment whose filename encodes a number of
  * entries which is different then ones it actually contains. */
+TEST(load, closedSegmentWithInconsistentFilenameNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND(3, 1);
+    DirRenameFile(f->dir, "0000000000000001-0000000000000003",
+                  "0000000000000001-0000000000000004");
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load closed segment 0000000000000001-0000000000000004: found 3 "
+               "entries (expected 4)");
+    return MUNIT_OK;
+}
+
+/* The data directory has a closed segment whose filename encodes a number of
+ * entries which is different then ones it actually contains. */
 TEST(load, closedSegmentWithInconsistentFilename, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     APPEND(3, 1);
     DirRenameFile(f->dir, "0000000000000001-0000000000000003",
                   "0000000000000001-0000000000000004");
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load closed segment 0000000000000001-0000000000000004: found 3 "
-               "entries (expected 4)");
+    /* Load in pristine condition */
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         NULL, /* snapshot */
+         1,         /* start index */
+         0,         /* data for first loaded entry */
+         0          /* n entries */
+    );
+    return MUNIT_OK;
+}
+
+/* The data directory has a closed segment with entries that are no longer
+ * needed, since they are included in a snapshot. It also has an open segment,
+ * however that does not have enough entries to reach the snapshot last
+ * index. */
+TEST(load, openSegmentWithEntriesBehindSnapshotNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND(1, 1);
+    APPEND(1, 2);
+    SNAPSHOT_PUT(1, 3, 1);
+    UNFINALIZE(2, 2, 1);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "last entry on disk has index 2, which is behind last "
+               "snapshot's index 3");
     return MUNIT_OK;
 }
 
@@ -891,13 +966,22 @@ TEST(load, closedSegmentWithInconsistentFilename, setUp, tearDown, 0, NULL)
 TEST(load, openSegmentWithEntriesBehindSnapshot, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
+    struct snapshot snapshot = {
+        1, /* term */
+        3, /* index */
+        1  /* data */
+    };
     APPEND(1, 1);
     APPEND(1, 2);
     SNAPSHOT_PUT(1, 3, 1);
     UNFINALIZE(2, 2, 1);
-    LOAD_ERROR(RAFT_CORRUPT,
-               "last entry on disk has index 2, which is behind last "
-               "snapshot's index 3");
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         &snapshot, /* snapshot */
+         4,         /* start index */
+         0,         /* data for first loaded entry */
+         0          /* n entries */
+    );
     return MUNIT_OK;
 }
 
@@ -926,6 +1010,23 @@ TEST(load, openSegmentNoClosedSegmentsSnapshotPresent, setUp, tearDown, 0, NULL)
 
 /* The data directory contains a snapshot and an open segment with a corrupt
  * format header and no closed segments. */
+TEST(load, corruptOpenSegmentNoClosedSegmentsSnapshotPresentNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    SNAPSHOT_PUT(1, 3, 1);
+    APPEND(1, 4);
+    UNFINALIZE(4, 4, 1);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
+    return MUNIT_OK;
+}
+
+/* The data directory contains a snapshot and an open segment with a corrupt
+ * format header and no closed segments. */
 TEST(load, corruptOpenSegmentNoClosedSegmentsSnapshotPresent, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -941,19 +1042,32 @@ TEST(load, corruptOpenSegmentNoClosedSegmentsSnapshotPresent, setUp, tearDown, 0
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
-
-    /* Open segment has been renamed during the first load */
-    munit_assert_false(DirHasFile(f->dir, "open-1"));
-    /* Next load is successful. */
-    LOAD_NO_SETUP(0,         /* term */
-                  0,         /* voted for */
-                  &snapshot, /* snapshot */
-                  4,         /* start index */
-                  1,         /* data for first loaded entry */
-                  1          /* n entries */
+    /* Load is successful. */
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         &snapshot, /* snapshot */
+         4,         /* start index */
+         1,         /* data for first loaded entry */
+         1          /* n entries */
     );
+    return MUNIT_OK;
+}
+
+/* The data directory contains a snapshot and an open segment with a corrupt
+ * format header and a closed segment. */
+TEST(load, corruptOpenSegmentClosedSegmentSnapshotPresentNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    SNAPSHOT_PUT(1, 3, 1);
+    APPEND(1, 4);
+    APPEND(1, 5);
+    UNFINALIZE(5, 5, 1);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
@@ -975,19 +1089,18 @@ TEST(load, corruptOpenSegmentClosedSegmentSnapshotPresent, setUp, tearDown, 0, N
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
 
-    /* Open segment has been renamed during the first load */
-    munit_assert_false(DirHasFile(f->dir, "open-1"));
-    /* Next load is successful. */
-    LOAD_NO_SETUP(0,         /* term */
-                  0,         /* voted for */
-                  &snapshot, /* snapshot */
-                  4,         /* start index */
-                  4,         /* data for first loaded entry */
-                  1          /* n entries */
+    /* Load is successful. */
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         &snapshot, /* snapshot */
+         4,         /* start index */
+         4,         /* data for first loaded entry */
+         1          /* n entries */
     );
+
+    /* Open segment has been renamed */
+    munit_assert_false(DirHasFile(f->dir, "open-1"));
     return MUNIT_OK;
 }
 
@@ -1010,19 +1123,52 @@ TEST(load, corruptOpenSegmentClosedSegmentsSnapshotPresent, setUp, tearDown, 0, 
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
 
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         &snapshot, /* snapshot */
+         4,         /* start index */
+         4,         /* data for first loaded entry */
+         2          /* n entries */
+    );
     /* Open segment has been renamed during the first load */
     munit_assert_false(DirHasFile(f->dir, "open-1"));
-    /* Next load is successful. */
-    LOAD_NO_SETUP(0,         /* term */
-                  0,         /* voted for */
-                  &snapshot, /* snapshot */
-                  4,         /* start index */
-                  4,         /* data for first loaded entry */
-                  2          /* n entries */
-    );
+    return MUNIT_OK;
+}
+
+/* The data directory contains a snapshot and an open segment with a corrupt
+ * format header and multiple closed segment. */
+TEST(load, corruptOpenSegmentClosedSegmentsSnapshotPresentNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    SNAPSHOT_PUT(1, 3, 1);
+    APPEND(1, 4);
+    APPEND(1, 5);
+    APPEND(1, 6);
+    UNFINALIZE(6, 6, 1);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
+    return MUNIT_OK;
+}
+
+/* The data directory contains a closed segment and an open segment with a corrupt
+ * format header and no snapshot. */
+TEST(load, corruptOpenSegmentClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND(4, 1);
+    APPEND(1, 5);
+    UNFINALIZE(5, 5, 1);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
@@ -1038,19 +1184,36 @@ TEST(load, corruptOpenSegmentClosedSegments, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
+    /* load is successful. */
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         NULL,      /* snapshot */
+         1,         /* start index */
+         1,         /* data for first loaded entry */
+         4          /* n entries */
+    );
+    /* Open segment has been renamed */
+    munit_assert_false(DirHasFile(f->dir, "open-1"));
+    return MUNIT_OK;
+}
+
+/* The data directory contains a closed segment and two open segments.
+ * The first open segment has a corrupt header. */
+TEST(load, corruptOpenSegmentsClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND(3, 1);
+    APPEND(1, 4);
+    APPEND(1, 5);
+    UNFINALIZE(4, 4, 1);
+    UNFINALIZE(5, 5, 2);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
                "load open segment open-1: unexpected format version 0");
 
-    /* Open segment has been renamed during the first load */
-    munit_assert_false(DirHasFile(f->dir, "open-1"));
-    /* Next load is successful. */
-    LOAD_NO_SETUP(0,         /* term */
-                  0,         /* voted for */
-                  NULL,      /* snapshot */
-                  1,         /* start index */
-                  1,         /* data for first loaded entry */
-                  4          /* n entries */
-    );
     return MUNIT_OK;
 }
 
@@ -1068,20 +1231,38 @@ TEST(load, corruptOpenSegmentsClosedSegments, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
 
-    /* Open segments have been renamed during the first load */
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         NULL,      /* snapshot */
+         1,         /* start index */
+         1,         /* data for first loaded entry */
+         3          /* n entries */
+    );
+
+    /* Open segments have been renamed */
     munit_assert_false(DirHasFile(f->dir, "open-1"));
     munit_assert_false(DirHasFile(f->dir, "open-2"));
-    /* Next load is successful. */
-    LOAD_NO_SETUP(0,         /* term */
-                  0,         /* voted for */
-                  NULL,      /* snapshot */
-                  1,         /* start index */
-                  1,         /* data for first loaded entry */
-                  3          /* n entries */
-    );
+    return MUNIT_OK;
+}
+
+/* The data directory contains a closed segment and two open segments.
+ * The second open segment has a corrupt header. */
+TEST(load, corruptLastOpenSegmentClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND(3, 1);
+    APPEND(1, 4);
+    APPEND(1, 5);
+    UNFINALIZE(4, 4, 1);
+    UNFINALIZE(5, 5, 2);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-2", &version, sizeof version, 0);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load open segment open-2: unexpected format version 0");
+
     return MUNIT_OK;
 }
 
@@ -1099,19 +1280,16 @@ TEST(load, corruptLastOpenSegmentClosedSegments, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-2", &version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load open segment open-2: unexpected format version 0");
 
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         NULL,      /* snapshot */
+         1,         /* start index */
+         1,         /* data for first loaded entry */
+         4          /* n entries */
+    );
     /* Open segment has been renamed during the first load */
     munit_assert_false(DirHasFile(f->dir, "open-2"));
-    /* Next load is successful. */
-    LOAD_NO_SETUP(0,         /* term */
-                  0,         /* voted for */
-                  NULL,      /* snapshot */
-                  1,         /* start index */
-                  1,         /* data for first loaded entry */
-                  4          /* n entries */
-    );
     return MUNIT_OK;
 }
 
@@ -1141,6 +1319,28 @@ TEST(load, closedSegmentsOverlappingWithSnapshot, setUp, tearDown, 0, NULL)
 
 /* The data directory has several closed segments, the last of which is corrupt.
  * There is a snapshot. */
+TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    SNAPSHOT_PUT(1, 4, 1);
+    APPEND(1, 5);
+    APPEND(2, 6);
+    APPEND(2, 8);
+
+    /* Corrupt the last closed segment */
+    size_t offset =
+        WORD_SIZE /* Format version */ + WORD_SIZE / 2 /* Header checksum */;
+    uint32_t corrupted = 123456789;
+    DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 9), &corrupted,
+                     sizeof corrupted, offset);
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load closed segment 0000000000000008-0000000000000009: entries "
+               "batch 1 starting at byte 8: data checksum mismatch");
+    return MUNIT_OK;
+}
+
+/* The data directory has several closed segments, the last of which is corrupt.
+ * There is a snapshot. */
 TEST(load, closedSegmentsWithSnapshotLastSegmentCorrupt, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -1160,16 +1360,12 @@ TEST(load, closedSegmentsWithSnapshotLastSegmentCorrupt, setUp, tearDown, 0, NUL
     uint32_t corrupted = 123456789;
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 9), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load closed segment 0000000000000008-0000000000000009: entries "
-               "batch 1 starting at byte 8: data checksum mismatch");
-
-    LOAD_NO_SETUP(0,         /* term */
-                  0,         /* voted for */
-                  &snapshot, /* snapshot */
-                  5,         /* start index */
-                  5,         /* data for first loaded entry */
-                  3          /* n entries */
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         &snapshot, /* snapshot */
+         5,         /* start index */
+         5,         /* data for first loaded entry */
+         3          /* n entries */
     );
     return MUNIT_OK;
 }
@@ -1198,22 +1394,42 @@ TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptOpenSegment, setUp, tearD
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 8), &corrupted,
                      sizeof corrupted, offset);
     munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
-    LOAD_ERROR(RAFT_CORRUPT,
-               "load closed segment 0000000000000008-0000000000000008: entries "
-               "batch 1 starting at byte 8: data checksum mismatch");
 
-    munit_assert_false(HAS_OPEN_SEGMENT_FILE(1));
-
-    LOAD_NO_SETUP(0,         /* term */
-                  0,         /* voted for */
-                  &snapshot, /* snapshot */
-                  5,         /* start index */
-                  5,         /* data for first loaded entry */
-                  3          /* n entries */
+    LOAD(0,         /* term */
+         0,         /* voted for */
+         &snapshot, /* snapshot */
+         5,         /* start index */
+         5,         /* data for first loaded entry */
+         3          /* n entries */
     );
+    munit_assert_false(HAS_OPEN_SEGMENT_FILE(1));
     return MUNIT_OK;
 }
 
+/* The data directory has several closed segments, the last of which is corrupt.
+ * There is an open segment and a snapshot. */
+TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptOpenSegmentNoRecover, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    SNAPSHOT_PUT(1, 4, 1);
+    APPEND(1, 5);
+    APPEND(2, 6);
+    APPEND(1, 8);
+    APPEND(1, 9);
+    UNFINALIZE(9, 9, 1);
+
+    /* Corrupt the last closed segment */
+    size_t offset =
+        WORD_SIZE /* Format version */ + WORD_SIZE / 2 /* Header checksum */;
+    uint32_t corrupted = 123456789;
+    DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 8), &corrupted,
+                     sizeof corrupted, offset);
+    munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
+               "load closed segment 0000000000000008-0000000000000008: entries "
+               "batch 1 starting at byte 8: data checksum mismatch");
+    return MUNIT_OK;
+}
 
 /* The data directory has several closed segments, the second to last one of which is corrupt.
  * There is a snapshot. */
@@ -1360,7 +1576,7 @@ TEST(load, closedSegmentWithCorruptedBatchHeader, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR(RAFT_CORRUPT,
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
                "load closed segment 0000000000000001-0000000000000001: entries "
                "batch 1 starting at byte 8: header checksum mismatch");
     return MUNIT_OK;
@@ -1376,7 +1592,7 @@ TEST(load, closedSegmentWithCorruptedBatchData, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR(RAFT_CORRUPT,
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
                "load closed segment 0000000000000001-0000000000000001: entries "
                "batch 1 starting at byte 8: data checksum mismatch");
     return MUNIT_OK;
@@ -1390,7 +1606,7 @@ TEST(load, closedSegmentWithBadIndex, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     APPEND(1, 2);
     DirRemoveFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1));
-    LOAD_ERROR(RAFT_CORRUPT,
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
                "unexpected closed segment 0000000000000002-0000000000000002: "
                "first index should have been 1");
     return MUNIT_OK;
@@ -1401,7 +1617,7 @@ TEST(load, emptyClosedSegment, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     DirWriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), NULL, 0);
-    LOAD_ERROR(
+    LOAD_ERROR_NO_RECOVER(
         RAFT_CORRUPT,
         "load closed segment 0000000000000001-0000000000000001: file is empty");
     return MUNIT_OK;
@@ -1413,7 +1629,7 @@ TEST(load, closedSegmentWithBadFormat, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     uint8_t buf[8] = {2, 0, 0, 0, 0, 0, 0, 0};
     DirWriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), buf, sizeof buf);
-    LOAD_ERROR(RAFT_CORRUPT,
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
                "load closed segment 0000000000000001-0000000000000001: "
                "unexpected format version 2");
     return MUNIT_OK;
@@ -1440,7 +1656,7 @@ TEST(load, openSegmentWithZeroFormatAndThenData, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     UNFINALIZE(1, 1, 1);
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
                "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
@@ -1453,7 +1669,7 @@ TEST(load, openSegmentWithBadFormat, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     UNFINALIZE(1, 1, 1);
     DirOverwriteFile(f->dir, "open-1", version, sizeof version, 0);
-    LOAD_ERROR(RAFT_CORRUPT,
+    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
                "load open segment open-1: unexpected format version 2");
     return MUNIT_OK;
 }

--- a/test/unit/test_uv_fs.c
+++ b/test/unit/test_uv_fs.c
@@ -394,3 +394,41 @@ TEST(UvFsMakeFile, exists, DirSetUp, DirTearDown, 0, NULL)
     munit_assert_int(rv, !=, 0);
     return MUNIT_OK;
 }
+
+/******************************************************************************
+ *
+ * UvFsRenameFile
+ *
+ *****************************************************************************/
+
+SUITE(UvFsRenameFile)
+
+TEST(UvFsRenameFile, rename, DirSetUp, DirTearDown, 0, NULL)
+{
+    const char *dir = data;
+    int rv;
+    char errmsg[RAFT_ERRMSG_BUF_SIZE];
+    struct raft_buffer bufs[2] = {{0},{0}};
+    rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
+    munit_assert_int(rv, ==, 0);
+    rv = UvFsRenameFile(dir, "foo", "bar", errmsg);
+    munit_assert_int(rv, ==, 0);
+    munit_assert_false(DirHasFile(dir, "foo"));
+    munit_assert_true(DirHasFile(dir, "bar"));
+    return MUNIT_OK;
+}
+
+/* rename to same name */
+TEST(UvFsRenameFile, same, DirSetUp, DirTearDown, 0, NULL)
+{
+    const char *dir = data;
+    int rv;
+    char errmsg[RAFT_ERRMSG_BUF_SIZE];
+    struct raft_buffer bufs[2] = {{0},{0}};
+    rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
+    munit_assert_int(rv, ==, 0);
+    rv = UvFsRenameFile(dir, "foo", "foo", errmsg);
+    munit_assert_int(rv, ==, 0);
+    munit_assert_true(DirHasFile(dir, "foo"));
+    return MUNIT_OK;
+}


### PR DESCRIPTION
This PR attempts to move corrupt segment files out of the way at startup. Once moved out of the way, the next startup can complete successfully requiring no manual intervention. The renamed files are named "corrupt-{timestamp}-{filename}" and are kept around in case they would contain useful data.

The logic is as follows:
- open segments: Are basically only renamed in case of an invalid format header, the other cases are already covered. If an open segment is corrupt, the other open segments are renamed too. In case they contained valid data, raft wouldn't attempt to load the data, because loading it could lead to missing transactions that were part of the corrupt segment leading to an inconsistent state of the log.
- closed segments: Are renamed when they are corrupt and if they are the last closed segment file that is found. When they are renamed all open segments are renamed too, for the same reason as above.

This would lead to less manual intervention in projects that make use of libraft, the trade-off is less visibility of the corruption.

