### PR TITLE
Issue 250/membership rollback

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1429,6 +1429,14 @@ static bool shouldTakeSnapshot(struct raft *r)
         return false;
     }
 
+    /* If there's an uncommitted configuration, do nothing. This assures we only
+     * include committed configurations in the snapshot. This also assures that
+     * the log entry containing the uncommitted configuration is still available
+     * when the configuration change has to be rolled back. */
+    if (r->configuration_uncommitted_index != 0) {
+        return false;
+    }
+
     return true;
 }
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -43,6 +43,8 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
     configurationClose(&r->configuration);
     r->configuration = snapshot->configuration;
     r->configuration_index = snapshot->configuration_index;
+    /* The configuration in the snapshot is by definition committed. */
+    r->configuration_uncommitted_index = 0;
     configurationTrace(r, &r->configuration, "configuration restore from snapshot");
 
     r->commit_index = snapshot->index;


### PR DESCRIPTION
Fixes #250. 

The fix ensures the log entry containing the uncommitted config entry is still present in case it has to be rolled back.

Draft: Investigating if this could lead to some form of "snapshot starvation" where a snapshot would never be taken when the config is being changed constantly.

Edit: I think it's possible to never take a snapshot with this addition to the code. The proper fix would be to keep a copy of the last committed configuration around and add that one to the snapshot. This again brings up the problem of the Raft API update #303 , because keeping a copy around will increase the size of `struct raft`.

Edit2: We can probably work around the API limitation (for now), we could probably get the last committed config from the log if it's still there, and if it's not, we could get it from the previous snapshot. One of the 2 has to succeed.