### PR TITLE
Revert "uv: Prevent calling close_cb twice"

### DIFF
--- a/src/uv.c
+++ b/src/uv.c
@@ -199,7 +199,6 @@ void uvMaybeFireCloseCb(struct uv *uv)
 
     if (uv->close_cb != NULL) {
         uv->close_cb(uv->io);
-        uv->close_cb = NULL;
     }
 }
 


### PR DESCRIPTION
This reverts commit c042b4ebb8f04c642357a2a94570ca11f011c367.

dqlite tests are not very happy with the change:

```
LIBDQLITE 1671181712620064690 maybeCheckpoint:130 wal size (2) < threshold (1000)
LIBDQLITE 1671181712620151091 leaderApplyFramesCb:236 apply frames cb
LIBDQLITE 1671181712620161391 leaderMaybeCheckpointLegacy:182 leader maybe checkpoint legacy
LIBDQLITE 1671181712620209491 clientRecvResult:219 client recv result fd 15 last_insert_id 0 rows_affected 0
LIBDQLITE 1671181712620222891 clientClose:42 client close fd 15
LIBDQLITE 1671181712620241991 dqlite_node_stop:753 dqlite node stop
LIBDQLITE 1671181712620267292 conn__stop:330 conn stop
LIBDQLITE 1671181712620282892 gateway__close:80 gateway close
LIBDQLITE 1671181712620295592 leader__close:143 leader close
LIBDQLITE 1671181712620436593 impl_close:208 impl close
LIBDQLITE 1671181712648843248 gateway__resume:1327 gateway resume - finished
LIBDQLITE 1671181712648869949 read_message:217 transport read failed 1
LIBDQLITE 1671181712648875149 conn__stop:330 conn stop
=================================================================
==14342==ERROR: AddressSanitizer: heap-use-after-free on address 0x61c000000760 at pc 0x7f64d551a560 bp 0x7f64d11fb730 sp 0x7f64d11fb720
WRITE of size 8 at 0x61c000000760 thread T1
    #0 0x7f64d551a55f in uvMaybeFireCloseCb src/uv.c:202
    #1 0x7f64d3d1435f in uv__work_done (/usr/lib/x86_64-linux-gnu/libuv.so.1+0x935f)
    #2 0x7f64d3d163b3  (/usr/lib/x86_64-linux-gnu/libuv.so.1+0xb3b3)
    #3 0x7f64d3d2633f in uv__io_poll (/usr/lib/x86_64-linux-gnu/libuv.so.1+0x1b33f)
    #4 0x7f64d3d16cc7 in uv_run (/usr/lib/x86_64-linux-gnu/libuv.so.1+0xbcc7)
    #5 0x7f64d4fb7413 in taskRun src/server.c:632
    #6 0x7f64d4fb7509 in taskStart src/server.c:658
    #7 0x7f64d52b06da in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76da)
    #8 0x7f64d4a1861e in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x12161e)

0x61c000000760 is located 1760 bytes inside of 1776-byte region [0x61c000000080,0x61c000000770)
freed by thread T1 here:
    #0 0x7f64d5b9e7a8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7a8)
    #1 0x7f64d4fb58b1 in raftCloseCb src/server.c:416
    #2 0x7f64d551a4d6 in uvMaybeFireCloseCb src/uv.c:201
    #3 0x7f64d3d1435f in uv__work_done (/usr/lib/x86_64-linux-gnu/libuv.so.1+0x935f)

previously allocated by thread T0 here:
    #0 0x7f64d5b9eb40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f64d551aa32 in raft_uv_init src/uv.c:659
    #2 0x7f64d4fb3682 in dqlite__init src/server.c:66
    #3 0x7f64d4fb43e2 in dqlite_node_create src/server.c:183
    #4 0x55e5fbb0d0b4 in test_server_start test/lib/server.c:57
    #5 0x55e5fba5e1e6 in setUp test/integration/test_client.c:37
    #6 0x55e5fbb04176 in munit_test_runner_exec test/lib/munit.c:1188
    #7 0x55e5fbb051c2 in munit_test_runner_run_test_with_params test/lib/munit.c:1357
    #8 0x55e5fbb07363 in munit_test_runner_run_test_wild test/lib/munit.c:1542
    #9 0x55e5fbb08104 in munit_test_runner_run_test test/lib/munit.c:1640
    #10 0x55e5fbb08869 in munit_test_runner_run_suite test/lib/munit.c:1678
    #11 0x55e5fbb08a46 in munit_test_runner_run_suite test/lib/munit.c:1687
    #12 0x55e5fbb08c1e in munit_test_runner_run test/lib/munit.c:1697
    #13 0x55e5fbb0c322 in munit_suite_main_custom test/lib/munit.c:2027
    #14 0x55e5fbb0c9b9 in munit_suite_main test/lib/munit.c:2055
    #15 0x55e5fbafecb1 in main test/integration/main.c:3
    #16 0x7f64d4918c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Thread T1 created by T0 here:
    #0 0x7f64d5af7d2f in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x37d2f)
    #1 0x7f64d4fb7ed8 in dqlite_node_start src/server.c:732
    #2 0x55e5fbb0d571 in test_server_start test/lib/server.c:86
    #3 0x55e5fba5e1e6 in setUp test/integration/test_client.c:37
    #4 0x55e5fbb04176 in munit_test_runner_exec test/lib/munit.c:1188
    #5 0x55e5fbb051c2 in munit_test_runner_run_test_with_params test/lib/munit.c:1357
    #6 0x55e5fbb07363 in munit_test_runner_run_test_wild test/lib/munit.c:1542
    #7 0x55e5fbb08104 in munit_test_runner_run_test test/lib/munit.c:1640
    #8 0x55e5fbb08869 in munit_test_runner_run_suite test/lib/munit.c:1678
    #9 0x55e5fbb08a46 in munit_test_runner_run_suite test/lib/munit.c:1687
    #10 0x55e5fbb08c1e in munit_test_runner_run test/lib/munit.c:1697
    #11 0x55e5fbb0c322 in munit_suite_main_custom test/lib/munit.c:2027
    #12 0x55e5fbb0c9b9 in munit_suite_main test/lib/munit.c:2055
    #13 0x55e5fbafecb1 in main test/integration/main.c:3
    #14 0x7f64d4918c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: heap-use-after-free src/uv.c:202 in uvMaybeFireCloseCb
Shadow bytes around the buggy address:
  0x0c387fff8090: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c387fff80a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c387fff80b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c387fff80c0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c387fff80d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c387fff80e0: fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd fa fa
  0x0c387fff80f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c387fff8100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c387fff8110: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c387fff8120: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c387fff8130: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==14342==ABORTING
Error: child exited unexpectedly with status 1
```