### PR TITLE
clang-format of raft.h

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -352,8 +352,8 @@ struct raft_message
  * Hold the details of a snapshot.
  * The user-provided raft_buffer structs should provide the user with enough
  * flexibility to adapt/evolve snapshot formats.
- * If this struct would NEED to be adapted in the future, raft can always move to
- * a new struct with a new name and a new raft_io version.
+ * If this struct would NEED to be adapted in the future, raft can always move
+ * to a new struct with a new name and a new raft_io version.
  */
 struct raft_snapshot
 {
@@ -545,10 +545,10 @@ struct raft_io
  * version 3:
  * Adds support for async snapshots through the `snapshot_async` function.
  * When this method is provided, raft will call `snapshot` in the main loop,
- * and when successful, will call `snapshot_async` by means of the `io->async_work` method.
- * The callback to `io->async_work` will in turn call `snapshot_finalize`
- * in the main loop when the work has completed independent of the return value
- * of `snapshot_async`.
+ * and when successful, will call `snapshot_async` using the `io->async_work`
+ * method, so blocking I/O calls are allowed in the implementation. After the
+ * `snapshot_async` completes, `snapshot_finalize` will be called in the main
+ * loop, independent of the return value of `snapshot_async`.
  * An implementation that does not use asynchronous snapshots MUST set
  * `snapshot_async` to NULL.
  * All memory allocated by the snapshot routines MUST be freed by the snapshot
@@ -637,7 +637,7 @@ struct raft
      *    leader. In this case #configuration and #configuration_previous
      *    must be empty and have no servers.
      *
-     * 2. #configuration_index is non-zero while #configuration_uncommitted_index
+     * 2. #configuration_index is non-zero and #configuration_uncommitted_index
      *    is zero. In this case the content of #configuration must match the one
      *    of the log entry at #configuration_index.
      *
@@ -646,9 +646,10 @@ struct raft
      *    the content of #configuration must match the one of the log entry at
      *    #configuration_uncommitted_index.
      *
-     * 4. In case the previous - committed - configuration can no longer be found
-     *    in the log e.g. after truncating the log when taking or installing a
-     *    snapshot, `configuration_previous` will contain a copy of it.
+     * 4. In case the previous - committed - configuration can no longer be
+     *    found in the log e.g. after truncating the log when taking or
+     *    installing a snapshot, `configuration_previous` will contain a copy
+     *    of it.
      */
     struct raft_configuration configuration;
     struct raft_configuration configuration_previous;
@@ -690,8 +691,8 @@ struct raft
     unsigned heartbeat_timeout;
 
     /*
-     * When the leader sends an InstallSnapshot RPC to a follower it will consider
-     * the RPC as failed after this timeout and retry.
+     * When the leader sends an InstallSnapshot RPC to a follower it will
+     * consider the RPC as failed after this timeout and retry.
      */
     unsigned install_snapshot_timeout;
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -12,12 +12,14 @@
 /**
  * Version.
  */
-#define RAFT_VERSION_MAJOR    1
-#define RAFT_VERSION_MINOR    17
-#define RAFT_VERSION_RELEASE  1
-#define RAFT_VERSION_NUMBER (RAFT_VERSION_MAJOR *100*100 + RAFT_VERSION_MINOR *100 + RAFT_VERSION_RELEASE)
+#define RAFT_VERSION_MAJOR 1
+#define RAFT_VERSION_MINOR 17
+#define RAFT_VERSION_RELEASE 1
+#define RAFT_VERSION_NUMBER                                      \
+    (RAFT_VERSION_MAJOR * 100 * 100 + RAFT_VERSION_MINOR * 100 + \
+     RAFT_VERSION_RELEASE)
 
-int raft_version_number (void);
+int raft_version_number(void);
 
 /**
  * Error codes.
@@ -83,7 +85,6 @@ struct raft_buffer
     void *base; /* Pointer to the buffer data. */
     size_t len; /* Length of the buffer. */
 };
-
 
 /**
  * Server role codes.
@@ -228,9 +229,9 @@ struct raft_request_vote
 struct raft_request_vote_result
 {
     int version;
-    raft_term term;        /* Receiver's current term (candidate updates itself). */
-    bool vote_granted;     /* True means candidate received vote. */
-    bool pre_vote;         /* The response to a pre-vote RequestVote or not. */
+    raft_term term;    /* Receiver's current term (candidate updates itself). */
+    bool vote_granted; /* True means candidate received vote. */
+    bool pre_vote;     /* The response to a pre-vote RequestVote or not. */
 };
 #define RAFT_REQUEST_VOTE_RESULT_VERSION 2
 
@@ -720,7 +721,7 @@ struct raft
                 raft_id id;
                 char *address;
             } current_leader;
-            uint64_t reserved[8];                 /* Future use */
+            uint64_t reserved[8]; /* Future use */
         } follower_state;
         struct
         {
@@ -940,7 +941,7 @@ RAFT_API raft_index raft_last_applied(struct raft *r);
     uint8_t req_id[16];    \
     uint8_t client_id[16]; \
     uint8_t unique_id[16]; \
-    uint64_t reserved[4]   \
+    uint64_t reserved[4]
 
 /**
  * Asynchronous request to append a new command entry to the log and apply it to


### PR DESCRIPTION
This branch adjusts a few comments and docstrings in `raft.h` to fit the 80 characters line limit, and runs `clang-format` against the whole file.

We have `.clang-format` file in the top-level directory of the source tree. It's basically the equivalent of `gofmt` in Golang, and helps keep the code layout consistent. We might tweak the configuration options in `.clang-format` if there are styles we want to change.

We might also consider adding a Github workflow lint action like https://github.com/marketplace/actions/clang-format-lint, or something along those lines.