### PR TITLE
raft: Add 'constructors' for struct raft, raft_fsm & raft_io

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -519,6 +519,12 @@ struct raft_io
                       raft_io_async_work_cb cb);
 };
 
+/**
+ * Creates a struct raft_io. Memory must be freed by the user after calling
+ * raft_close.
+ */
+RAFT_API int raft_io_create(struct raft_io **io);
+
 /*
  * version 2:
  * introduces `snapshot_finalize`, when this method is not NULL, it will
@@ -562,6 +568,12 @@ struct raft_fsm
                           struct raft_buffer *bufs[],
                           unsigned *n_bufs);
 };
+
+/**
+ * Creates a struct raft_fsm. Memory must be freed by the user after calling
+ * raft_close.
+ */
+RAFT_API int raft_fsm_create(struct raft_fsm **fsm);
 
 /**
  * State codes.
@@ -772,6 +784,13 @@ struct raft
     unsigned max_catch_up_rounds;
     unsigned max_catch_up_round_duration;
 };
+
+/**
+ * Creates a struct raft. Memory must be freed by the user after calling
+ * raft_close.
+ */
+RAFT_API int raft_create(struct raft **r);
+
 
 RAFT_API int raft_init(struct raft *r,
                        struct raft_io *io,

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -29,8 +29,8 @@ struct raft_fixture_server
     raft_id id;                /* Server ID. */
     char address[16];          /* Server address (stringified ID). */
     struct raft_tracer tracer; /* Tracer. */
-    struct raft_io io;         /* In-memory raft_io implementation. */
-    struct raft raft;          /* Raft instance. */
+    struct raft_io *io;        /* In-memory raft_io implementation. */
+    struct raft *raft;         /* Raft instance. */
 };
 
 /**

--- a/src/raft.c
+++ b/src/raft.c
@@ -24,6 +24,33 @@
 #define DEFAULT_MAX_CATCH_UP_ROUNDS 10
 #define DEFAULT_MAX_CATCH_UP_ROUND_DURATION (5 * 1000)
 
+int raft_create(struct raft **r)
+{
+    *r = raft_calloc(1, sizeof(**r));
+    if (*r == NULL) {
+        return RAFT_NOMEM;
+    }
+    return 0;
+}
+
+int raft_fsm_create(struct raft_fsm **fsm)
+{
+    *fsm = raft_calloc(1, sizeof(**fsm));
+    if (*fsm == NULL) {
+        return RAFT_NOMEM;
+    }
+    return 0;
+}
+
+int raft_io_create(struct raft_io **io)
+{
+    *io = raft_calloc(1, sizeof(**io));
+    if (*io == NULL) {
+        return RAFT_NOMEM;
+    }
+    return 0;
+}
+
 static int ioFsmCompat(struct raft *r,
                        struct raft_io *io,
                        struct raft_fsm *fsm);


### PR DESCRIPTION
This allows the raft library to allocate enough space for the structs
without depending on the space allocated by the user that could be
compiled against an older version of libraft.

I eventually want to restructure the header files and hide internal
data structures that should not have been exposed.