### PR TITLE
configuration: More tracing when configs are committed.

### DIFF
--- a/src/membership.c
+++ b/src/membership.c
@@ -115,6 +115,7 @@ int membershipUncommittedChange(struct raft *r,
 {
     struct raft_configuration configuration;
     int rv;
+    char msg[128];
 
     assert(r != NULL);
     assert(r->state == RAFT_FOLLOWER);
@@ -128,7 +129,10 @@ int membershipUncommittedChange(struct raft *r,
         tracef("failed to decode configuration at index:%llu", index);
         goto err;
     }
-    configurationTrace(r, &configuration, "uncommitted config change");
+
+    /* ignore errors */
+    snprintf(msg, sizeof(msg), "uncommitted config change at index:%llu", index);
+    configurationTrace(r, &configuration, msg);
 
     raft_configuration_close(&r->configuration);
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1403,6 +1403,7 @@ static void applyChange(struct raft *r, const raft_index index)
      * via an AppendEntries RPC (for followers), then reset the uncommitted
      * index, since that uncommitted configuration is now committed. */
     if (r->configuration_uncommitted_index == index) {
+        tracef("configuration at index:%llu is committed.", index);
         r->configuration_uncommitted_index = 0;
     }
 


### PR DESCRIPTION
Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>