### PR TITLE
tick: Don't convert to candidate while a snapshot is installing

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1201,6 +1201,9 @@ static void installSnapshotCb(struct raft_io_snapshot_put *req, int status)
     struct raft_append_entries_result result;
     int rv;
 
+    /* We avoid converting to candidate state while installing a snapshot. */
+    assert(r->state == RAFT_FOLLOWER || r->state == RAFT_UNAVAILABLE);
+
     r->snapshot.put.data = NULL;
 
     result.term = r->current_term;
@@ -1246,9 +1249,6 @@ discard:
     raft_configuration_close(&snapshot->configuration);
 
 respond:
-    /* TODO Investigate when and if a RAFT_FOLLOWER moves to RAFT_CANDIDATE
-     * during the installation of a snapshot.
-     * See https://github.com/canonical/raft/issues/343 */
     if (r->state == RAFT_FOLLOWER) {
         result.last_log_index = r->last_stored;
         sendAppendEntriesResult(r, &result);

--- a/src/tick.c
+++ b/src/tick.c
@@ -41,6 +41,11 @@ static int tickFollower(struct raft *r)
      *   current leader or granting vote to candidate, convert to candidate.
      */
     if (electionTimerExpired(r) && server->role == RAFT_VOTER) {
+        if (r->snapshot.put.data != NULL) {
+            tracef("installing snapshot -> don't convert to candidate");
+            electionResetTimer(r);
+            return 0;
+        }
         tracef("convert to candidate and start new election");
         rv = convertToCandidate(r, false /* disrupt leader */);
         if (rv != 0) {


### PR DESCRIPTION
Closes #343. @MathieuBordere, let me know if this wasn't what you had in mind, I'm sure there are other possible approaches. 

Signed-off-by: Cole Miller <cole.miller@canonical.com>