### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup dependencies
       run: |
           sudo apt-get update -qq
@@ -70,7 +70,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup dependencies
       run: |
           sudo apt-get update -qq
@@ -108,7 +108,7 @@ jobs:
   build-nolz4-fail:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup dependencies
       run: |
           sudo apt-get update -qq

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,7 @@ jobs:
         os:
           - ubuntu-18.04
           - ubuntu-20.04
+          - ubuntu-22.04
         compiler:
           - gcc
           - clang
@@ -64,6 +65,7 @@ jobs:
         os:
           - ubuntu-18.04
           - ubuntu-20.04
+          - ubuntu-22.04
         compiler:
           - gcc
           - clang
@@ -106,7 +108,7 @@ jobs:
         verbose: true
 
   build-nolz4-fail:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Setup dependencies

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download Coverity Build Tool
         run: |


### PR DESCRIPTION
- Update checkout action to v3. Fixes a Github warning for using Node 12.

- Add ubuntu 22.04 to test matrix. Github is phasing out support for ubuntu 18.04 in april 2023 https://github.com/actions/runner-images/issues/6002 Tests on 18.04 will fail during the "brown-out" periods until then. Add ubuntu 22.04 to test suite to prep for removal of 18.04.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>