### PR TITLE
uv_truncate: Add some assertions

### DIFF
--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -100,8 +100,11 @@ err:
 
 static void uvTruncateAfterWorkCb(uv_work_t *work, int status)
 {
+    assert(work != NULL);
     struct uvTruncate *truncate = work->data;
+    assert(truncate != NULL);
     struct uv *uv = truncate->uv;
+    assert(uv != NULL);
     assert(status == 0);
     if (truncate->status != 0) {
         uv->errored = true;


### PR DESCRIPTION
Quick fix so that (once RAFT_ASSERT_WITH_BACKTRACE is turned on for Jepsen) if #332 happens again we'll get a backtrace out of it.

Signed-off-by: Cole Miller <cole.miller@canonical.com>