### PR TITLE
test/integration/append_helpers: Fix unaligned access

### DIFF
--- a/test/integration/append_helpers.h
+++ b/test/integration/append_helpers.h
@@ -38,7 +38,8 @@ static void appendCbAssertResult(struct raft_io_append *req, int status)
             entry->batch = NULL;                            \
             munit_assert_ptr_not_null(entry->buf.base);     \
             memset(entry->buf.base, 0, entry->buf.len);     \
-            *(uint64_t *)entry->buf.base = f->count;        \
+            uint64_t _temporary = f->count;                 \
+            memcpy(entry->buf.base, &_temporary, 8);        \
             f->count++;                                     \
         }                                                   \
     }


### PR DESCRIPTION
#305 introduced a test with unaligned log entries, but the ENTRIES macro in test/integration/append_helpers.h can generate an unaligned access in this situation.

Should fix the latest Launchpad build failures.

Signed-off-by: Cole Miller <cole.miller@canonical.com>