### PR TITLE
heap: Add raft_heap_get

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1079,6 +1079,19 @@ RAFT_API void raft_heap_set(struct raft_heap *heap);
  */
 RAFT_API void raft_heap_set_default(void);
 
+/**
+ * Return a reference to the current dynamic memory allocator.
+ *
+ * This is intended for use by applications that want to temporarily replace
+ * and then restore the original allocator, or that want to defer to the
+ * original allocator in some circumstances.
+ *
+ * The behavior of attempting to mutate the default allocator through the
+ * pointer returned by this function, including attempting to deallocate
+ * the backing memory, is undefined.
+ */
+RAFT_API const struct raft_heap *raft_heap_get(void);
+
 #undef RAFT__REQUEST
 
 #endif /* RAFT_H */

--- a/src/heap.c
+++ b/src/heap.c
@@ -114,3 +114,8 @@ void raft_heap_set_default(void)
 {
     currentHeap = &defaultHeap;
 }
+
+const struct raft_heap *raft_heap_get(void)
+{
+    return currentHeap;
+}


### PR DESCRIPTION
As part of working on https://github.com/canonical/dqlite/pull/395, I'm trying to add some tests that inject failures of raft_malloc and co., similar to what's already set up for the sqlite3 allocator [here](https://github.com/canonical/dqlite/blob/master/test/lib/heap.c). To implement that, we need (read-only) access to the *current* raft_heap, so that our fault-injecting raft_heap can defer to the original allocator as needed (and so that it's possible to restore the original allocator).

To that end, add a new function `struct raft_heap *raft_heap_get(void)` to raft.h, implemented by simply returning `currentHeap`. We explicitly disallow using the returned pointer to mutate the default allocator.

Signed-off-by: Cole Miller <cole.miller@canonical.com>