### PR TITLE
replication: Tweak applyLeaderCb cleanup

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -531,8 +531,12 @@ out:
     index = request->index;
     raft_free(request);
     if (status != 0) {
-        logTruncate(r->log, index);
-        convertToFollower(r);
+        if (index <= logLastIndex(r->log)) {
+            logTruncate(r->log, index);
+        }
+        if (r->state == RAFT_LEADER) {
+            convertToFollower(r);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #338. After thinking about it for a while, I've convinced myself that appendLeaderCb can just skip truncating the log if the appended entries (for which the disk write was cancelled) are not present, because this can occur in a totally benign way. For example, we could start an append request for an entry at index 16 and then start another for index 17 before the first request is finished. Then we could cancel those two requests in the same order they were submitted, and the appendLeaderCb for the second request won't see any entry at index 17 to be truncated. And in fact this seems to be just what happened to cause that Jepsen failure.

(It would be elegant to cancel queued requests in LIFO order, so that each callback sees the log in the same state it was just after it appended its own entries. That would obviate the need for the logLastIndex check here. But I'm a little nervous about unanticipated consequences from changing that ordering.)

Signed-off-by: Cole Miller <cole.miller@canonical.com>