### PR TITLE
Config rollback

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -634,7 +634,8 @@ struct raft
      * 1. #configuration_index and #configuration_uncommitted_index are both
      *    zero. This should only happen when a brand new server starts joining a
      *    cluster and is waiting to receive log entries from the current
-     *    leader. In this case #configuration must be empty and have no servers.
+     *    leader. In this case #configuration and #configuration_previous
+     *    must be empty and have no servers.
      *
      * 2. #configuration_index is non-zero while #configuration_uncommitted_index
      *    is zero. In this case the content of #configuration must match the one
@@ -645,11 +646,12 @@ struct raft
      *    the content of #configuration must match the one of the log entry at
      *    #configuration_uncommitted_index.
      *
-     * TODO previous_configuration will always contain a copy of the previous
-     * configuration, if any, and is used in configuration rollback scenarios.
+     * 4. In case the previous - committed - configuration can no longer be found
+     *    in the log e.g. after truncating the log when taking or installing a
+     *    snapshot, `configuration_previous` will contain a copy of it.
      */
     struct raft_configuration configuration;
-    struct raft_configuration configuration_previous; //currently not used.
+    struct raft_configuration configuration_previous;
     raft_index configuration_index;
     raft_index configuration_uncommitted_index;
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -63,4 +63,11 @@ int configurationDecode(const struct raft_buffer *buf,
 
 /* Output the configuration to the raft tracer */
 void configurationTrace(const struct raft *r, struct raft_configuration *c, const char *msg);
+
+/* Replaces the previous configuration with a copy of the configuration */
+int configurationBackup(struct raft *r, struct raft_configuration *src);
+
+/* Replaces the current configuration with a copy of the previous configuration. */
+int configurationRestorePrevious(struct raft *r);
+
 #endif /* CONFIGURATION_H_ */

--- a/src/raft.c
+++ b/src/raft.c
@@ -71,6 +71,7 @@ int raft_init(struct raft *r,
     }
 
     raft_configuration_init(&r->configuration);
+    raft_configuration_init(&r->configuration_previous);
     r->configuration_index = 0;
     r->configuration_uncommitted_index = 0;
     r->election_timeout = DEFAULT_ELECTION_TIMEOUT;
@@ -110,6 +111,7 @@ static void ioCloseCb(struct raft_io *io)
     raft_free(r->address);
     logClose(r->log);
     raft_configuration_close(&r->configuration);
+    raft_configuration_close(&r->configuration_previous);
     if (r->close_cb != NULL) {
         r->close_cb(r);
     }

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -65,6 +65,7 @@ int snapshotCopy(const struct raft_snapshot *src, struct raft_snapshot *dst)
 
     dst->term = src->term;
     dst->index = src->index;
+    dst->configuration_index = src->configuration_index;
 
     rv = configurationCopy(&src->configuration, &dst->configuration);
     if (rv != 0) {

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -43,6 +43,7 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
     configurationClose(&r->configuration);
     r->configuration = snapshot->configuration;
     r->configuration_index = snapshot->configuration_index;
+    r->configuration_uncommitted_index = 0;
     configurationTrace(r, &r->configuration, "configuration restore from snapshot");
 
     r->commit_index = snapshot->index;


### PR DESCRIPTION
This PR introduces the following changes:

* Set `configuration_uncommitted_index` upon startup as we can't know if the configuration is committed or not.
* Backup the configuration in case the configuration entry is no longer present in the log.

  1. After taking a snapshot and before purging entries from the log.
  2. After installing a snapshot in case the next config needs to be rolled back.
* Only store committed configurations in a snapshot and not the latest available configuration.

Fixes https://github.com/canonical/raft/issues/250