### PR TITLE
test_uv_tcp_connect: Disable test for certain uv versions

### DIFF
--- a/test/integration/test_uv_tcp_connect.c
+++ b/test/integration/test_uv_tcp_connect.c
@@ -217,6 +217,18 @@ TEST(tcp_connect, closeImmediately, setUp, tearDownDeps, 0, NULL)
 TEST(tcp_connect, closeDuringHandshake, setUp, tearDownDeps, 0, NULL)
 {
     struct fixture *f = data;
+
+    /* This test fails for libuv version >= 1.44.2 due to changes in uv_run
+     * whereby queueing and processing the write_cb happen in the same loop
+     * iteration, not leaving us a chance to close without going through a lot
+     * of hoops.
+     * https://github.com/libuv/libuv/pull/3598 */
+    unsigned incompatible_uv = (1 << 16) | (44 <<  8) | 2;
+    if (uv_version() >= incompatible_uv) {
+        CLOSE;
+        return MUNIT_SKIP;
+    }
+
     CONNECT_CLOSE(2, TCP_SERVER_ADDRESS, 1);
     return MUNIT_OK;
 }


### PR DESCRIPTION
Closes https://github.com/canonical/raft/issues/292

A change introduced in `libuv 1.44.2` causes the write of the handshake data to complete after a single loop iteration, not allowing us a chance to close between the invocation of `uv_write` and the invocation of the `uv_write_cb`. Decided to disable the test for uv versions 1.44.2 and higher. 