### PR TITLE
Support printing backtrace when an assertion fails

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -222,6 +222,11 @@ endif # LZ4_ENABLED
 
 endif # UV_ENABLED
 
+if BACKTRACE_ENABLED
+libraft_la_CFLAGS += -DRAFT_ASSERT_WITH_BACKTRACE
+libraft_la_LDFLAGS += -lbacktrace
+endif # BACKTRACE_ENABLED
+
 if EXAMPLE_ENABLED
 
 bin_PROGRAMS += \

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,9 @@ AM_CONDITIONAL(LZ4_AVAILABLE, test "x$have_lz4" = "xyes")
 # compression by default.
 AM_CONDITIONAL(LZ4_ENABLED, test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xyes")
 
+AC_ARG_ENABLE(backtrace, AS_HELP_STRING([--enable-backtrace[=ARG]], [print backtrace on assertion failure [default=no]]))
+AM_CONDITIONAL(BACKTRACE_ENABLED, test "x$enable_backtrace" = "xyes")
+
 # The fake I/O implementation and associated fixture is built by default, unless
 # explicitly disabled.
 AC_ARG_ENABLE(fixture, AS_HELP_STRING([--disable-fixture], [do not build the raft_fixture test helper]))

--- a/src/assert.h
+++ b/src/assert.h
@@ -19,6 +19,20 @@ extern void munit_errorf_ex(const char *filename,
     do {                 \
         (void)sizeof(x); \
     } while (0)
+#elif defined(RAFT_ASSERT_WITH_BACKTRACE)
+#include <assert.h> /* for __assert_fail */
+#include <backtrace.h>
+#include <stdio.h>
+#undef assert
+#define assert(x)                                                 \
+    do {                                                          \
+        struct backtrace_state *state_;                           \
+        if (!(x)) {                                               \
+            state_ = backtrace_create_state(NULL, 0, NULL, NULL); \
+            backtrace_print(state_, 0, stderr);                   \
+            __assert_fail(#x, __FILE__, __LINE__, __func__);      \
+        }                                                         \
+    } while (0)
 #else
 #include <assert.h>
 #endif


### PR DESCRIPTION
More than once while looking at an assertion failure in Jepsen logs I've wished that it came with a backtrace -- this PR implements that.

Specifically, if RAFT_ASSERT_WITH_BACKTRACE is defined during compilation, we call into [libbacktrace](https://github.com/ianlancetaylor/libbacktrace) to print a symbolic backtrace before aborting. I still need to add the build system stuff to enable/disable this feature, find libbacktrace, and pass the appropriate flags during compilation.

Signed-off-by: Cole Miller <cole.miller@canonical.com>