### PR TITLE
byte: Tweak signature of byteSha1Transform

### DIFF
--- a/src/byte.c
+++ b/src/byte.c
@@ -170,7 +170,7 @@ A million repetitions of "a"
     z += (w ^ x ^ y) + blk(i) + 0xCA62C1D6 + rol(v, 5); \
     w = rol(w, 30);
 
-static void byteSha1Transform(uint32_t state[5], const uint8_t buffer[64])
+static void byteSha1Transform(uint32_t state[5], const void *buffer)
 {
     uint32_t a, b, c, d, e;
     typedef union {


### PR DESCRIPTION
To avoid a (spurious) compiler warning on ppc64el.

Signed-off-by: Cole Miller <cole.miller@canonical.com>