### PR TITLE
Revert addition of Requires.private to raft.pc

### DIFF
--- a/raft.pc.in
+++ b/raft.pc.in
@@ -6,6 +6,5 @@ includedir=@includedir@
 Name: raft
 Description: C implementation of the Raft Consensus protocol
 Version:  @PACKAGE_VERSION@
-Requires.private: @REQUIRES@
 Libs: -L${libdir} -lraft
 Cflags: -I${includedir}


### PR DESCRIPTION
This partially reverts #377 and #378 -- the Requires.private line is causing builds to fail on Launchpad.

Signed-off-by: Cole Miller <cole.miller@canonical.com>