### PR TITLE
uv_finalize: Strengthen index assertions

### DIFF
--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -135,13 +135,12 @@ int UvFinalize(struct uv *uv,
                raft_index first_index,
                raft_index last_index)
 {
+    tracef("uv finalize start:%llu end:%llu", first_index, last_index);
     struct uvDyingSegment *segment;
     int rv;
 
-    if (used > 0) {
-        assert(first_index > 0);
-        assert(last_index >= first_index);
-    }
+    assert(first_index > 0);
+    assert(last_index >= first_index);
 
     segment = RaftHeapMalloc(sizeof *segment);
     if (segment == NULL) {


### PR DESCRIPTION
This is an experiment by way of investigating #324. @freeekanayaka confirmed that the last index of a finalizing segment is not supposed to be 0, so I strengthen some assertions in UvFinalize to try to catch that kind of weird situation earlier. (I'm not actually clear on why the `if (used > 0)` is there in the first place.)

Signed-off-by: Cole Miller <cole.miller@canonical.com>