### PR TITLE
Fix raft.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,7 +175,7 @@ CC_CHECK_FLAGS_APPEND([AM_LDFLAGS],[LDFLAGS],[ \
 AC_SUBST(AM_LDLAGS)
 
 REQUIRES=''
-AS_IF(test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xyes", REQUIRES=lz4)
+AS_IF(test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xyes", REQUIRES=liblz4)
 AS_IF(test "$have_uv" = yes, REQUIRES="$REQUIRES libuv")
 AC_SUBST(REQUIRES)
 


### PR DESCRIPTION
Follow-up to #377 -- I mistakenly used `lz4` in `Requires.private` instead of `liblz4`.

Signed-off-by: Cole Miller <cole.miller@canonical.com>