### PR TITLE
Uvappend 8-byte alignment

### DIFF
--- a/src/uv.h
+++ b/src/uv.h
@@ -318,7 +318,8 @@ int UvPrepare(struct uv *uv,
  * and then remove it immediately. */
 void UvPrepareClose(struct uv *uv);
 
-/* Implementation of raft_io->append.*/
+/* Implementation of raft_io->append. All the raft_buffers of the raft_entry structs
+ * in the entries array are required to have a len that is a multiple of 8. */
 int UvAppend(struct raft_io *io,
              struct raft_io_append *req,
              const struct raft_entry entries[],

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -753,8 +753,6 @@ int uvSegmentBufferAppend(struct uvSegmentBuffer *b,
     crc2 = 0;
     for (i = 0; i < n_entries; i++) {
         const struct raft_entry *entry = &entries[i];
-        /* TODO: enforce the requirement of 8-byte alignment also in the
-         * higher-level APIs. */
         assert(entry->buf.len % sizeof(uint64_t) == 0);
         memcpy(cursor, entry->buf.base, entry->buf.len);
         crc2 = byteCrc32(cursor, entry->buf.len, crc2);

--- a/test/integration/append_helpers.h
+++ b/test/integration/append_helpers.h
@@ -45,23 +45,24 @@ static void appendCbAssertResult(struct raft_io_append *req, int status)
 
 /* Submit an append request identified by I, with N_ENTRIES entries, each one of
  * size ENTRY_SIZE. When the append request completes, CB will be called
- * and DATA will be available in result->data. */
-#define APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE, CB, DATA)   \
-    struct raft_io_append _req##I;                                  \
-    struct result _result##I = {0, false, DATA};                    \
-    int _rv##I;                                                     \
-    ENTRIES(I, N_ENTRIES, ENTRY_SIZE);                              \
-    _req##I.data = &_result##I;                                     \
-    _rv##I = f->io.append(&f->io, &_req##I, _entries##I, N_ENTRIES, \
-                          CB);                                      \
-    munit_assert_int(_rv##I, ==, 0)
+ * and DATA will be available in result->data. f->io.append is expected to
+ * return RV. */
+#define APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE, CB, DATA, RV) \
+    struct raft_io_append _req##I;                                    \
+    struct result _result##I = {0, false, DATA};                      \
+    int _rv##I;                                                       \
+    ENTRIES(I, N_ENTRIES, ENTRY_SIZE);                                \
+    _req##I.data = &_result##I;                                       \
+    _rv##I = f->io.append(&f->io, &_req##I, _entries##I, N_ENTRIES,   \
+                          CB);                                        \
+    munit_assert_int(_rv##I, ==, RV)
 
 /* Submit an append request identified by I, with N_ENTRIES entries, each one of
  * size ENTRY_SIZE. The default expectation is for the operation to succeed. A
  * custom STATUS can be set with APPEND_EXPECT. */
 #define APPEND_SUBMIT(I, N_ENTRIES, ENTRY_SIZE)                       \
         APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE,               \
-                              appendCbAssertResult, NULL)             \
+                              appendCbAssertResult, NULL, 0)          \
 
 /* Try to submit an append request and assert that the given error code and
  * message are returned. */

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -143,6 +143,17 @@ static void tearDown(void *data)
 
 SUITE(append)
 
+/* Append an entries array containing unaligned buffers. */
+TEST(append, unaligned, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND_SUBMIT_CB_DATA(0, 1, 9, NULL, NULL, RAFT_INVALID);
+    munit_assert_string_equal(f->io.errmsg, "entry buffers must be 8-byte aligned");
+    APPEND_SUBMIT_CB_DATA(1, 3, 63, NULL, NULL, RAFT_INVALID);
+    munit_assert_string_equal(f->io.errmsg, "entry buffers must be 8-byte aligned");
+    return MUNIT_OK;
+}
+
 /* Append the very first batch of entries. */
 TEST(append, first, setUp, tearDownDeps, 0, NULL)
 {

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -657,9 +657,9 @@ TEST(append, barrierOpenSegments, setUp, tearDown, 0, blocking_bool_params)
 		     "0000000000000009-0000000000000012", NULL};
     bd.files = files;
 
-    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
-    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
-    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
 
     struct UvBarrier barrier = {0};
     barrier.data = (void*) &bd;
@@ -693,9 +693,9 @@ TEST(append, blockingBarrierNoOpenSegments, setUp, tearDown, 0, NULL)
     barrier.blocking = true;
     UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
 
-    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
-    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
-    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);
@@ -731,9 +731,9 @@ TEST(append, blockingBarrierSingleOpenSegment, setUp, tearDown, 0, NULL)
     barrier.blocking = true;
     UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
 
-    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
-    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
-    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);
@@ -794,7 +794,7 @@ TEST(append, nonBlockingBarrierLongBlockingTask, setUp, tearDown, 0, NULL)
     barrier.data = (void*) &bd;
     barrier.blocking = false;
     UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier, barrierCbLongWork);
-    APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd, 0);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);
@@ -819,7 +819,7 @@ TEST(append, blockingBarrierLongBlockingTask, setUp, tearDown, 0, NULL)
     barrier.data = (void*) &bd;
     barrier.blocking = true;
     UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier, barrierCbLongWork);
-    APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd);
+    APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd, 0);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);


### PR DESCRIPTION
Should prevent issues like: https://github.com/canonical/raft/issues/304

