### PR TITLE
lib/heap: Only count non-NULL allocations.

### DIFF
--- a/test/lib/heap.c
+++ b/test/lib/heap.c
@@ -22,11 +22,15 @@ static void heapInit(struct heap *h)
 static void *heapMalloc(void *data, size_t size)
 {
     struct heap *h = data;
+    void *ptr = NULL;
     if (FaultTick(&h->fault)) {
         return NULL;
     }
-    h->n++;
-    return munit_malloc(size);
+    ptr = munit_malloc(size);
+    if (ptr != NULL) {
+        h->n++;
+    }
+    return ptr;
 }
 
 static void heapFree(void *data, void *ptr)


### PR DESCRIPTION
False positive memory-leak can be detected in case `0` size is passed.