### PR TITLE
Revert "replication: Drop append entries result if a state transition has occurred"

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -849,22 +849,21 @@ static void appendFollowerCb(struct raft_io_append *req, int status)
     assert(args->entries != NULL);
     assert(args->n_entries > 0);
 
+    result.term = r->current_term;
+    result.version = RAFT_APPEND_ENTRIES_RESULT_VERSION;
+    if (status != 0) {
+        if (r->state != RAFT_FOLLOWER) {
+            tracef("local server is not follower -> ignore I/O failure");
+            goto out;
+        }
+        result.rejected = args->prev_log_index + 1;
+        goto respond;
+    }
+
     /* If we're shutting down or have errored, ignore the result. */
     if (r->state == RAFT_UNAVAILABLE) {
         tracef("local server is unavailable -> ignore I/O result");
         goto out;
-    }
-    /* If a new term has started since the request came in, ignore the result. */
-    if (args->term != r->current_term) {
-        tracef("new term while processing request -> ignore I/O result");
-        goto out;
-    }
-
-    result.version = RAFT_APPEND_ENTRIES_RESULT_VERSION;
-    result.term = args->term;
-    if (status != 0) {
-        result.rejected = args->prev_log_index + 1;
-        goto respond;
     }
 
     /* We received an InstallSnapshot RCP while these entries were being
@@ -1196,7 +1195,6 @@ struct recvInstallSnapshot
 {
     struct raft *raft;
     struct raft_snapshot snapshot;
-    raft_term term; /* Used to check for state transitions. */
 };
 
 static void installSnapshotCb(struct raft_io_snapshot_put *req, int status)
@@ -1215,13 +1213,11 @@ static void installSnapshotCb(struct raft_io_snapshot_put *req, int status)
     result.term = r->current_term;
     result.version = RAFT_APPEND_ENTRIES_RESULT_VERSION;
 
-    /* If we are shutting down, let's discard the result. */
+    /* If we are shutting down, let's discard the result. TODO: what about other
+     * states? */
     if (r->state == RAFT_UNAVAILABLE) {
-        tracef("shutting down -> discard result of snapshot installation");
         goto discard;
     }
-    /* We don't transition to candidate state while a snapshot is being installed. */
-    assert(request->term == r->current_term);
 
     if (status != 0) {
         result.rejected = snapshot->index;
@@ -1317,7 +1313,6 @@ int replicationInstallSnapshot(struct raft *r,
         goto err;
     }
     request->raft = r;
-    request->term = r->current_term;
 
     snapshot = &request->snapshot;
     snapshot->term = args->last_term;


### PR DESCRIPTION
I believe that this fix is the cause of the new (and more frequent) Jepsen failures #355, so I'm reverting it until I understand what went wrong and can make another attempt to fix the original issue.

Reverts canonical/raft#351