### PR TITLE
Expose an accessor for the current Raft role

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -900,9 +900,15 @@ RAFT_API void raft_set_max_catch_up_round_duration(struct raft *r,
 RAFT_API const char *raft_errmsg(struct raft *r);
 
 /**
- * Return the code of the current raft state.
+ * Return the code of the current raft state (follower/candidate/leader).
  */
 RAFT_API int raft_state(struct raft *r);
+
+/**
+ * Return the code of the current raft role (spare/standby/voter),
+ * or -1 if this server is not in the current configuration.
+ */
+RAFT_API int raft_role(struct raft *r);
 
 /**
  * Return the ID and address of the current known leader, if any.

--- a/src/state.c
+++ b/src/state.c
@@ -42,3 +42,12 @@ raft_index raft_last_applied(struct raft *r)
 {
     return r->last_applied;
 }
+
+int raft_role(struct raft *r)
+{
+    const struct raft_server *local = configurationGet(&r->configuration, r->id);
+    if (local == NULL) {
+	    return -1;
+    }
+    return local->role;
+}


### PR DESCRIPTION
I found myself needing this during my work on server-side role management for dqlite -- when a node is shutting down, it's expected to check whether it's a voter, and if so to promote another node into that role before going offline.

Signed-off-by: Cole Miller <cole.miller@canonical.com>