### PR TITLE
byte: Don't inline byteSha1Update

### DIFF
--- a/src/byte.c
+++ b/src/byte.c
@@ -300,8 +300,7 @@ void byteSha1Init(struct byteSha1 *s)
 }
 
 /* Run your data through this. */
-
-void byteSha1Update(struct byteSha1 *s, const uint8_t *data, uint32_t len)
+void __attribute__((noinline)) byteSha1Update(struct byteSha1 *s, const uint8_t *data, uint32_t len)
 {
     uint32_t i;
     uint32_t j;
@@ -315,14 +314,7 @@ void byteSha1Update(struct byteSha1 *s, const uint8_t *data, uint32_t len)
         memcpy(&s->buffer[j], data, (i = 64 - j));
         byteSha1Transform(s->state, s->buffer);
         for (; i + 63 < len; i += 64) {
-#if defined(__powerpc64__) && defined(__GNUC__) && __GNUC__ >= 12
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overread"
-#endif
             byteSha1Transform(s->state, &data[i]);
-#if defined(__powerpc64__) && defined(__GNUC__) && __GNUC__ >= 12
-#pragma GCC diagnostic pop
-#endif
         }
         j = 0;
     } else


### PR DESCRIPTION
Inlining seems to cause a false-positive stringop-overread warning on ppc64le, as this is not performance sensitive code in real-world systems, it's okay to not inline this function.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>