### PR TITLE
Seed rand

### DIFF
--- a/test/fuzzy/test_election.c
+++ b/test/fuzzy/test_election.c
@@ -77,7 +77,7 @@ TEST(election, changeReviveOutdated, setup, tear_down, 0, _params)
     CLUSTER_KILL(i);
 
     /* Server i's term will be lower than the term of the election. */
-    CLUSTER_STEP_UNTIL_HAS_LEADER(10000);
+    CLUSTER_STEP_UNTIL_HAS_LEADER(20000);
 
     /* Add some entries to the log */
     CLUSTER_MAKE_PROGRESS;
@@ -85,7 +85,7 @@ TEST(election, changeReviveOutdated, setup, tear_down, 0, _params)
     CLUSTER_KILL_LEADER;
     CLUSTER_STEP_UNTIL_HAS_NO_LEADER(10000);
 
-    /* Reviver server i with an outdated log and term, the cluster
+    /* Revive server i with an outdated log and term, the cluster
      * should be able to elect a new leader */
     CLUSTER_REVIVE(i);
     CLUSTER_STEP_UNTIL_HAS_LEADER(20000);


### PR DESCRIPTION
Noticed a [test failure](https://github.com/canonical/raft/runs/7067972964), increasing timeout should fix this in most cases, it happens because candidates time out at around the same time a couple of times in a row, resulting in having 2 candidates with the same term who won't vote for one another and the votes of all online servers are needed for quorum.

Meanwhile also cleaned up the PRNG seeding in raft_uv.