### PR TITLE
github: Explicitly remove liblz4 when we don't expect it.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,7 +114,10 @@ jobs:
     - name: Setup dependencies
       run: |
           sudo apt-get update -qq
+          # make sure liblz4 is not there
+          sudo apt-get remove liblz4-dev || true
           sudo apt-get install -qq lcov linux-libc-dev libuv1-dev btrfs-progs xfsprogs zfsutils-linux
+          sudo ldconfig
 
     # Expect the configure step to fail
     - name: Build


### PR DESCRIPTION
Closes #364 as `liblz4-dev` is sometimes unexpectedly installed on the test runner see e.g. [here](https://pipelines.actions.githubusercontent.com/serviceHosts/7a203d8c-0490-43b8-8c5f-2e23b9a74d71/_apis/pipelines/1/runs/790/signedlogcontent/2?urlExpires=2023-01-11T13%3A49%3A10.5551811Z&urlSigningMethod=HMACV1&urlSignature=w35yAASnVkE%2BXghrfVoHktVFGsFm14HMs5N1tCENxNE%3D)

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>