### PR TITLE
uv: Clear io->impl when it's freed

### DIFF
--- a/src/uv.c
+++ b/src/uv.c
@@ -223,6 +223,7 @@ static void uvClose(struct raft_io *io, raft_io_close_cb cb)
 {
     struct uv *uv;
     uv = io->impl;
+    assert(uv != NULL);
     assert(!uv->closing);
     uv->close_cb = cb;
     uv->closing = true;
@@ -743,6 +744,7 @@ void raft_uv_close(struct raft_io *io)
 {
     struct uv *uv;
     uv = io->impl;
+    io->impl = NULL;
     raft_free(uv);
 }
 


### PR DESCRIPTION
This is related to #341 -- just trying to catch a bit earlier the situation where uvMaybeFireCloseCb somehow runs to completion more than once. 

Signed-off-by: Cole Miller <cole.miller@canonical.com>