### PR TITLE
byte: Ignore false positive stringop-overread warning

### DIFF
--- a/src/byte.c
+++ b/src/byte.c
@@ -315,7 +315,14 @@ void byteSha1Update(struct byteSha1 *s, const uint8_t *data, uint32_t len)
         memcpy(&s->buffer[j], data, (i = 64 - j));
         byteSha1Transform(s->state, s->buffer);
         for (; i + 63 < len; i += 64) {
+#if defined(__powerpc64__) && defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
             byteSha1Transform(s->state, &data[i]);
+#if defined(__powerpc64__) && defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic pop
+#endif
         }
         j = 0;
     } else


### PR DESCRIPTION
silences a warning when `byteSha1Update` is called with a 1 byte buffer. The line with the silenced warning will never be called because to enter the for loop `i + 63` has to be smaller than `len`, but `len` is `1` and `i` is unsigned, `i + 63` will never be smaller than `1`, so the code is unreachable in that case.

Fixes kinetic builds for raft on ppc64el.

Full diagnostic:
```
In function ‘byteSha1Update’,
    inlined from ‘byteSha1Digest’ at src/byte.c:358:5:
src/byte.c:318:13: error: ‘byteSha1Transform’ reading 64 bytes from a region of size 0 [-Werror=stringop-overread]
  318 |             byteSha1Transform(s->state, &data[i]);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/byte.c:318:13: note: referencing argument 2 of type ‘const uint8_t[64]’
src/byte.c: In function ‘byteSha1Digest’:
src/byte.c:173:13: note: in a call to function ‘byteSha1Transform’
  173 | static void byteSha1Transform(uint32_t state[5], const uint8_t buffer[64])
      |             ^~~~~~~~~~~~~~~~~
In function ‘byteSha1Update’,
    inlined from ‘byteSha1Digest’ at src/byte.c:361:9:
src/byte.c:318:13: error: ‘byteSha1Transform’ reading 64 bytes from a region of size 0 [-Werror=stringop-overread]
  318 |             byteSha1Transform(s->state, &data[i]);
      |
```

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>