### PR TITLE
Deprecate raft_fixture_init

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -502,20 +502,6 @@ struct raft_io
 };
 
 /*
- * version 1:
- * struct raft_fsm
- * {
- *     int version;
- *     void *data;
- *     int (*apply)(struct raft_fsm *fsm,
- *                  const struct raft_buffer *buf,
- *                  void **result);
- *     int (*snapshot)(struct raft_fsm *fsm,
- *                     struct raft_buffer *bufs[],
- *                     unsigned *n_bufs);
- *     int (*restore)(struct raft_fsm *fsm, struct raft_buffer *buf);
- * };
- *
  * version 2:
  * introduces `snapshot_finalize`, when this method is not NULL, it will
  * always run after a successful call to `snapshot`, whether the snapshot has
@@ -537,6 +523,7 @@ struct raft_fsm
                     struct raft_buffer *bufs[],
                     unsigned *n_bufs);
     int (*restore)(struct raft_fsm *fsm, struct raft_buffer *buf);
+    /* Fields below added since version 2. */
     int (*snapshot_finalize)(struct raft_fsm *fsm,
                              struct raft_buffer *bufs[],
                              unsigned *n_bufs);

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -74,14 +74,23 @@ struct raft_fixture
 };
 
 /**
+ * !!! DEPRECATED users should use `raft_fixture_initialize`. !!!
+ *
  * Initialize a raft cluster fixture with @n servers. Each server will use an
  * in-memory @raft_io implementation and one of the given @fsms. All servers
  * will be initially connected to one another, but they won't be bootstrapped or
  * started.
  */
+__attribute__((deprecated("use raft_fixture_initialize")))
 RAFT_API int raft_fixture_init(struct raft_fixture *f,
                                unsigned n,
                                struct raft_fsm *fsms);
+
+/**
+ * Initialize a raft cluster fixture. Servers can be added by using
+ * `raft_fixture_grow`.
+ */
+RAFT_API int raft_fixture_initialize(struct raft_fixture *f);
 
 /**
  * Release all memory used by the fixture.

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -978,6 +978,15 @@ int raft_fixture_init(struct raft_fixture *f, unsigned n, struct raft_fsm *fsms)
     return 0;
 }
 
+int raft_fixture_initialize(struct raft_fixture *f)
+{
+    f->time = 0;
+    logInit(&f->log);
+    f->commit_index = 0;
+    f->hook = NULL;
+    return 0;
+}
+
 void raft_fixture_close(struct raft_fixture *f)
 {
     unsigned i;

--- a/test/integration/test_fixture.c
+++ b/test/integration/test_fixture.c
@@ -29,8 +29,13 @@ static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
         FsmInit(&f->fsms[i], 2);
     }
 
-    rc = raft_fixture_init(&f->fixture, N_SERVERS, f->fsms);
+    rc = raft_fixture_initialize(&f->fixture);
     munit_assert_int(rc, ==, 0);
+
+    for (i = 0; i < N_SERVERS; i++) {
+        rc = raft_fixture_grow(&f->fixture, &f->fsms[i]);
+        munit_assert_int(rc, ==, 0);
+    }
 
     rc = raft_fixture_configuration(&f->fixture, N_SERVERS, &configuration);
     munit_assert_int(rc, ==, 0);

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -44,11 +44,13 @@
                 atoi(munit_parameters_get(params, CLUSTER_FSM_VERSION_PARAM)); \
         }                                                                      \
         munit_assert_int(_n, >, 0);                                            \
+        _rv = raft_fixture_initialize(&f->cluster);                            \
+        munit_assert_int(_rv, ==, 0);                                          \
         for (_i = 0; _i < _n; _i++) {                                          \
             FsmInit(&f->fsms[_i], _fsm_version);                               \
+            _rv = raft_fixture_grow(&f->cluster, &f->fsms[_i]);                \
+            munit_assert_int(_rv, ==, 0);                                      \
         }                                                                      \
-        _rv = raft_fixture_init(&f->cluster, _n, f->fsms);                     \
-        munit_assert_int(_rv, ==, 0);                                          \
         for (_i = 0; _i < _n; _i++) {                                          \
             raft_set_pre_vote(raft_fixture_get(&f->cluster, _i), _pre_vote);   \
             if (_hb) {                                                         \


### PR DESCRIPTION
Accessing the client-supplied `struct raft_fsm` array can cause memory
errors when the client was compiled against a raft version with an
older, smaller `struct raft_fsm` version when using `raft_fixture_init`.
This happens because the new raft library will stride through the array with the new size,
while the binary, compiled against an older version, will only allocate space
for the old size, this results in corruptions.