### PR TITLE
Run clang-format against the whole tree

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ BraceWrapping:
  AfterStruct: true
 IndentWidth: 4
 PointerAlignment: Right
+ForEachMacros: ['QUEUE_FOREACH']

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,19 @@
+name: Linting
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.14
+      with:
+        source: 'src test example'
+        exclude: 'test/lib/munit.*'
+        extensions: 'c,h'
+        clangFormatVersion: 14
+        style: file

--- a/include/raft/fixture.h
+++ b/include/raft/fixture.h
@@ -72,7 +72,7 @@ struct raft_fixture
     struct raft_fixture_event *event; /* Last event occurred. */
     raft_fixture_event_cb hook;       /* Event callback. */
     struct raft_fixture_server *servers[RAFT_FIXTURE_MAX_SERVERS];
-    uint64_t reserved[16];            /* For future expansion of struct. */
+    uint64_t reserved[16]; /* For future expansion of struct. */
 };
 
 /**
@@ -437,7 +437,6 @@ RAFT_API unsigned raft_fixture_n_recv(struct raft_fixture *f,
 /**
  * Force the @i'th server into the UNAVAILABLE state.
  */
-RAFT_API void raft_fixture_make_unavailable(struct raft_fixture *f,
-                                            unsigned i);
+RAFT_API void raft_fixture_make_unavailable(struct raft_fixture *f, unsigned i);
 
 #endif /* RAFT_FIXTURE_H */

--- a/include/raft/uv.h
+++ b/include/raft/uv.h
@@ -113,14 +113,16 @@ RAFT_API void raft_uv_set_segment_size(struct raft_io *io, size_t size);
  *
  * By default snapshots are compressed if the appropriate libraries are found.
  */
-RAFT_API int raft_uv_set_snapshot_compression(struct raft_io *io, bool compressed);
+RAFT_API int raft_uv_set_snapshot_compression(struct raft_io *io,
+                                              bool compressed);
 
 /**
  * Set how many milliseconds to wait between subsequent retries when
  * establishing a connection with another server. The default is 1000
  * milliseconds.
  */
-RAFT_API void raft_uv_set_connect_retry_delay(struct raft_io *io, unsigned msecs);
+RAFT_API void raft_uv_set_connect_retry_delay(struct raft_io *io,
+                                              unsigned msecs);
 
 /**
  * Emit low-level debug messages using the given tracer.
@@ -131,8 +133,7 @@ RAFT_API void raft_uv_set_tracer(struct raft_io *io,
 /**
  * Enable or disable auto-recovery on startup. Default enabled.
  */
-RAFT_API void raft_uv_set_auto_recovery(struct raft_io *io,
-                                        bool flag);
+RAFT_API void raft_uv_set_auto_recovery(struct raft_io *io, bool flag);
 
 /**
  * Callback invoked by the transport implementation when a new incoming
@@ -271,6 +272,7 @@ RAFT_API void raft_uv_tcp_close(struct raft_uv_transport *t);
  *
  * Must be called before raft_init().
  */
-RAFT_API int raft_uv_tcp_set_bind_address(struct raft_uv_transport *t, const char *address);
+RAFT_API int raft_uv_tcp_set_bind_address(struct raft_uv_transport *t,
+                                          const char *address);
 
 #endif /* RAFT_UV_H */

--- a/src/array.h
+++ b/src/array.h
@@ -8,7 +8,7 @@
 /* Append item I of type T to array A which currently has N items.
  *
  * A and N must both by pointers. Set RV to -1 in case of failure. */
-#define ARRAY__APPEND(T, I, A, N, RV)			     \
+#define ARRAY__APPEND(T, I, A, N, RV)                        \
     {                                                        \
         T *tmp_array;                                        \
         tmp_array = raft_realloc(*A, (*N + 1) * sizeof **A); \

--- a/src/byte.c
+++ b/src/byte.c
@@ -300,7 +300,8 @@ void byteSha1Init(struct byteSha1 *s)
 }
 
 /* Run your data through this. */
-void __attribute__((noinline)) byteSha1Update(struct byteSha1 *s, const uint8_t *data, uint32_t len)
+void __attribute__((noinline))
+byteSha1Update(struct byteSha1 *s, const uint8_t *data, uint32_t len)
 {
     uint32_t i;
     uint32_t j;

--- a/src/compress.h
+++ b/src/compress.h
@@ -14,15 +14,18 @@
  * returned to the caller through `compressed`. Returns a non-0 value upon
  * failure.
  */
-int Compress(struct raft_buffer bufs[], unsigned n_bufs,
-             struct raft_buffer *compressed, char *errmsg);
+int Compress(struct raft_buffer bufs[],
+             unsigned n_bufs,
+             struct raft_buffer *compressed,
+             char *errmsg);
 
 /*
  * Decompresses the content of `buf` into a newly allocated buffer that is
  * returned to the caller through `decompressed`. Returns a non-0 value upon
  * failure.
  */
-int Decompress(struct raft_buffer buf, struct raft_buffer *decompressed,
+int Decompress(struct raft_buffer buf,
+               struct raft_buffer *decompressed,
                char *errmsg);
 
 /* Returns `true` if `data` is compressed, `false` otherwise. */

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -7,7 +7,6 @@
 /* Current encoding format version. */
 #define ENCODING_FORMAT 1
 
-
 void configurationInit(struct raft_configuration *c)
 {
     c->servers = NULL;
@@ -333,9 +332,11 @@ int configurationDecode(const struct raft_buffer *buf,
 }
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
-void configurationTrace(const struct raft *r, struct raft_configuration *c, const char *msg)
+void configurationTrace(const struct raft *r,
+                        struct raft_configuration *c,
+                        const char *msg)
 {
-    if (r == NULL || c == NULL || !r->tracer->enabled ) {
+    if (r == NULL || c == NULL || !r->tracer->enabled) {
         return;
     }
 
@@ -356,7 +357,8 @@ int configurationBackup(struct raft *r, struct raft_configuration *src)
     struct raft_configuration dst;
 
     /* Copy the configuration to an intermediate configuration because the copy
-     * can fail and we don't want to be left without the previous configuration. */
+     * can fail and we don't want to be left without the previous configuration.
+     */
     configurationInit(&dst);
     rv = configurationCopy(src, &dst);
     if (rv != 0) {

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -62,12 +62,15 @@ int configurationDecode(const struct raft_buffer *buf,
                         struct raft_configuration *c);
 
 /* Output the configuration to the raft tracer */
-void configurationTrace(const struct raft *r, struct raft_configuration *c, const char *msg);
+void configurationTrace(const struct raft *r,
+                        struct raft_configuration *c,
+                        const char *msg);
 
 /* Replaces the previous configuration with a copy of the configuration */
 int configurationBackup(struct raft *r, struct raft_configuration *src);
 
-/* Replaces the current configuration with a copy of the previous configuration. */
+/* Replaces the current configuration with a copy of the previous configuration.
+ */
 int configurationRestorePrevious(struct raft *r);
 
 #endif /* CONFIGURATION_H_ */

--- a/src/convert.c
+++ b/src/convert.c
@@ -182,7 +182,7 @@ int convertToCandidate(struct raft *r, bool disrupt_leader)
 
 void convertInitialBarrierCb(struct raft_barrier *req, int status)
 {
-    (void) status;
+    (void)status;
     raft_free(req);
 }
 
@@ -213,26 +213,31 @@ int convertToLeader(struct raft *r)
     r->leader_state.round_index = 0;
     r->leader_state.round_start = 0;
 
-    /* By definition, all entries until the last_stored entry will be committed if
-     * we are the only voter around. */
+    /* By definition, all entries until the last_stored entry will be committed
+     * if we are the only voter around. */
     size_t n_voters = configurationVoterCount(&r->configuration);
     if (n_voters == 1 && (r->last_stored > r->commit_index)) {
-        tracef("apply log entries after self election %llu %llu", r->last_stored, r->commit_index);
+        tracef("apply log entries after self election %llu %llu",
+               r->last_stored, r->commit_index);
         r->commit_index = r->last_stored;
         rv = replicationApply(r);
     } else if (n_voters > 1) {
         /* Raft Dissertation, paragraph 6.4:
-         * The Leader Completeness Property guarantees that a leader has all committed
-         * entries, but at the start of its term, it may not know which those are.
-         * To find out, it needs to commit an entry from its term. Raft handles this by having
-         * each leader commit a blank no-op entry into the log at the start of its term. */
+         * The Leader Completeness Property guarantees that a leader has all
+         * committed entries, but at the start of its term, it may not know
+         * which those are. To find out, it needs to commit an entry from its
+         * term. Raft handles this by having each leader commit a blank no-op
+         * entry into the log at the start of its term. */
         struct raft_barrier *req = raft_malloc(sizeof(*req));
         if (req == NULL) {
             return RAFT_NOMEM;
         }
         rv = raft_barrier(r, req, convertInitialBarrierCb);
         if (rv != 0) {
-            tracef("failed to send no-op barrier entry after leader conversion: %d", rv);
+            tracef(
+                "failed to send no-op barrier entry after leader conversion: "
+                "%d",
+                rv);
         }
     }
 

--- a/src/election.c
+++ b/src/election.c
@@ -114,8 +114,8 @@ int electionStart(struct raft *r)
      * configuration (meaning that we are a voting server). */
     assert(voting_index < r->configuration.n);
 
-    /* Coherence check that configurationVoterCount and configurationIndexOfVoter
-     * have returned something that makes sense. */
+    /* Coherence check that configurationVoterCount and
+     * configurationIndexOfVoter have returned something that makes sense. */
     assert(n_voters <= r->configuration.n);
     assert(voting_index < n_voters);
 
@@ -202,8 +202,8 @@ int electionVote(struct raft *r,
 
     is_transferee =
         r->transfer != NULL && r->transfer->id == args->candidate_id;
-    if (!args->pre_vote && r->voted_for != 0 && r->voted_for != args->candidate_id &&
-        !is_transferee) {
+    if (!args->pre_vote && r->voted_for != 0 &&
+        r->voted_for != args->candidate_id && !is_transferee) {
         tracef("local server already voted -> not granting vote");
         return 0;
     }
@@ -214,13 +214,13 @@ int electionVote(struct raft *r,
      * > cluster that they would be willing
      * > to grant the candidate their votes (if the candidate's log is
      * > sufficiently up-to-date, and the voters
-     * > have not received heartbeats from a valid leader for at least a baseline
-     * > election timeout)
-     * Arriving here means that in a pre-vote phase, we will cast our vote
-     * if the candidate's log is sufficiently up-to-date, no matter what the
-     * candidate's term is. We have already checked if we currently have a leader
-     * upon reception of the RequestVote RPC, meaning the 2 conditions will be
-     * satisfied if the candidate's log is up-to-date.
+     * > have not received heartbeats from a valid leader for at least a
+     * baseline > election timeout) Arriving here means that in a pre-vote
+     * phase, we will cast our vote if the candidate's log is sufficiently
+     * up-to-date, no matter what the candidate's term is. We have already
+     * checked if we currently have a leader upon reception of the RequestVote
+     * RPC, meaning the 2 conditions will be satisfied if the candidate's log is
+     * up-to-date.
      * */
     local_last_index = logLastIndex(r->log);
 

--- a/src/entry.c
+++ b/src/entry.c
@@ -1,5 +1,5 @@
-#include <string.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "assert.h"
 #include "entry.h"

--- a/src/err.c
+++ b/src/err.c
@@ -6,7 +6,7 @@
 #include "assert.h"
 
 #define WRAP_SEP ": "
-#define WRAP_SEP_LEN (size_t)strlen(WRAP_SEP)
+#define WRAP_SEP_LEN (size_t) strlen(WRAP_SEP)
 
 void errMsgWrap(char *e, const char *format)
 {

--- a/src/err.c
+++ b/src/err.c
@@ -6,7 +6,7 @@
 #include "assert.h"
 
 #define WRAP_SEP ": "
-#define WRAP_SEP_LEN (size_t) strlen(WRAP_SEP)
+#define WRAP_SEP_LEN ((size_t)strlen(WRAP_SEP))
 
 void errMsgWrap(char *e, const char *format)
 {

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -169,7 +169,7 @@ struct io
     unsigned randomized_election_timeout; /* Value returned by io->random() */
     unsigned network_latency;             /* Milliseconds to deliver RPCs */
     unsigned disk_latency;                /* Milliseconds to perform disk I/O */
-    unsigned work_duration; /* Milliseconds to long running work */
+    unsigned work_duration;               /* Milliseconds to run async work */
 
     struct
     {

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -1388,8 +1388,7 @@ static void getLowestRequestCompletionTime(struct raft_fixture *f,
     for (j = 0; j < f->n; j++) {
         struct io *io = f->servers[j]->io.impl;
         queue *head;
-        QUEUE_FOREACH(head, &io->requests)
-        {
+        QUEUE_FOREACH (head, &io->requests) {
             struct ioRequest *r = QUEUE_DATA(head, struct ioRequest, queue);
             if (r->completion_time < *t) {
                 *t = r->completion_time;
@@ -1421,8 +1420,7 @@ static void completeRequest(struct raft_fixture *f, unsigned i, raft_time t)
     bool found = false;
     f->time = t;
     f->event->server_index = i;
-    QUEUE_FOREACH(head, &io->requests)
-    {
+    QUEUE_FOREACH (head, &io->requests) {
         r = QUEUE_DATA(head, struct ioRequest, queue);
         if (r->completion_time == t) {
             found = true;
@@ -1788,8 +1786,7 @@ static bool hasDelivered(struct raft_fixture *f, void *arg)
     queue *head;
     raft = raft_fixture_get(f, target->i);
     io = raft->io->impl;
-    QUEUE_FOREACH(head, &io->requests)
-    {
+    QUEUE_FOREACH (head, &io->requests) {
         struct ioRequest *r;
         r = QUEUE_DATA(head, struct ioRequest, queue);
         message = NULL;

--- a/src/fixture.c
+++ b/src/fixture.c
@@ -53,7 +53,8 @@ RAFT_API int raft_fixture_event_type(struct raft_fixture_event *event)
     return event->type;
 }
 
-RAFT_API unsigned raft_fixture_event_server_index(struct raft_fixture_event *event)
+RAFT_API unsigned raft_fixture_event_server_index(
+    struct raft_fixture_event *event)
 {
     assert(event != NULL);
     return event->server_index;
@@ -168,7 +169,7 @@ struct io
     unsigned randomized_election_timeout; /* Value returned by io->random() */
     unsigned network_latency;             /* Milliseconds to deliver RPCs */
     unsigned disk_latency;                /* Milliseconds to perform disk I/O */
-    unsigned work_duration;               /* Milliseconds to long running work */
+    unsigned work_duration; /* Milliseconds to long running work */
 
     struct
     {
@@ -326,7 +327,7 @@ static void ioFlushSnapshotGet(struct io *s, struct snapshot_get *r)
 /* Flush an async work request */
 static void ioFlushAsyncWork(struct io *s, struct async_work *r)
 {
-    (void) s;
+    (void)s;
     int rv;
     rv = r->req->work(r->req);
     r->req->cb(r->req, rv);
@@ -725,7 +726,6 @@ static int ioMethodAsyncWork(struct raft_io *raft_io,
     QUEUE_PUSH(&io->requests, &r->queue);
     return 0;
 }
-
 
 static int ioMethodSnapshotGet(struct raft_io *raft_io,
                                struct raft_io_snapshot_get *req,

--- a/src/log.c
+++ b/src/log.c
@@ -335,7 +335,7 @@ static bool refsDecr(struct raft_log *l,
     return true;
 }
 
-struct raft_log* logInit(void)
+struct raft_log *logInit(void)
 {
     struct raft_log *log;
 
@@ -343,7 +343,6 @@ struct raft_log* logInit(void)
     if (log == NULL) {
         return NULL;
     }
-
 
     log->entries = NULL;
     log->size = 0;
@@ -438,7 +437,8 @@ void logStart(struct raft_log *l,
     l->offset = start_index - 1;
 }
 
-/* Ensure that the entries array has enough free slots for adding a new entry. */
+/* Ensure that the entries array has enough free slots for adding a new entry.
+ */
 static int ensureCapacity(struct raft_log *l)
 {
     struct raft_entry *entries; /* New entries array */
@@ -630,8 +630,8 @@ raft_term logTermOf(struct raft_log *l, const raft_index index)
 
     if (index == l->snapshot.last_index) {
         assert(l->snapshot.last_term != 0);
-        /* Coherence check that if we still have the entry at last_index, its term
-         * matches the one in the snapshot. */
+        /* Coherence check that if we still have the entry at last_index, its
+         * term matches the one in the snapshot. */
         i = locateEntry(l, index);
         if (i != l->size) {
             assert(l->entries[i].term == l->snapshot.last_term);

--- a/src/log.h
+++ b/src/log.h
@@ -8,7 +8,6 @@
 /* Initial size of the entry reference count hash table. */
 #define LOG__REFS_INITIAL_SIZE 256
 
-
 /**
  * Counter for outstanding references to a log entry.
  *
@@ -54,7 +53,7 @@ struct raft_log
 };
 
 /* Initialize an empty in-memory log of raft entries. */
-struct raft_log* logInit(void);
+struct raft_log *logInit(void);
 
 /* Release all memory used by the given log object. */
 void logClose(struct raft_log *l);

--- a/src/membership.c
+++ b/src/membership.c
@@ -22,7 +22,8 @@ int membershipCanChangeConfiguration(struct raft *r)
     }
 
     if (r->configuration_uncommitted_index != 0) {
-        tracef("r->configuration_uncommitted_index %llu", r->configuration_uncommitted_index);
+        tracef("r->configuration_uncommitted_index %llu",
+               r->configuration_uncommitted_index);
         rv = RAFT_CANTCHANGE;
         goto err;
     }
@@ -76,8 +77,10 @@ bool membershipUpdateCatchUpRound(struct raft *r)
     /* If the server did not reach the target index for this round, it did not
      * catch up. */
     if (match_index < r->leader_state.round_index) {
-        tracef("member (index: %u) not yet caught up match_index:%llu round_index:%llu",
-                server_index, match_index, r->leader_state.round_index);
+        tracef(
+            "member (index: %u) not yet caught up match_index:%llu "
+            "round_index:%llu",
+            server_index, match_index, r->leader_state.round_index);
         return false;
     }
 
@@ -87,8 +90,8 @@ bool membershipUpdateCatchUpRound(struct raft *r)
     is_up_to_date = match_index == last_index;
     is_fast_enough = round_duration < r->election_timeout;
 
-    tracef("member is_up_to_date:%d is_fast_enough:%d",
-            is_up_to_date, is_fast_enough);
+    tracef("member is_up_to_date:%d is_fast_enough:%d", is_up_to_date,
+           is_fast_enough);
 
     /* If the server's log is fully up-to-date or the round that just terminated
      * was fast enough, then the server as caught up. */
@@ -132,7 +135,8 @@ int membershipUncommittedChange(struct raft *r,
     }
 
     /* ignore errors */
-    snprintf(msg, sizeof(msg), "uncommitted config change at index:%llu", index);
+    snprintf(msg, sizeof(msg), "uncommitted config change at index:%llu",
+             index);
     configurationTrace(r, &configuration, msg);
 
     raft_configuration_close(&r->configuration);
@@ -195,7 +199,8 @@ void membershipLeadershipTransferInit(struct raft *r,
     r->transfer = req;
 }
 
-static void membershipLeadershipSendCb(struct raft_io_send *send, int status) {
+static void membershipLeadershipSendCb(struct raft_io_send *send, int status)
+{
     (void)status;
     RaftHeapFree(send);
 }

--- a/src/membership.h
+++ b/src/membership.h
@@ -38,7 +38,7 @@ int membershipRollback(struct raft *r);
 
 /* Initialize the state of a leadership transfer request. */
 void membershipLeadershipTransferInit(struct raft *r,
-				      struct raft_transfer *req,
+                                      struct raft_transfer *req,
                                       raft_id id,
                                       raft_transfer_cb cb);
 

--- a/src/progress.h
+++ b/src/progress.h
@@ -23,7 +23,7 @@ struct raft_progress
     raft_index snapshot_index;    /* Last index of most recent snapshot sent. */
     raft_time last_send;          /* Timestamp of last AppendEntries RPC. */
     raft_time snapshot_last_send; /* Timestamp of last InstallSnaphot RPC. */
-    bool recent_recv;             /* A msg was received within election timeout. */
+    bool recent_recv; /* A msg was received within election timeout. */
 };
 
 /* Create and initialize the array of progress objects used by the leader to *

--- a/src/queue.h
+++ b/src/queue.h
@@ -51,6 +51,7 @@ typedef void *queue[2];
     for ((q) = QUEUE_NEXT(e); (q) != (e); (q) = QUEUE_NEXT(q))
 
 /* Return the structure holding the given element. */
-#define QUEUE_DATA(e, type, field) ((type *)((void*)((char *)(e)-offsetof(type, field))))
+#define QUEUE_DATA(e, type, field) \
+    ((type *)((void *)((char *)(e)-offsetof(type, field))))
 
 #endif /* QUEUE_H_*/

--- a/src/raft.c
+++ b/src/raft.c
@@ -13,8 +13,8 @@
 #include "membership.h"
 #include "tracing.h"
 
-#define DEFAULT_ELECTION_TIMEOUT 1000 /* One second */
-#define DEFAULT_HEARTBEAT_TIMEOUT 100 /* One tenth of a second */
+#define DEFAULT_ELECTION_TIMEOUT 1000          /* One second */
+#define DEFAULT_HEARTBEAT_TIMEOUT 100          /* One tenth of a second */
 #define DEFAULT_INSTALL_SNAPSHOT_TIMEOUT 30000 /* 30 seconds */
 #define DEFAULT_SNAPSHOT_THRESHOLD 1024
 #define DEFAULT_SNAPSHOT_TRAILING 2048
@@ -26,7 +26,7 @@
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
-int raft_version_number (void)
+int raft_version_number(void)
 {
     return RAFT_VERSION_NUMBER;
 }
@@ -46,7 +46,7 @@ int raft_init(struct raft *r,
 
     rv = ioFsmVersionCheck(r, io, fsm);
     if (rv != 0) {
-	goto err;
+        goto err;
     }
 
     r->io = io;
@@ -267,13 +267,13 @@ static int ioFsmVersionCheck(struct raft *r,
         return -1;
     }
 
-    if ((fsm->version > 2 && fsm->snapshot_async != NULL)
-        && ((io->version < 2) || (io->async_work == NULL))) {
-        ErrMsgPrintf(r->errmsg,
+    if ((fsm->version > 2 && fsm->snapshot_async != NULL) &&
+        ((io->version < 2) || (io->async_work == NULL))) {
+        ErrMsgPrintf(
+            r->errmsg,
             "async snapshot requires io->version > 1 and async_work method.");
         return -1;
     }
 
     return 0;
 }
-

--- a/src/recv.c
+++ b/src/recv.c
@@ -160,7 +160,8 @@ int recvEnsureMatchingTerms(struct raft *r, raft_term term, int *match)
     recvCheckMatchingTerms(r, term, match);
 
     if (*match == -1) {
-        tracef("old term - current_term:%llu other_term:%llu", r->current_term, term);
+        tracef("old term - current_term:%llu other_term:%llu", r->current_term,
+               term);
         return 0;
     }
 
@@ -205,7 +206,8 @@ int recvUpdateLeader(struct raft *r, const raft_id id, const char *address)
     if (r->follower_state.current_leader.address != NULL) {
         RaftHeapFree(r->follower_state.current_leader.address);
     }
-    r->follower_state.current_leader.address = RaftHeapMalloc(strlen(address) + 1);
+    r->follower_state.current_leader.address =
+        RaftHeapMalloc(strlen(address) + 1);
     if (r->follower_state.current_leader.address == NULL) {
         return RAFT_NOMEM;
     }

--- a/src/recv_append_entries.c
+++ b/src/recv_append_entries.c
@@ -33,8 +33,11 @@ int recvAppendEntries(struct raft *r,
     assert(id > 0);
     assert(args != NULL);
     assert(address != NULL);
-    tracef("self:%llu from:%llu@%s leader_commit:%llu n_entries:%d prev_log_index:%llu prev_log_term:%llu, term:%llu",
-            r->id, id, address, args->leader_commit, args->n_entries, args->prev_log_index, args->prev_log_term, args->term);
+    tracef(
+        "self:%llu from:%llu@%s leader_commit:%llu n_entries:%d "
+        "prev_log_index:%llu prev_log_term:%llu, term:%llu",
+        r->id, id, address, args->leader_commit, args->n_entries,
+        args->prev_log_index, args->prev_log_term, args->term);
 
     result->rejected = args->prev_log_index;
     result->last_log_index = logLastIndex(r->log);

--- a/src/recv_append_entries_result.c
+++ b/src/recv_append_entries_result.c
@@ -1,9 +1,9 @@
 #include "recv_append_entries_result.h"
 #include "assert.h"
 #include "configuration.h"
-#include "tracing.h"
 #include "recv.h"
 #include "replication.h"
+#include "tracing.h"
 
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
@@ -22,7 +22,8 @@ int recvAppendEntriesResult(struct raft *r,
     assert(result != NULL);
 
     tracef("self:%llu from:%llu@%s last_log_index:%llu rejected:%llu term:%llu",
-            r->id, id, address, result->last_log_index, result->rejected, result->term);
+           r->id, id, address, result->last_log_index, result->rejected,
+           result->term);
 
     if (r->state != RAFT_LEADER) {
         tracef("local server is not leader -> ignore");

--- a/src/recv_install_snapshot.c
+++ b/src/recv_install_snapshot.c
@@ -28,8 +28,11 @@ int recvInstallSnapshot(struct raft *r,
     bool async;
 
     assert(address != NULL);
-    tracef("self:%llu from:%llu@%s conf_index:%llu last_index:%llu last_term:%llu term:%llu",
-            r->id, id, address, args->conf_index, args->last_index, args->last_term, args->term);
+    tracef(
+        "self:%llu from:%llu@%s conf_index:%llu last_index:%llu last_term:%llu "
+        "term:%llu",
+        r->id, id, address, args->conf_index, args->last_index, args->last_term,
+        args->term);
 
     result->rejected = args->last_index;
     result->last_log_index = logLastIndex(r->log);

--- a/src/recv_request_vote.c
+++ b/src/recv_request_vote.c
@@ -30,10 +30,12 @@ int recvRequestVote(struct raft *r,
     assert(id > 0);
     assert(args != NULL);
 
-    tracef("self:%llu from:%llu@%s candidate_id:%llu disrupt_leader:%d last_log_index:%llu "
-           "last_log_term:%llu pre_vote:%d term:%llu",
-           r->id, id, address, args->candidate_id, args->disrupt_leader, args->last_log_index,
-           args->last_log_term, args->pre_vote, args->term);
+    tracef(
+        "self:%llu from:%llu@%s candidate_id:%llu disrupt_leader:%d "
+        "last_log_index:%llu "
+        "last_log_term:%llu pre_vote:%d term:%llu",
+        r->id, id, address, args->candidate_id, args->disrupt_leader,
+        args->last_log_index, args->last_log_term, args->pre_vote, args->term);
     result->vote_granted = false;
     result->pre_vote = args->pre_vote;
     result->version = RAFT_REQUEST_VOTE_RESULT_VERSION;
@@ -78,11 +80,12 @@ int recvRequestVote(struct raft *r,
 
     /* Reject the request if we are installing a snapshot.
      *
-     * This condition should only be reachable if the disrupt_leader flag is set,
-     * since otherwise we wouldn't have passed the have_leader check above (follower
-     * state is not cleared while a snapshot is being installed). */
+     * This condition should only be reachable if the disrupt_leader flag is
+     * set, since otherwise we wouldn't have passed the have_leader check above
+     * (follower state is not cleared while a snapshot is being installed). */
     if (replicationInstallSnapshotBusy(r)) {
-        tracef("installing snapshot -> reject (disrupt_leader:%d)", (int)args->disrupt_leader);
+        tracef("installing snapshot -> reject (disrupt_leader:%d)",
+               (int)args->disrupt_leader);
         goto reply;
     }
 
@@ -101,7 +104,8 @@ int recvRequestVote(struct raft *r,
      * same as the request term (otherwise we would have rejected the request or
      * bumped our term). */
     if (!args->pre_vote) {
-        tracef("no pre_vote: current_term:%llu term:%llu", r->current_term, args->term);
+        tracef("no pre_vote: current_term:%llu term:%llu", r->current_term,
+               args->term);
         assert(r->current_term == args->term);
     }
 
@@ -113,13 +117,13 @@ int recvRequestVote(struct raft *r,
 reply:
     result->term = r->current_term;
     /* Nodes don't update their term when seeing a Pre-Vote RequestVote RPC.
-     * To prevent the candidate from ignoring the response of this node if it has
-     * a smaller term than the candidate, we include the term of the request.
-     * The smaller term can occur if this node was partitioned from the cluster
-     * and has reestablished connectivity. This prevents a cluster deadlock
-     * when a majority of the nodes is online, but they fail to establish quorum
-     * because the vote of a former partitioned node with a smaller term is
-     * needed for majority.*/
+     * To prevent the candidate from ignoring the response of this node if it
+     * has a smaller term than the candidate, we include the term of the
+     * request. The smaller term can occur if this node was partitioned from the
+     * cluster and has reestablished connectivity. This prevents a cluster
+     * deadlock when a majority of the nodes is online, but they fail to
+     * establish quorum because the vote of a former partitioned node with a
+     * smaller term is needed for majority.*/
     if (args->pre_vote) {
         result->term = args->term;
     }

--- a/src/recv_request_vote_result.c
+++ b/src/recv_request_vote_result.c
@@ -24,9 +24,11 @@ int recvRequestVoteResult(struct raft *r,
     assert(r != NULL);
     assert(id > 0);
 
-    tracef("self:%llu from:%llu@%s term:%llu vote_granted:%d pre_vote:%d version:%d",
-    	    r->id, id, address, result->term, result->vote_granted, result->pre_vote,
-    	    result->version);
+    tracef(
+        "self:%llu from:%llu@%s term:%llu vote_granted:%d pre_vote:%d "
+        "version:%d",
+        r->id, id, address, result->term, result->vote_granted,
+        result->pre_vote, result->version);
     votes_index = configurationIndexOfVoter(&r->configuration, id);
     if (votes_index == r->configuration.n) {
         tracef("non-voting or unknown server -> reject");
@@ -67,7 +69,8 @@ int recvRequestVoteResult(struct raft *r,
     }
 
     /* Avoid counting pre-vote votes as regular votes. */
-    if (result->version > 1 && result->pre_vote && !r->candidate_state.in_pre_vote) {
+    if (result->version > 1 && result->pre_vote &&
+        !r->candidate_state.in_pre_vote) {
         tracef("receive stale pre-vote response -> ignore");
         return 0;
     }
@@ -76,7 +79,8 @@ int recvRequestVoteResult(struct raft *r,
      * sends real RequestVote RPCs, crashes, comes online, starts a pre-vote
      * and then receives the response to the RequestVote RPC it sent
      * out before crashing. */
-    if (result->version > 1 && !result->pre_vote && r->candidate_state.in_pre_vote) {
+    if (result->version > 1 && !result->pre_vote &&
+        r->candidate_state.in_pre_vote) {
         tracef("receive vote response during pre-vote -> ignore");
         return 0;
     }

--- a/src/recv_timeout_now.c
+++ b/src/recv_timeout_now.c
@@ -26,7 +26,11 @@ int recvTimeoutNow(struct raft *r,
 
     (void)address;
 
-    tracef("self:%llu from:%llu@%s last_log_index:%llu last_log_term:%llu term:%llu", r->id, id, address, args->last_log_index, args->last_log_term, args->term);
+    tracef(
+        "self:%llu from:%llu@%s last_log_index:%llu last_log_term:%llu "
+        "term:%llu",
+        r->id, id, address, args->last_log_index, args->last_log_term,
+        args->term);
     /* Ignore the request if we are not voters. */
     local_server = configurationGet(&r->configuration, r->id);
     if (local_server == NULL || local_server->role != RAFT_VOTER) {
@@ -38,7 +42,8 @@ int recvTimeoutNow(struct raft *r,
      * leader. */
     if (r->state != RAFT_FOLLOWER ||
         r->follower_state.current_leader.id != id) {
-        tracef("Ignore - r->state:%d current_leader.id:%llu", r->state, r->follower_state.current_leader.id);
+        tracef("Ignore - r->state:%d current_leader.id:%llu", r->state,
+               r->follower_state.current_leader.id);
         return 0;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -329,8 +329,8 @@ int replicationProgress(struct raft *r, unsigned i)
          * next_index - 1. */
         prev_index = next_index - 1;
         prev_term = logTermOf(r->log, prev_index);
-        /* If the entry is not anymore in our log, send the last snapshot if we're
-         * not doing so already. */
+        /* If the entry is not anymore in our log, send the last snapshot if
+         * we're not doing so already. */
         if (prev_term == 0 && !progress_state_is_snapshot) {
             assert(prev_index < snapshot_index);
             tracef("missing entry at index %lld -> send snapshot", prev_index);
@@ -1101,8 +1101,8 @@ int replicationAppend(struct raft *r,
      *   entry).
      */
     if (n == 0) {
-        if ((args->leader_commit > r->commit_index)
-             && !replicationInstallSnapshotBusy(r)) {
+        if ((args->leader_commit > r->commit_index) &&
+            !replicationInstallSnapshotBusy(r)) {
             r->commit_index = min(args->leader_commit, r->last_stored);
             rv = replicationApply(r);
             if (rv != 0) {
@@ -1131,11 +1131,11 @@ int replicationAppend(struct raft *r,
      * that we issue below actually completes.  */
     for (j = 0; j < n; j++) {
         struct raft_entry *entry = &args->entries[i + j];
-         /* TODO This copy should not strictly be necessary, as the batch logic will
-          * take care of freeing the batch buffer in which the entries are received.
-          * However, this would lead to memory spikes in certain edge cases.
-          * https://github.com/canonical/dqlite/issues/276
-          */
+        /* TODO This copy should not strictly be necessary, as the batch logic
+         * will take care of freeing the batch buffer in which the entries are
+         * received. However, this would lead to memory spikes in certain edge
+         * cases. https://github.com/canonical/dqlite/issues/276
+         */
         struct raft_entry copy = {0};
         rv = entryCopy(entry, &copy);
         if (rv != 0) {
@@ -1158,7 +1158,8 @@ int replicationAppend(struct raft *r,
     assert(request->args.n_entries == n);
     if (request->args.n_entries == 0) {
         tracef("No log entries found at index %llu", request->index);
-        ErrMsgPrintf(r->errmsg, "No log entries found at index %llu", request->index);
+        ErrMsgPrintf(r->errmsg, "No log entries found at index %llu",
+                     request->index);
         rv = RAFT_SHUTDOWN;
         goto err_after_acquire_entries;
     }
@@ -1226,17 +1227,19 @@ static void installSnapshotCb(struct raft_io_snapshot_put *req, int status)
         goto discard;
     }
     /* If the request is from a previous term, it means that someone else became
-     * a candidate while we were installing the snapshot. In that case, we want to
-     * install the snapshot anyway, but our "current leader" may no longer be the
-     * same as the server that sent the install request, so we shouldn't send a
-     * response to that server. */
+     * a candidate while we were installing the snapshot. In that case, we want
+     * to install the snapshot anyway, but our "current leader" may no longer be
+     * the same as the server that sent the install request, so we shouldn't
+     * send a response to that server. */
     if (request->term != r->current_term) {
-        tracef("new term since receiving snapshot -> install but don't respond");
+        tracef(
+            "new term since receiving snapshot -> install but don't respond");
         should_respond = false;
     }
 
     if (status != 0) {
-        tracef("save snapshot %llu: %s", snapshot->index, raft_strerror(status));
+        tracef("save snapshot %llu: %s", snapshot->index,
+               raft_strerror(status));
         goto discard;
     }
 
@@ -1248,7 +1251,8 @@ static void installSnapshotCb(struct raft_io_snapshot_put *req, int status)
      */
     rv = snapshotRestore(r, snapshot);
     if (rv != 0) {
-        tracef("restore snapshot %llu: %s", snapshot->index, raft_strerror(status));
+        tracef("restore snapshot %llu: %s", snapshot->index,
+               raft_strerror(status));
         goto discard;
     }
 
@@ -1440,7 +1444,8 @@ static void applyChange(struct raft *r, const raft_index index)
          */
         server = configurationGet(&r->configuration, r->id);
         if (server == NULL || server->role != RAFT_VOTER) {
-            tracef("leader removed from config or no longer voter server: %p", (void*)server);
+            tracef("leader removed from config or no longer voter server: %p",
+                   (void *)server);
             convertToFollower(r);
         }
 
@@ -1507,7 +1512,8 @@ static void takeSnapshotCb(struct raft_io_snapshot_put *req, int status)
      * write. Therefore, we only need to backup a configuration in case
      * configuration_index == snapshot->configuration_index, i.e. the last
      * committed configuration is the configuration in the snapshot. (for
-     * simplicity this doesn't take into account the snapshot trailing parameter)*/
+     * simplicity this doesn't take into account the snapshot trailing
+     * parameter)*/
     if (r->configuration_index == snapshot->configuration_index) {
         rv = configurationBackup(r, &snapshot->configuration);
         if (rv != 0) {
@@ -1522,7 +1528,8 @@ out:
     r->snapshot.pending.term = 0;
 }
 
-static int putSnapshot(struct raft *r, struct raft_snapshot *snapshot,
+static int putSnapshot(struct raft *r,
+                       struct raft_snapshot *snapshot,
                        raft_io_snapshot_put_cb cb)
 {
     int rv;
@@ -1539,8 +1546,8 @@ static int putSnapshot(struct raft *r, struct raft_snapshot *snapshot,
     return rv;
 }
 
-static void takeSnapshotDoneCb(struct raft_io_async_work *take,
-                               int status) {
+static void takeSnapshotDoneCb(struct raft_io_async_work *take, int status)
+{
     struct raft *r = take->data;
     struct raft_snapshot *snapshot = &r->snapshot.pending;
     int rv;
@@ -1569,7 +1576,8 @@ static int takeSnapshotAsync(struct raft_io_async_work *take)
     return r->fsm->snapshot_async(r->fsm, &snapshot->bufs, &snapshot->n_bufs);
 }
 
-static int copyLastCommittedConfiguration(const struct raft *r, struct raft_configuration *dst)
+static int copyLastCommittedConfiguration(const struct raft *r,
+                                          struct raft_configuration *dst)
 {
     const struct raft_entry *entry;
     int rv;

--- a/src/replication.c
+++ b/src/replication.c
@@ -450,8 +450,7 @@ static struct request *getRequest(struct raft *r,
     if (r->state != RAFT_LEADER) {
         return NULL;
     }
-    QUEUE_FOREACH(head, &r->leader_state.requests)
-    {
+    QUEUE_FOREACH (head, &r->leader_state.requests) {
         req = QUEUE_DATA(head, struct request, queue);
         if (req->index == index) {
             assert(req->type == type);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -44,7 +44,8 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
     r->configuration = snapshot->configuration;
     r->configuration_index = snapshot->configuration_index;
     r->configuration_uncommitted_index = 0;
-    configurationTrace(r, &r->configuration, "configuration restore from snapshot");
+    configurationTrace(r, &r->configuration,
+                       "configuration restore from snapshot");
 
     r->commit_index = snapshot->index;
     r->last_applied = snapshot->index;

--- a/src/start.c
+++ b/src/start.c
@@ -13,8 +13,10 @@
 #define tracef(...) Tracef(r->tracer, __VA_ARGS__)
 
 /* Restore the most recent configurations. */
-static int restoreConfigurations(struct raft *r, raft_index prev_index,
-                                 raft_index last_index, struct raft_entry *last)
+static int restoreConfigurations(struct raft *r,
+                                 raft_index prev_index,
+                                 raft_index last_index,
+                                 struct raft_entry *last)
 {
     struct raft_configuration last_conf;
     int rv;
@@ -53,7 +55,8 @@ static int restoreConfigurations(struct raft *r, raft_index prev_index,
         }
     }
 
-    configurationTrace(r, &r->configuration, "restore most recent configuration");
+    configurationTrace(r, &r->configuration,
+                       "restore most recent configuration");
     return 0;
 }
 
@@ -89,7 +92,8 @@ static int restoreEntries(struct raft *r,
         r->last_stored++;
         /* Only take configurations into account that are newer than the
          * configuration restored from the snapshot. */
-        if (entry->type == RAFT_CHANGE && r->last_stored > r->configuration_index) {
+        if (entry->type == RAFT_CHANGE &&
+            r->last_stored > r->configuration_index) {
             prev_conf_index = last_conf_index;
             last_conf = entry;
             last_conf_index = r->last_stored;
@@ -177,8 +181,8 @@ int raft_start(struct raft *r)
         snapshot_term = snapshot->term;
         raft_free(snapshot);
 
-        /* Enable configuration rollback if the next configuration after installing
-         * this snapshot needs to be rolled back. */
+        /* Enable configuration rollback if the next configuration after
+         * installing this snapshot needs to be rolled back. */
         rv = configurationBackup(r, &r->configuration);
         if (rv != 0) {
             tracef("failed to backup current configuration.");

--- a/src/state.c
+++ b/src/state.c
@@ -45,9 +45,10 @@ raft_index raft_last_applied(struct raft *r)
 
 int raft_role(struct raft *r)
 {
-    const struct raft_server *local = configurationGet(&r->configuration, r->id);
+    const struct raft_server *local =
+        configurationGet(&r->configuration, r->id);
     if (local == NULL) {
-	    return -1;
+        return -1;
     }
     return local->role;
 }

--- a/src/tick.c
+++ b/src/tick.c
@@ -171,7 +171,8 @@ static int tickLeader(struct raft *r)
         /* Abort the promotion if we are at the 10'th round and it's still
          * taking too long, or if the server is unresponsive. */
         if (is_too_slow || is_unresponsive) {
-            tracef("server_index:%d is_too_slow:%d is_unresponsive:%d", server_index, is_too_slow, is_unresponsive);
+            tracef("server_index:%d is_too_slow:%d is_unresponsive:%d",
+                   server_index, is_too_slow, is_unresponsive);
             struct raft_change *change;
 
             r->leader_state.promotee_id = 0;

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -14,8 +14,9 @@ static inline void noopTracerEmit(struct raft_tracer *t,
     (void)line;
     (void)message;
 }
-struct raft_tracer NoopTracer = {.impl = NULL, .enabled = false, .emit = noopTracerEmit};
-
+struct raft_tracer NoopTracer = {.impl = NULL,
+                                 .enabled = false,
+                                 .emit = noopTracerEmit};
 
 static inline void stderrTracerEmit(struct raft_tracer *t,
                                     const char *file,
@@ -27,9 +28,12 @@ static inline void stderrTracerEmit(struct raft_tracer *t,
     /* ignore errors */
     clock_gettime(CLOCK_REALTIME, &ts);
     int64_t ns = ts.tv_sec * 1000000000 + ts.tv_nsec;
-    fprintf(stderr, "LIBRAFT   %" PRId64 " %s:%d %s\n", ns, file, line, message);
+    fprintf(stderr, "LIBRAFT   %" PRId64 " %s:%d %s\n", ns, file, line,
+            message);
 }
-struct raft_tracer StderrTracer = {.impl = NULL, .enabled = false, .emit = stderrTracerEmit};
+struct raft_tracer StderrTracer = {.impl = NULL,
+                                   .enabled = false,
+                                   .emit = stderrTracerEmit};
 
 void raft_tracer_maybe_enable(struct raft_tracer *tracer, bool enabled)
 {

--- a/src/uv.c
+++ b/src/uv.c
@@ -29,7 +29,7 @@
 #define CONNECT_RETRY_DELAY 1000
 
 /* Cleans up files that are no longer used by the system */
-static int uvMaintenance(const char *dir, char* errmsg)
+static int uvMaintenance(const char *dir, char *errmsg)
 {
     struct uv_fs_s req;
     struct uv_dirent_s entry;
@@ -454,8 +454,9 @@ err:
      * might have cleaned up corrupt data. Most of the arguments are already
      * reset after the `err` label, except for `start_index`. */
     if (rv == RAFT_CORRUPT && uv->auto_recovery && depth == 0) {
-	*start_index = 1;
-    	return uvLoadSnapshotAndEntries(uv, snapshot, start_index, entries, n, depth + 1);
+        *start_index = 1;
+        return uvLoadSnapshotAndEntries(uv, snapshot, start_index, entries, n,
+                                        depth + 1);
     }
     return rv;
 }
@@ -477,8 +478,8 @@ static int uvLoad(struct raft_io *io,
     *voted_for = uv->metadata.voted_for;
     *snapshot = NULL;
 
-    rv =
-        uvLoadSnapshotAndEntries(uv, snapshot, start_index, entries, n_entries, 0);
+    rv = uvLoadSnapshotAndEntries(uv, snapshot, start_index, entries, n_entries,
+                                  0);
     if (rv != 0) {
         return rv;
     }
@@ -602,7 +603,7 @@ static raft_time uvTime(struct raft_io *io)
 /* Implementation of raft_io->random. */
 static int uvRandom(struct raft_io *io, int min, int max)
 {
-    (void) io;
+    (void)io;
     return min + (abs(rand()) % (max - min));
 }
 
@@ -613,8 +614,8 @@ static void uvSeedRand(struct uv *uv)
 
     sz = getrandom(&seed, sizeof seed, GRND_NONBLOCK);
     if (sz == -1 || sz < ((ssize_t)sizeof seed)) {
-        /* Fall back to an inferior random seed when `getrandom` would have blocked or
-         * when not enough randomness was returned. */
+        /* Fall back to an inferior random seed when `getrandom` would have
+         * blocked or when not enough randomness was returned. */
         seed ^= (unsigned)uv->id;
         seed ^= (unsigned)uv_now(uv->loop);
         struct timeval time = {0};
@@ -665,8 +666,8 @@ int raft_uv_init(struct raft_io *io,
 
     uv->io = io;
     uv->loop = loop;
-    strncpy(uv->dir, dir, sizeof(uv->dir)-1);
-    uv->dir[sizeof(uv->dir)-1] = '\0';
+    strncpy(uv->dir, dir, sizeof(uv->dir) - 1);
+    uv->dir[sizeof(uv->dir) - 1] = '\0';
     uv->transport = transport;
     uv->transport->data = NULL;
     uv->tracer = &StderrTracer;

--- a/src/uv.h
+++ b/src/uv.h
@@ -31,7 +31,8 @@
 
 /* Template string for snapshot metadata filenames: snapshot term,  snapshot
  * index, creation timestamp (milliseconds since epoch). */
-#define UV__SNAPSHOT_META_TEMPLATE UV__SNAPSHOT_TEMPLATE UV__SNAPSHOT_META_SUFFIX
+#define UV__SNAPSHOT_META_TEMPLATE \
+    UV__SNAPSHOT_TEMPLATE UV__SNAPSHOT_META_SUFFIX
 
 /* State codes. */
 enum {
@@ -92,7 +93,7 @@ struct uv
     queue aborting;                      /* Cleanups upon errors or shutdown */
     bool closing;                        /* True if we are closing */
     raft_io_close_cb close_cb;           /* Invoked when finishing closing */
-    bool auto_recovery;                  /* Try to recover from corrupt segments */
+    bool auto_recovery; /* Try to recover from corrupt segments */
 };
 
 /* Implementation of raft_io->truncate. */
@@ -274,7 +275,6 @@ int UvSnapshotGet(struct raft_io *io,
                   struct raft_io_snapshot_get *req,
                   raft_io_snapshot_get_cb cb);
 
-
 /* Implementation of raft_io->async_work (defined in uv_work.c). */
 int UvAsyncWork(struct raft_io *io,
                 struct raft_io_async_work *req,
@@ -318,8 +318,9 @@ int UvPrepare(struct uv *uv,
  * and then remove it immediately. */
 void UvPrepareClose(struct uv *uv);
 
-/* Implementation of raft_io->append. All the raft_buffers of the raft_entry structs
- * in the entries array are required to have a len that is a multiple of 8. */
+/* Implementation of raft_io->append. All the raft_buffers of the raft_entry
+ * structs in the entries array are required to have a len that is a multiple
+ * of 8. */
 int UvAppend(struct raft_io *io,
              struct raft_io_append *req,
              const struct raft_entry entries[],

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -272,14 +272,14 @@ out:
         if (rv != 0) {
             uv->errored = true;
         }
-    } else if (s->finalize
-               && (s->pending_last_index == s->last_index)
-               && !s->writer.closing) {
+    } else if (s->finalize && (s->pending_last_index == s->last_index) &&
+               !s->writer.closing) {
         /* If there are no more append_pending_reqs or write requests in flight,
          * this segment must be finalized here in case we don't receive
          * AppendEntries RPCs anymore (could happen during a Snapshot install,
-         * causing the BarrierCb to never fire), but check that the callbacks that
-         * fired after completion of this write didn't already close the segment. */
+         * causing the BarrierCb to never fire), but check that the callbacks
+         * that fired after completion of this write didn't already close the
+         * segment. */
         uvAliveSegmentFinalize(s);
     }
 }
@@ -331,12 +331,13 @@ start:
         return 0;
     }
 
-    /* If there's a blocking barrier in progress, and it's not waiting for this segment
-     * to be finalized, let's wait.
+    /* If there's a blocking barrier in progress, and it's not waiting for this
+     * segment to be finalized, let's wait.
      *
-     * FIXME shouldn't we wait even if segment->barrier == uv->barrier, if there are
-     * other open segments associated with the same barrier? */
-    if (uv->barrier != NULL && segment->barrier != uv->barrier && uv->barrier->blocking) {
+     * FIXME shouldn't we wait even if segment->barrier == uv->barrier, if there
+     * are other open segments associated with the same barrier? */
+    if (uv->barrier != NULL && segment->barrier != uv->barrier &&
+        uv->barrier->blocking) {
         return 0;
     }
 
@@ -636,7 +637,8 @@ static int uvCheckEntryBuffersAligned(struct uv *uv,
 
     for (i = 0; i < n; i++) {
         if (entries[i].buf.len % 8) {
-            ErrMsgPrintf(uv->io->errmsg, "entry buffers must be 8-byte aligned");
+            ErrMsgPrintf(uv->io->errmsg,
+                         "entry buffers must be 8-byte aligned");
             Tracef(uv->tracer, "%s", uv->io->errmsg);
             return RAFT_INVALID;
         }
@@ -748,7 +750,7 @@ bool UvBarrierReady(struct uv *uv)
         struct uvAliveSegment *segment;
         segment = QUEUE_DATA(head, struct uvAliveSegment, queue);
         if (segment->barrier == uv->barrier) {
-                return false;
+            return false;
         }
     }
     return true;
@@ -845,12 +847,12 @@ static void uvBarrierClose(struct uv *uv)
          *
          * - by UvBarrierReady, to check whether it's time to invoke the barrier
          *   callback after successfully finalizing a segment
-         * - by uvAppendMaybeStart, to see whether we should go ahead with writing
-         *   to a segment even though a barrier is active because the barrier is
-         *   waiting on that same segment to be finalized (but see the FIXME in
-         *   that function)
-         * - to save a barrier for later, if UvBarrier was called when uv->barrier
-         *   was already set
+         * - by uvAppendMaybeStart, to see whether we should go ahead with
+         * writing to a segment even though a barrier is active because the
+         * barrier is waiting on that same segment to be finalized (but see the
+         * FIXME in that function)
+         * - to save a barrier for later, if UvBarrier was called when
+         * uv->barrier was already set
          *
          * If we're cancelling the barrier, we don't need to save it for later;
          * the callback will not be invoked a second time in any case; and

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -715,8 +715,7 @@ static void uvFinalizeCurrentAliveSegmentOnceIdle(struct uv *uv)
     /* Check if there are pending append requests targeted to the current
      * segment. */
     has_pending_reqs = false;
-    QUEUE_FOREACH(head, &uv->append_pending_reqs)
-    {
+    QUEUE_FOREACH (head, &uv->append_pending_reqs) {
         struct uvAppend *r = QUEUE_DATA(head, struct uvAppend, queue);
         if (r->segment == s) {
             has_pending_reqs = true;
@@ -745,8 +744,7 @@ bool UvBarrierReady(struct uv *uv)
     }
 
     queue *head;
-    QUEUE_FOREACH(head, &uv->append_segments)
-    {
+    QUEUE_FOREACH (head, &uv->append_segments) {
         struct uvAliveSegment *segment;
         segment = QUEUE_DATA(head, struct uvAliveSegment, queue);
         if (segment->barrier == uv->barrier) {
@@ -771,8 +769,7 @@ int UvBarrier(struct uv *uv,
     /* Arrange for all open segments not already involved in other barriers to
      * be finalized as soon as their append requests get completed and mark them
      * as involved in this specific barrier request.  */
-    QUEUE_FOREACH(head, &uv->append_segments)
-    {
+    QUEUE_FOREACH (head, &uv->append_segments) {
         struct uvAliveSegment *segment;
         segment = QUEUE_DATA(head, struct uvAliveSegment, queue);
         if (segment->barrier != NULL) {
@@ -830,8 +827,7 @@ static void uvBarrierClose(struct uv *uv)
     struct UvBarrier *barrier = NULL;
     queue *head;
     assert(uv->closing);
-    QUEUE_FOREACH(head, &uv->append_segments)
-    {
+    QUEUE_FOREACH (head, &uv->append_segments) {
         struct uvAliveSegment *segment;
         segment = QUEUE_DATA(head, struct uvAliveSegment, queue);
         if (segment->barrier != NULL && segment->barrier != barrier) {

--- a/src/uv_encoding.c
+++ b/src/uv_encoding.c
@@ -36,8 +36,7 @@ static size_t sizeofRequestVoteResultV1(void)
 
 static size_t sizeofRequestVoteResult(void)
 {
-    return sizeofRequestVoteResultV1() +
-           sizeof(uint64_t) /* Flags. */;
+    return sizeofRequestVoteResultV1() + sizeof(uint64_t) /* Flags. */;
 }
 
 static size_t sizeofAppendEntries(const struct raft_append_entries *p)

--- a/src/uv_encoding.c
+++ b/src/uv_encoding.c
@@ -36,7 +36,8 @@ static size_t sizeofRequestVoteResultV1(void)
 
 static size_t sizeofRequestVoteResult(void)
 {
-    return sizeofRequestVoteResultV1() + sizeof(uint64_t) /* Flags. */;
+    return sizeofRequestVoteResultV1() + /* Size of older version 1 message */
+           sizeof(uint64_t) /* Flags. */;
 }
 
 static size_t sizeofAppendEntries(const struct raft_append_entries *p)

--- a/src/uv_encoding.h
+++ b/src/uv_encoding.h
@@ -56,5 +56,4 @@ void uvEncodeBatchHeader(const struct raft_entry *entries,
                          unsigned n,
                          void *buf);
 
-
 #endif /* UV_ENCODING_H_ */

--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -90,7 +90,8 @@ static void uvFinalizeAfterWorkCb(uv_work_t *work, int status)
      * barrier to unblock or if we are done closing. */
     if (QUEUE_IS_EMPTY(&uv->finalize_reqs)) {
         tracef("unblock barrier or close");
-        if (uv->barrier != NULL && UvBarrierReady(uv) && uv->barrier->cb != NULL) {
+        if (uv->barrier != NULL && UvBarrierReady(uv) &&
+            uv->barrier->cb != NULL) {
             uv->barrier->cb(uv->barrier);
         }
         uvMaybeFireCloseCb(uv);

--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -282,7 +282,7 @@ int UvFsMakeFile(const char *dir,
                  char *errmsg)
 {
     int rv;
-    char tmp_filename[UV__FILENAME_LEN+1] = {0};
+    char tmp_filename[UV__FILENAME_LEN + 1] = {0};
     char path[UV__PATH_SZ] = {0};
     char tmp_path[UV__PATH_SZ] = {0};
 
@@ -290,7 +290,7 @@ int UvFsMakeFile(const char *dir,
      * TODO as of libuv 1.34.0, use `uv_fs_mkstemp` */
     size_t sz = sizeof(tmp_filename);
     rv = snprintf(tmp_filename, sz, TMP_FILE_FMT, filename);
-    if (rv < 0 || rv >= (int) sz) {
+    if (rv < 0 || rv >= (int)sz) {
         return rv;
     }
     int flags = UV_FS_O_WRONLY | UV_FS_O_CREAT | UV_FS_O_EXCL;
@@ -422,7 +422,7 @@ int UvFsReadInto(uv_file fd, struct raft_buffer *buf, char *errmsg)
 
     /* TODO: use uv_fs_read() */
     while (offset < buf->len) {
-        rv = read(fd, (char*)buf->base + offset, buf->len - offset);
+        rv = read(fd, (char *)buf->base + offset, buf->len - offset);
         if (rv == -1) {
             UvOsErrMsg(errmsg, "read", -errno);
             return RAFT_IOERR;
@@ -546,9 +546,9 @@ int UvFsRemoveFile(const char *dir, const char *filename, char *errmsg)
 }
 
 int UvFsRenameFile(const char *dir,
-		   const char *filename1,
-		   const char *filename2,
-		   char *errmsg)
+                   const char *filename1,
+                   const char *filename2,
+                   char *errmsg)
 {
     char path1[UV__PATH_SZ];
     char path2[UV__PATH_SZ];

--- a/src/uv_fs.h
+++ b/src/uv_fs.h
@@ -99,9 +99,9 @@ int UvFsTruncateAndRenameFile(const char *dir,
 
 /* Synchronously rename a file. */
 int UvFsRenameFile(const char *dir,
-		   const char *filename1,
-		   const char *filename2,
-		   char *errmsg);
+                   const char *filename1,
+                   const char *filename2,
+                   char *errmsg);
 
 /* Return information about the I/O capabilities of the underlying file
  * system.

--- a/src/uv_metadata.c
+++ b/src/uv_metadata.c
@@ -101,8 +101,8 @@ static int uvMetadataLoadN(const char *dir,
             }
             return 0;
         }
-        ErrMsgPrintf(errmsg, "%s has size %jd instead of %zu", filename, (intmax_t)size,
-                     sizeof content);
+        ErrMsgPrintf(errmsg, "%s has size %jd instead of %zu", filename,
+                     (intmax_t)size, sizeof content);
         return RAFT_CORRUPT;
     }
 

--- a/src/uv_prepare.c
+++ b/src/uv_prepare.c
@@ -132,7 +132,10 @@ static unsigned uvPrepareCount(struct uv *uv)
     queue *head;
     unsigned n;
     n = 0;
-    QUEUE_FOREACH(head, &uv->prepare_pool) { n++; }
+    QUEUE_FOREACH(head, &uv->prepare_pool)
+    {
+        n++;
+    }
     return n;
 }
 

--- a/src/uv_prepare.c
+++ b/src/uv_prepare.c
@@ -132,8 +132,7 @@ static unsigned uvPrepareCount(struct uv *uv)
     queue *head;
     unsigned n;
     n = 0;
-    QUEUE_FOREACH(head, &uv->prepare_pool)
-    {
+    QUEUE_FOREACH (head, &uv->prepare_pool) {
         n++;
     }
     return n;

--- a/src/uv_recv.c
+++ b/src/uv_recv.c
@@ -252,15 +252,15 @@ static void uvServerReadCb(uv_stream_t *stream,
 
             type = byteFlip64(s->preamble[0]);
 
-	    /* Only use first 2 bytes of the type. Normally we would check if
-	     * type doesn't overflow UINT16_MAX, but we don't do this to allow
-	     * future legacy nodes to still handle messages that include extra
-	     * information in the 6 unused bytes of the type field of the
-	     * preamble.
-	     * TODO: This is preparation to add the version of the message
-	     * in the raft preamble. Once this change has been active for
-	     * sufficiently long time, we can start encoding the version in some
-	     * of the remaining bytes of s->preamble[0]. */
+            /* Only use first 2 bytes of the type. Normally we would check if
+             * type doesn't overflow UINT16_MAX, but we don't do this to allow
+             * future legacy nodes to still handle messages that include extra
+             * information in the 6 unused bytes of the type field of the
+             * preamble.
+             * TODO: This is preparation to add the version of the message
+             * in the raft preamble. Once this change has been active for
+             * sufficiently long time, we can start encoding the version in some
+             * of the remaining bytes of s->preamble[0]. */
             rv = uvDecodeMessage((uint16_t)type, &s->header, &s->message,
                                  &s->payload.len);
             if (rv != 0) {

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -595,7 +595,8 @@ done:
 
         /* At least one entry was loaded */
         assert(end_index >= first_index);
-        int nb = snprintf(filename, sizeof(filename), UV__CLOSED_TEMPLATE, first_index, end_index);
+        int nb = snprintf(filename, sizeof(filename), UV__CLOSED_TEMPLATE,
+                          first_index, end_index);
         if ((nb < 0) || ((size_t)nb >= sizeof(filename))) {
             tracef("snprintf failed: %d", nb);
             rv = RAFT_IOERR;
@@ -616,7 +617,8 @@ done:
         info->first_index = first_index;
         info->end_index = end_index;
         memset(info->filename, '\0', sizeof(info->filename));
-        _Static_assert(sizeof(info->filename) >= sizeof(filename), "Destination buffer too small");
+        _Static_assert(sizeof(info->filename) >= sizeof(filename),
+                       "Destination buffer too small");
         /* info->filename is zeroed out, info->filename is at least as large as
          * filename and we checked that nb < sizeof(filename) -> we won't
          * overflow and the result will be zero terminated. */
@@ -806,11 +808,11 @@ void uvSegmentBufferReset(struct uvSegmentBuffer *b, unsigned retain)
  * Upon a restart, raft will not detect the segment anymore and will try
  * to start without it.
  * */
-#define CORRUPT_FILE_FMT "corrupt-%"PRId64"-%s"
+#define CORRUPT_FILE_FMT "corrupt-%" PRId64 "-%s"
 static void uvMoveCorruptSegment(struct uv *uv, struct uvSegmentInfo *info)
 {
     char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
-    char new_filename[UV__FILENAME_LEN+1] = {0};
+    char new_filename[UV__FILENAME_LEN + 1] = {0};
     size_t sz = sizeof(new_filename);
     int rv;
 
@@ -834,12 +836,13 @@ static void uvMoveCorruptSegment(struct uv *uv, struct uvSegmentInfo *info)
 /*
  * On startup, raft will try to recover when a corrupt segment is detected.
  *
- * When a corrupt open segment is encountered, it, and all subsequent open segments,
- * are renamed. Not renaming newer, possible non-corrupt, open segments could lead
- * to loading inconsistent data.
+ * When a corrupt open segment is encountered, it, and all subsequent open
+ * segments, are renamed. Not renaming newer, possible non-corrupt, open
+ * segments could lead to loading inconsistent data.
  *
  * When a corrupt closed segment is encountered, it will be renamed when
- * it is the last closed segment, in that case all open-segments are renamed too.
+ * it is the last closed segment, in that case all open-segments are renamed
+ * too.
  */
 static void uvRecoverFromCorruptSegment(struct uv *uv,
                                         size_t i_corrupt,

--- a/src/uv_send.c
+++ b/src/uv_send.c
@@ -264,8 +264,7 @@ static unsigned uvClientPendingCount(struct uvClient *c)
 {
     queue *head;
     unsigned n = 0;
-    QUEUE_FOREACH(head, &c->pending)
-    {
+    QUEUE_FOREACH (head, &c->pending) {
         n++;
     }
     return n;
@@ -413,8 +412,7 @@ static int uvGetClient(struct uv *uv,
     int rv;
 
     /* Check if we already have a client object for this peer server. */
-    QUEUE_FOREACH(head, &uv->clients)
-    {
+    QUEUE_FOREACH (head, &uv->clients) {
         *client = QUEUE_DATA(head, struct uvClient, queue);
         if ((*client)->id != id) {
             continue;

--- a/src/uv_send.c
+++ b/src/uv_send.c
@@ -264,7 +264,10 @@ static unsigned uvClientPendingCount(struct uvClient *c)
 {
     queue *head;
     unsigned n = 0;
-    QUEUE_FOREACH(head, &c->pending) { n++; }
+    QUEUE_FOREACH(head, &c->pending)
+    {
+        n++;
+    }
     return n;
 }
 

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -32,11 +32,11 @@ static bool uvSnapshotParseFilename(const char *filename,
     size_t filename_len = strlen(filename);
     assert(filename_len < UV__FILENAME_LEN);
     if (meta) {
-        matched = sscanf(filename, UV__SNAPSHOT_META_TEMPLATE "%n",
-                         term, index, timestamp, &consumed);
+        matched = sscanf(filename, UV__SNAPSHOT_META_TEMPLATE "%n", term, index,
+                         timestamp, &consumed);
     } else {
-        matched = sscanf(filename, UV__SNAPSHOT_TEMPLATE "%n",
-                         term, index, timestamp, &consumed);
+        matched = sscanf(filename, UV__SNAPSHOT_TEMPLATE "%n", term, index,
+                         timestamp, &consumed);
     }
     if (matched != 3 || consumed != (int)filename_len) {
         return false;
@@ -53,7 +53,8 @@ static bool uvSnapshotParseFilename(const char *filename,
 static bool uvSnapshotInfoMatch(const char *filename,
                                 struct uvSnapshotInfo *info)
 {
-    if (!uvSnapshotParseFilename(filename, true, &info->term, &info->index, &info->timestamp)) {
+    if (!uvSnapshotParseFilename(filename, true, &info->term, &info->index,
+                                 &info->timestamp)) {
         return false;
     }
     /* Allow room for '\0' terminator */
@@ -132,7 +133,10 @@ int UvSnapshotInfoAppendIfMatch(struct uv *uv,
     return 0;
 }
 
-static int uvSnapshotIsOrphanInternal(const char *dir, const char *filename, bool meta, bool *orphan)
+static int uvSnapshotIsOrphanInternal(const char *dir,
+                                      const char *filename,
+                                      bool meta,
+                                      bool *orphan)
 {
     int rv;
     *orphan = false;
@@ -144,14 +148,15 @@ static int uvSnapshotIsOrphanInternal(const char *dir, const char *filename, boo
         return 0;
     }
 
-    /* filename is a well-formed snapshot filename, check if the sibling file exists. */
+    /* filename is a well-formed snapshot filename, check if the sibling file
+     * exists. */
     char sibling_filename[UV__FILENAME_LEN];
     if (meta) {
         rv = snprintf(sibling_filename, UV__FILENAME_LEN, UV__SNAPSHOT_TEMPLATE,
                       term, index, timestamp);
     } else {
-        rv = snprintf(sibling_filename, UV__FILENAME_LEN, UV__SNAPSHOT_META_TEMPLATE,
-                      term, index, timestamp);
+        rv = snprintf(sibling_filename, UV__FILENAME_LEN,
+                      UV__SNAPSHOT_META_TEMPLATE, term, index, timestamp);
     }
 
     if (rv >= UV__FILENAME_LEN) {
@@ -477,10 +482,10 @@ out:
 }
 
 static int makeFileCompressed(const char *dir,
-                           const char *filename,
-                           struct raft_buffer *bufs,
-                           unsigned n_bufs,
-                           char *errmsg)
+                              const char *filename,
+                              struct raft_buffer *bufs,
+                              unsigned n_bufs,
+                              char *errmsg)
 {
     int rv;
 
@@ -687,7 +692,8 @@ int UvSnapshotPut(struct raft_io *io,
      * all current open segments. New writes can continue on newly opened
      * segments that will only contain entries that are newer than the snapshot,
      * and we don't change append_next_index. */
-    next_index = (trailing == 0) ? (snapshot->index + 1) : uv->append_next_index;
+    next_index =
+        (trailing == 0) ? (snapshot->index + 1) : uv->append_next_index;
     rv = UvBarrier(uv, next_index, &put->barrier, uvSnapshotPutBarrierCb);
     if (rv != 0) {
         goto err_after_configuration_encode;

--- a/src/uv_tcp.h
+++ b/src/uv_tcp.h
@@ -13,8 +13,9 @@ struct UvTcp
     struct uv_loop_s *loop;              /* Event loop */
     raft_id id;                          /* ID of this raft server */
     const char *address;                 /* Address of this raft server */
-    unsigned n_listeners;                /* The number of listener sockets (multi IPs) */
-    struct uv_tcp_s* listeners;          /* The array of tcp listen sockets (multi IPs) */
+    unsigned n_listeners; /* The number of listener sockets (multi IPs) */
+    struct uv_tcp_s
+        *listeners; /* The array of tcp listen sockets (multi IPs) */
     raft_uv_accept_cb accept_cb;         /* Call after accepting a connection */
     queue accepting;                     /* Connections being accepted */
     queue connecting;                    /* Pending connection requests */

--- a/src/uv_tcp.h
+++ b/src/uv_tcp.h
@@ -13,9 +13,8 @@ struct UvTcp
     struct uv_loop_s *loop;              /* Event loop */
     raft_id id;                          /* ID of this raft server */
     const char *address;                 /* Address of this raft server */
-    unsigned n_listeners; /* The number of listener sockets (multi IPs) */
-    struct uv_tcp_s
-        *listeners; /* The array of tcp listen sockets (multi IPs) */
+    unsigned n_listeners;                /* Number of listener sockets */
+    struct uv_tcp_s *listeners;          /* Listener sockets */
     raft_uv_accept_cb accept_cb;         /* Call after accepting a connection */
     queue accepting;                     /* Connections being accepted */
     queue connecting;                    /* Pending connection requests */

--- a/src/uv_tcp_connect.c
+++ b/src/uv_tcp_connect.c
@@ -39,13 +39,13 @@ struct uvTcpConnect
     uv_buf_t handshake;                  /* Handshake data */
     struct uv_tcp_s *tcp;                /* TCP connection socket handle */
     struct uv_getaddrinfo_s getaddrinfo; /* DNS resolve request */
-    const struct addrinfo* ai_current;   /* The current sockaddr to connect to */
-    struct uv_connect_s connect;         /* TCP connection request */
-    struct uv_write_s write;             /* TCP handshake request */
-    int status;                          /* Returned to the request callback */
-    bool resolving;                      /* Indicate name resolving in progress */
-    bool retry;                          /* Indicate tcp connect failure handling */
-    queue queue;                         /* Pending connect queue */
+    const struct addrinfo *ai_current; /* The current sockaddr to connect to */
+    struct uv_connect_s connect;       /* TCP connection request */
+    struct uv_write_s write;           /* TCP handshake request */
+    int status;                        /* Returned to the request callback */
+    bool resolving;                    /* Indicate name resolving in progress */
+    bool retry;  /* Indicate tcp connect failure handling */
+    queue queue; /* Pending connect queue */
 };
 
 /* Encode an handshake message into the given buffer. */
@@ -150,7 +150,8 @@ static void uvTcpTryNextConnectCb(struct uv_handle_s *handle)
 
     if (t->closing) {
         connect->status = RAFT_CANCELED;
-        /* We are already in close cb for the tcp handle, simply invoke final cb */
+        /* We are already in close cb for the tcp handle, simply invoke final cb
+         */
         uvTcpConnectUvCloseCb(handle);
         return;
     }

--- a/src/uv_tcp_listen.c
+++ b/src/uv_tcp_listen.c
@@ -35,9 +35,9 @@ struct uvTcpHandshake
 /* Hold handshake data for a new connection being established. */
 struct uvTcpIncoming
 {
-    struct UvTcp *t;                 /* Transport implementation */
-    struct uv_tcp_s *listener;      /* The tcp handle, which accepted this socket */
-    struct uv_tcp_s *tcp;            /* TCP connection socket handle */
+    struct UvTcp *t;           /* Transport implementation */
+    struct uv_tcp_s *listener; /* The tcp handle, which accepted this socket */
+    struct uv_tcp_s *tcp;      /* TCP connection socket handle */
     struct uvTcpHandshake handshake; /* Handshake data */
     queue queue;                     /* Pending accept queue */
 };

--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -146,7 +146,7 @@ static void uvTruncateBarrierCb(struct UvBarrier *barrier)
                        uvTruncateAfterWorkCb);
     if (rv != 0) {
         tracef("truncate index %lld: %s", truncate->index, uv_strerror(rv));
-	tracef("clear truncate work");
+        tracef("clear truncate work");
         uv->truncate_work.data = NULL;
         uv->errored = true;
     }

--- a/src/uv_writer.c
+++ b/src/uv_writer.c
@@ -149,8 +149,8 @@ static void uvWriterPollCb(uv_poll_t *poller, int status, int events)
     assert(w->event_fd >= 0);
     assert(status == 0);
     if (status != 0) {
-        /* UNTESTED libuv docs: If an error happens while polling, status will be < 0 and
-         * corresponds with one of the UV_E* error codes. */
+        /* UNTESTED libuv docs: If an error happens while polling, status will
+         * be < 0 and corresponds with one of the UV_E* error codes. */
         goto fail_requests;
     }
 
@@ -173,7 +173,8 @@ static void uvWriterPollCb(uv_poll_t *poller, int status, int events)
      *
      * If we got here at least one write should have completed and io_events
      * should return immediately without blocking. */
-    n_events = UvOsIoGetevents(w->ctx, 1, (long int)w->n_events, w->events, NULL);
+    n_events =
+        UvOsIoGetevents(w->ctx, 1, (long int)w->n_events, w->events, NULL);
     assert(n_events >= 1);
     if (n_events < 1) {
         /* UNTESTED */

--- a/src/uv_writer.h
+++ b/src/uv_writer.h
@@ -18,21 +18,22 @@ typedef void (*UvWriterCloseCb)(struct UvWriter *w);
 
 struct UvWriter
 {
-    void *data;                    /* User data */
-    struct uv_loop_s *loop;        /* Event loop */
-    uv_file fd;                    /* File handle */
-    bool async;                    /* Whether fully async I/O is supported */
-    aio_context_t ctx;             /* KAIO handle */
-    struct io_event *events;       /* Array of KAIO response objects */
-    unsigned n_events;             /* Length of the events array */
-    int event_fd;                  /* Poll'ed to check if write is finished */
-    struct uv_poll_s event_poller; /* Poll event_fd for completed poll requests */
-    struct uv_check_s check;       /* Check for completed threadpool requests */
-    UvWriterCloseCb close_cb;      /* Close callback */
-    queue poll_queue;              /* Pollable write requests */
-    queue work_queue;              /* Threadpool write requests */
-    bool closing;                  /* Whether we're closing or closed */
-    char *errmsg;                  /* Description of last error */
+    void *data;              /* User data */
+    struct uv_loop_s *loop;  /* Event loop */
+    uv_file fd;              /* File handle */
+    bool async;              /* Whether fully async I/O is supported */
+    aio_context_t ctx;       /* KAIO handle */
+    struct io_event *events; /* Array of KAIO response objects */
+    unsigned n_events;       /* Length of the events array */
+    int event_fd;            /* Poll'ed to check if write is finished */
+    struct uv_poll_s
+        event_poller;         /* Poll event_fd for completed poll requests */
+    struct uv_check_s check;  /* Check for completed threadpool requests */
+    UvWriterCloseCb close_cb; /* Close callback */
+    queue poll_queue;         /* Pollable write requests */
+    queue work_queue;         /* Threadpool write requests */
+    bool closing;             /* Whether we're closing or closed */
+    char *errmsg;             /* Description of last error */
 };
 
 /* Initialize a file writer. */

--- a/test/fuzzy/test_replication.c
+++ b/test/fuzzy/test_replication.c
@@ -164,7 +164,7 @@ TEST(replication, partitioned, setup, tear_down, 0, _params)
         raft_fixture_desaturate(&f->cluster, leader_id - 1, raft->id - 1);
     }
 
-    //TODO this fails with seed 0x3914306f
+    // TODO this fails with seed 0x3914306f
     CLUSTER_STEP_UNTIL_HAS_LEADER(30000);
 
     /* Re-try now to append the entry. */

--- a/test/integration/append_helpers.h
+++ b/test/integration/append_helpers.h
@@ -48,22 +48,21 @@ static void appendCbAssertResult(struct raft_io_append *req, int status)
  * size ENTRY_SIZE. When the append request completes, CB will be called
  * and DATA will be available in result->data. f->io.append is expected to
  * return RV. */
-#define APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE, CB, DATA, RV) \
-    struct raft_io_append _req##I;                                    \
-    struct result _result##I = {0, false, DATA};                      \
-    int _rv##I;                                                       \
-    ENTRIES(I, N_ENTRIES, ENTRY_SIZE);                                \
-    _req##I.data = &_result##I;                                       \
-    _rv##I = f->io.append(&f->io, &_req##I, _entries##I, N_ENTRIES,   \
-                          CB);                                        \
+#define APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE, CB, DATA, RV)    \
+    struct raft_io_append _req##I;                                       \
+    struct result _result##I = {0, false, DATA};                         \
+    int _rv##I;                                                          \
+    ENTRIES(I, N_ENTRIES, ENTRY_SIZE);                                   \
+    _req##I.data = &_result##I;                                          \
+    _rv##I = f->io.append(&f->io, &_req##I, _entries##I, N_ENTRIES, CB); \
     munit_assert_int(_rv##I, ==, RV)
 
 /* Submit an append request identified by I, with N_ENTRIES entries, each one of
  * size ENTRY_SIZE. The default expectation is for the operation to succeed. A
  * custom STATUS can be set with APPEND_EXPECT. */
-#define APPEND_SUBMIT(I, N_ENTRIES, ENTRY_SIZE)                       \
-        APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE,               \
-                              appendCbAssertResult, NULL, 0)          \
+#define APPEND_SUBMIT(I, N_ENTRIES, ENTRY_SIZE)                           \
+    APPEND_SUBMIT_CB_DATA(I, N_ENTRIES, ENTRY_SIZE, appendCbAssertResult, \
+                          NULL, 0)
 
 /* Try to submit an append request and assert that the given error code and
  * message are returned. */

--- a/test/integration/test_apply.c
+++ b/test/integration/test_apply.c
@@ -40,7 +40,7 @@ struct result
     int status;
     bool done;
     raft_index prev_applied;
-    struct raft* raft;
+    struct raft *raft;
 };
 
 static void applyCbAssertResult(struct raft_apply *req, int status, void *_)

--- a/test/integration/test_assign.c
+++ b/test/integration/test_assign.c
@@ -440,7 +440,7 @@ TEST(raft_assign, demoteLeader, setUp, tearDown, 0, NULL)
     munit_assert_int(CLUSTER_LEADER, ==, 0);
     ASSIGN_WAIT;
     CLUSTER_STEP_UNTIL_HAS_LEADER(5000);
-    munit_assert_int(CLUSTER_LEADER, = !, 0);
+    munit_assert_int(CLUSTER_LEADER, !=, 0);
     return MUNIT_OK;
 }
 
@@ -452,6 +452,6 @@ TEST(raft_assign, demoteLeaderToSpare, setUp, tearDown, 0, NULL)
     munit_assert_int(CLUSTER_LEADER, ==, 0);
     ASSIGN_WAIT;
     CLUSTER_STEP_UNTIL_HAS_LEADER(5000);
-    munit_assert_int(CLUSTER_LEADER, = !, 0);
+    munit_assert_int(CLUSTER_LEADER, !=, 0);
     return MUNIT_OK;
 }

--- a/test/integration/test_assign.c
+++ b/test/integration/test_assign.c
@@ -440,7 +440,7 @@ TEST(raft_assign, demoteLeader, setUp, tearDown, 0, NULL)
     munit_assert_int(CLUSTER_LEADER, ==, 0);
     ASSIGN_WAIT;
     CLUSTER_STEP_UNTIL_HAS_LEADER(5000);
-    munit_assert_int(CLUSTER_LEADER, =!, 0);
+    munit_assert_int(CLUSTER_LEADER, = !, 0);
     return MUNIT_OK;
 }
 
@@ -452,6 +452,6 @@ TEST(raft_assign, demoteLeaderToSpare, setUp, tearDown, 0, NULL)
     munit_assert_int(CLUSTER_LEADER, ==, 0);
     ASSIGN_WAIT;
     CLUSTER_STEP_UNTIL_HAS_LEADER(5000);
-    munit_assert_int(CLUSTER_LEADER, =!, 0);
+    munit_assert_int(CLUSTER_LEADER, = !, 0);
     return MUNIT_OK;
 }

--- a/test/integration/test_election.c
+++ b/test/integration/test_election.c
@@ -595,7 +595,7 @@ TEST(election, preVote, setUp, tearDown, 0, NULL)
 
     CLUSTER_STEP; /* Server 0 completes sending a pre-vote RequestVote RPC */
     CLUSTER_STEP; /* Server 1 receives the pre-vote RequestVote RPC */
-    ASSERT_TERM(1, 1); /* Server 1 does increment its term */
+    ASSERT_TERM(1, 1);      /* Server 1 does increment its term */
     ASSERT_VOTED_FOR(1, 0); /* Server 1 does not persist its vote */
     ASSERT_TIME(1015);
 
@@ -607,7 +607,7 @@ TEST(election, preVote, setUp, tearDown, 0, NULL)
 
     CLUSTER_STEP; /* Server 1 completes sending an actual RequestVote RPC */
     CLUSTER_STEP; /* Server 1 receives the actual RequestVote RPC */
-    ASSERT_TERM(1, 2); /* Server 1 does increment its term. */
+    ASSERT_TERM(1, 2);      /* Server 1 does increment its term. */
     ASSERT_VOTED_FOR(1, 1); /* Server 1 does persists its vote */
 
     CLUSTER_STEP; /* Server 1 completes sending actual RequestVote result */
@@ -632,25 +632,25 @@ TEST(election, preVoteWithcandidateCrash, setUp, tearDown, 0, cluster_3_params)
     ASSERT_TIME(1000);
     ASSERT_TERM(0, 1);
 
-     /* Server 1 and 2 ticks */
+    /* Server 1 and 2 ticks */
     CLUSTER_STEP_N(2);
     ASSERT_FOLLOWER(1);
     ASSERT_FOLLOWER(2);
 
-     /* Server 0 completes sending a pre-vote RequestVote RPCs */
+    /* Server 0 completes sending a pre-vote RequestVote RPCs */
     CLUSTER_STEP_N(2);
 
-    CLUSTER_STEP; /* Server 1 receives the pre-vote RequestVote RPC */
-    ASSERT_TERM(1, 1); /* Server 1 does not increment its term */
+    CLUSTER_STEP;           /* Server 1 receives the pre-vote RequestVote RPC */
+    ASSERT_TERM(1, 1);      /* Server 1 does not increment its term */
     ASSERT_VOTED_FOR(1, 0); /* Server 1 does not persist its vote */
     ASSERT_TIME(1015);
 
-    CLUSTER_STEP; /* Server 2 receives the pre-vote RequestVote RPC */
-    ASSERT_TERM(2, 1); /* Server 2 does not increment its term */
+    CLUSTER_STEP;           /* Server 2 receives the pre-vote RequestVote RPC */
+    ASSERT_TERM(2, 1);      /* Server 2 does not increment its term */
     ASSERT_VOTED_FOR(2, 0); /* Server 1 does not persist its vote */
     ASSERT_TIME(1015);
 
-     /* Server 1 and 2 complete sending pre-vote RequestVote results */
+    /* Server 1 and 2 complete sending pre-vote RequestVote results */
     CLUSTER_STEP_N(2);
 
     /* Server 0 receives the pre-vote RequestVote results */
@@ -659,15 +659,15 @@ TEST(election, preVoteWithcandidateCrash, setUp, tearDown, 0, cluster_3_params)
     ASSERT_TERM(0, 2); /* Server 0 has now incremented its term. */
     ASSERT_TIME(1030);
 
-     /* Server 0 completes sending actual RequestVote RPCs */
+    /* Server 0 completes sending actual RequestVote RPCs */
     CLUSTER_STEP_N(2);
 
-    CLUSTER_STEP; /* Server 1 receives the actual RequestVote RPC */
-    ASSERT_TERM(1, 2); /* Server 1 does increment its term. */
+    CLUSTER_STEP;           /* Server 1 receives the actual RequestVote RPC */
+    ASSERT_TERM(1, 2);      /* Server 1 does increment its term. */
     ASSERT_VOTED_FOR(1, 1); /* Server 1 does persists its vote */
 
-    CLUSTER_STEP; /* Server 2 receives the actual RequestVote RPC */
-    ASSERT_TERM(2, 2); /* Server 2 does increment its term. */
+    CLUSTER_STEP;           /* Server 2 receives the actual RequestVote RPC */
+    ASSERT_TERM(2, 2);      /* Server 2 does increment its term. */
     ASSERT_VOTED_FOR(2, 1); /* Server 2 does persists its vote */
 
     /* Server 0 crashes. */
@@ -691,7 +691,7 @@ TEST(election, preVoteWithcandidateCrash, setUp, tearDown, 0, cluster_3_params)
     /* Server 1 receives the pre-vote RequestVote Result */
     CLUSTER_STEP_N(2);
     /* Server 1 increments it's term to start a non pre-vote election */
-    ASSERT_TERM(1, 3); /* Server 1 has now incremented its term. */
+    ASSERT_TERM(1, 3);      /* Server 1 has now incremented its term. */
     ASSERT_VOTED_FOR(1, 2); /* Server 1 has persisted its vote */
     ASSERT_TIME(2230);
 
@@ -716,8 +716,8 @@ TEST(election, preVoteNoStaleVotes, setUp, tearDown, 0, cluster_3_params)
     raft_set_pre_vote(CLUSTER_RAFT(1), true);
     raft_set_pre_vote(CLUSTER_RAFT(2), true);
 
-    /* Server 2 is 1 term ahead of the other servers, this will allow it to send stale
-     * pre-vote responses that pass the term checks. */
+    /* Server 2 is 1 term ahead of the other servers, this will allow it to send
+     * stale pre-vote responses that pass the term checks. */
     CLUSTER_SET_TERM(2, 2);
     CLUSTER_START;
 
@@ -727,21 +727,21 @@ TEST(election, preVoteNoStaleVotes, setUp, tearDown, 0, cluster_3_params)
     ASSERT_TIME(1000);
     ASSERT_TERM(0, 1);
 
-     /* Server 1 and 2 ticks */
+    /* Server 1 and 2 ticks */
     CLUSTER_STEP_N(2);
     ASSERT_FOLLOWER(1);
     ASSERT_FOLLOWER(2);
 
-     /* Server 0 completes sending a pre-vote RequestVote RPCs */
+    /* Server 0 completes sending a pre-vote RequestVote RPCs */
     CLUSTER_STEP_N(2);
 
-    CLUSTER_STEP; /* Server 1 receives the pre-vote RequestVote RPC */
-    ASSERT_TERM(1, 1); /* Server 1 does not increment its term */
+    CLUSTER_STEP;           /* Server 1 receives the pre-vote RequestVote RPC */
+    ASSERT_TERM(1, 1);      /* Server 1 does not increment its term */
     ASSERT_VOTED_FOR(1, 0); /* Server 1 does not persist its vote */
     ASSERT_TIME(1015);
 
-    CLUSTER_STEP; /* Server 2 receives the pre-vote RequestVote RPC */
-    ASSERT_TERM(2, 2); /* Server 2 does not increment its term */
+    CLUSTER_STEP;           /* Server 2 receives the pre-vote RequestVote RPC */
+    ASSERT_TERM(2, 2);      /* Server 2 does not increment its term */
     ASSERT_VOTED_FOR(2, 0); /* Server 1 does not persist its vote */
     ASSERT_TIME(1015);
 
@@ -757,7 +757,8 @@ TEST(election, preVoteNoStaleVotes, setUp, tearDown, 0, cluster_3_params)
     ASSERT_TERM(0, 2); /* Server 0 has now incremented its term. */
     ASSERT_TIME(1030);
 
-    /* Don't send messages from 0, this ensures no real RequestVote RPCs are sent */
+    /* Don't send messages from 0, this ensures no real RequestVote RPCs are
+     * sent */
     CLUSTER_SATURATE(0, 1);
     CLUSTER_SATURATE(0, 2);
 

--- a/test/integration/test_fixture.c
+++ b/test/integration/test_fixture.c
@@ -107,8 +107,7 @@ static void tearDown(void *data)
 
 /* Assert that the x field of the FSM with the given index matches the given
  * value. */
-#define ASSERT_FSM_X(I, VALUE) \
-    munit_assert_int(FsmGetX(&f->fsms[I]), ==, VALUE)
+#define ASSERT_FSM_X(I, VALUE) munit_assert_int(FsmGetX(&f->fsms[I]), ==, VALUE)
 
 /******************************************************************************
  *

--- a/test/integration/test_heap.c
+++ b/test/integration/test_heap.c
@@ -24,7 +24,7 @@ TEST(raft_heap, calloc, NULL, NULL, 0, NULL)
     void *p;
     p = raft_calloc(1, 8);
     munit_assert_ptr_not_null(p);
-    munit_assert_int(*(uint64_t*)p, ==, 0);
+    munit_assert_int(*(uint64_t *)p, ==, 0);
     raft_free(p);
     return MUNIT_OK;
 }
@@ -34,10 +34,10 @@ TEST(raft_heap, realloc, NULL, NULL, 0, NULL)
     void *p;
     p = raft_realloc(NULL, 8);
     munit_assert_ptr_not_null(p);
-    *(uint64_t*)p = 1;
+    *(uint64_t *)p = 1;
     p = raft_realloc(p, 16);
     munit_assert_ptr_not_null(p);
-    munit_assert_int(*(uint64_t*)p, ==, 1);
+    munit_assert_int(*(uint64_t *)p, ==, 1);
     raft_free(p);
     return MUNIT_OK;
 }

--- a/test/integration/test_init.c
+++ b/test/integration/test_init.c
@@ -18,15 +18,17 @@ TEST(raft_init, incompatIoFsmAsyncSnapshotNotNull, NULL, NULL, 0, NULL)
     struct raft_fsm fsm = {0};
     io.version = 1; /* Too low */
     io.async_work = (int (*)(struct raft_io *, struct raft_io_async_work *,
-			     raft_io_async_work_cb))(uintptr_t)0xDEADBEEF;
+                             raft_io_async_work_cb))(uintptr_t)0xDEADBEEF;
     fsm.version = 3;
-    fsm.snapshot_async = (int (*)(struct raft_fsm *,
-                          struct raft_buffer **, unsigned int *))(uintptr_t)0xDEADBEEF;
+    fsm.snapshot_async = (int (*)(struct raft_fsm *, struct raft_buffer **,
+                                  unsigned int *))(uintptr_t)0xDEADBEEF;
 
     int rc;
     rc = raft_init(&r, &io, &fsm, 1, "1");
     munit_assert_int(rc, ==, -1);
-    munit_assert_string_equal(r.errmsg, "async snapshot requires io->version > 1 and async_work method.");
+    munit_assert_string_equal(
+        r.errmsg,
+        "async snapshot requires io->version > 1 and async_work method.");
     return MUNIT_OK;
 }
 
@@ -40,13 +42,15 @@ TEST(raft_init, incompatIoFsmAsyncSnapshotNull, NULL, NULL, 0, NULL)
     io.version = 2;
     io.async_work = NULL;
     fsm.version = 3;
-    fsm.snapshot_async = (int (*)(struct raft_fsm *,
-                          struct raft_buffer **, unsigned int *))(uintptr_t)0xDEADBEEF;
+    fsm.snapshot_async = (int (*)(struct raft_fsm *, struct raft_buffer **,
+                                  unsigned int *))(uintptr_t)0xDEADBEEF;
 
     int rc;
     rc = raft_init(&r, &io, &fsm, 1, "1");
     munit_assert_int(rc, ==, -1);
-    munit_assert_string_equal(r.errmsg, "async snapshot requires io->version > 1 and async_work method.");
+    munit_assert_string_equal(
+        r.errmsg,
+        "async snapshot requires io->version > 1 and async_work method.");
     return MUNIT_OK;
 }
 

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -83,14 +83,14 @@ struct result
 };
 
 /* Submit an apply request. */
-#define APPLY_SUBMIT(I)                                                      \
-    struct raft_buffer _buf;                                                 \
-    struct raft_apply _req;                                                  \
-    struct result _result = {0, false};                                      \
-    int _rv;                                                                 \
-    FsmEncodeSetX(123, &_buf);                                               \
-    _req.data = &_result;                                                    \
-    _rv = raft_apply(CLUSTER_RAFT(I), &_req, &_buf, 1, NULL);                \
+#define APPLY_SUBMIT(I)                                       \
+    struct raft_buffer _buf;                                  \
+    struct raft_apply _req;                                   \
+    struct result _result = {0, false};                       \
+    int _rv;                                                  \
+    FsmEncodeSetX(123, &_buf);                                \
+    _req.data = &_result;                                     \
+    _rv = raft_apply(CLUSTER_RAFT(I), &_req, &_buf, 1, NULL); \
     munit_assert_int(_rv, ==, 0);
 
 /******************************************************************************

--- a/test/integration/test_replication.c
+++ b/test/integration/test_replication.c
@@ -255,8 +255,9 @@ TEST(replication, sendProbe, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-static bool indices_updated(struct raft_fixture *f, void* data) {
-    (void) f;
+static bool indices_updated(struct raft_fixture *f, void *data)
+{
+    (void)f;
     const struct raft *r = data;
     return r->last_stored == 4 && r->leader_state.progress[1].match_index == 3;
 }
@@ -526,7 +527,8 @@ TEST(replication, recvPrevLogTermMismatch, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-static void assert_config(struct raft* raft, struct raft_configuration *expected)
+static void assert_config(struct raft *raft,
+                          struct raft_configuration *expected)
 {
     struct raft_configuration *actual;
     actual = &raft->configuration;
@@ -534,8 +536,7 @@ static void assert_config(struct raft* raft, struct raft_configuration *expected
     munit_assert_uint(actual->n, ==, expected->n);
     for (unsigned i = 0; i < actual->n; i++) {
         munit_assert_ulong(actual->servers[i].id, ==, expected->servers[i].id);
-        munit_assert_int(actual->servers[i].role,
-                         ==,
+        munit_assert_int(actual->servers[i].role, ==,
                          expected->servers[i].role);
         munit_assert_string_equal(actual->servers[i].address,
                                   expected->servers[i].address);
@@ -546,7 +547,12 @@ static void assert_config(struct raft* raft, struct raft_configuration *expected
  * prevLogTerm, and value of prevLogIndex is greater than server's commit
  * index (i.e. this is a normal inconsistency), we reject the request. This time
  * it's a configuration entry. */
-TEST(replication, recvPrevLogTermMismatchConfiguration, setUp, tearDown, 0, NULL)
+TEST(replication,
+     recvPrevLogTermMismatchConfiguration,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry1;
@@ -590,7 +596,12 @@ TEST(replication, recvPrevLogTermMismatchConfiguration, setUp, tearDown, 0, NULL
  * index (i.e. this is a normal inconsistency), we reject the request. This time
  * it's a configuration entry, there's also an older configuration entry
  * present.  */
-TEST(replication, recvPrevLogTermMismatchConfigurationWithPrevious, setUp, tearDown, 0, NULL)
+TEST(replication,
+     recvPrevLogTermMismatchConfigurationWithPrevious,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry1;
@@ -646,7 +657,12 @@ TEST(replication, recvPrevLogTermMismatchConfigurationWithPrevious, setUp, tearD
  * index (i.e. this is a normal inconsistency), we reject the request. This time
  * it's a configuration entry and there is a snapshot, there's no previous
  * configuration entry in the log. */
-TEST(replication, recvPrevLogTermMismatchConfigurationSnapshotNoPrev, setUp, tearDown, 0, NULL)
+TEST(replication,
+     recvPrevLogTermMismatchConfigurationSnapshotNoPrev,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct raft_entry entry1;
@@ -667,7 +683,7 @@ TEST(replication, recvPrevLogTermMismatchConfigurationSnapshotNoPrev, setUp, tea
                          1 /* conf index                                    */,
                          5 /* x                                             */,
                          0 /* y                                             */);
-    CLUSTER_SET_TERM(1,1);
+    CLUSTER_SET_TERM(1, 1);
 
     /* The servers have an entry with a conflicting term. */
     entry1.type = RAFT_COMMAND;

--- a/test/integration/test_snapshot.c
+++ b/test/integration/test_snapshot.c
@@ -54,12 +54,12 @@ static void tearDown(void *data)
     }
 
 /* Set the snapshot timeout on all servers of the cluster */
-#define SET_SNAPSHOT_TIMEOUT(VALUE)                                   \
-    {                                                                 \
-        unsigned i;                                                   \
-        for (i = 0; i < CLUSTER_N; i++) {                             \
-            raft_set_install_snapshot_timeout(CLUSTER_RAFT(i), VALUE);\
-        }                                                             \
+#define SET_SNAPSHOT_TIMEOUT(VALUE)                                    \
+    {                                                                  \
+        unsigned i;                                                    \
+        for (i = 0; i < CLUSTER_N; i++) {                              \
+            raft_set_install_snapshot_timeout(CLUSTER_RAFT(i), VALUE); \
+        }                                                              \
     }
 
 static int ioMethodSnapshotPutFail(struct raft_io *raft_io,
@@ -68,11 +68,11 @@ static int ioMethodSnapshotPutFail(struct raft_io *raft_io,
                                    const struct raft_snapshot *snapshot,
                                    raft_io_snapshot_put_cb cb)
 {
-    (void) raft_io;
-    (void) trailing;
-    (void) req;
-    (void) snapshot;
-    (void) cb;
+    (void)raft_io;
+    (void)trailing;
+    (void)req;
+    (void)snapshot;
+    (void)cb;
     return -1;
 }
 
@@ -88,9 +88,9 @@ static int ioMethodAsyncWorkFail(struct raft_io *raft_io,
                                  struct raft_io_async_work *req,
                                  raft_io_async_work_cb cb)
 {
-    (void) raft_io;
-    (void) req;
-    (void) cb;
+    (void)raft_io;
+    (void)req;
+    (void)cb;
     return -1;
 }
 
@@ -106,33 +106,33 @@ static int fsmSnapshotFail(struct raft_fsm *fsm,
                            struct raft_buffer *bufs[],
                            unsigned *n_bufs)
 {
-    (void) fsm;
-    (void) bufs;
-    (void) n_bufs;
+    (void)fsm;
+    (void)bufs;
+    (void)n_bufs;
     return -1;
 }
 
-#define SET_FAULTY_SNAPSHOT_ASYNC()                                  \
-    {                                                                \
-        unsigned i;                                                  \
-        for (i = 0; i < CLUSTER_N; i++) {                            \
-            CLUSTER_RAFT(i)->fsm->snapshot_async = fsmSnapshotFail;  \
-        }                                                            \
+#define SET_FAULTY_SNAPSHOT_ASYNC()                                 \
+    {                                                               \
+        unsigned i;                                                 \
+        for (i = 0; i < CLUSTER_N; i++) {                           \
+            CLUSTER_RAFT(i)->fsm->snapshot_async = fsmSnapshotFail; \
+        }                                                           \
     }
 
-#define RESET_FSM_ASYNC(I)                                           \
-    {                                                                \
-        struct raft_fsm *fsm = CLUSTER_RAFT(I)->fsm;                 \
-        FsmClose(fsm);                                               \
-        FsmInitAsync(fsm, fsm->version);                             \
+#define RESET_FSM_ASYNC(I)                           \
+    {                                                \
+        struct raft_fsm *fsm = CLUSTER_RAFT(I)->fsm; \
+        FsmClose(fsm);                               \
+        FsmInitAsync(fsm, fsm->version);             \
     }
 
-#define SET_FAULTY_SNAPSHOT()                                        \
-    {                                                                \
-        unsigned i;                                                  \
-        for (i = 0; i < CLUSTER_N; i++) {                            \
-            CLUSTER_RAFT(i)->fsm->snapshot = fsmSnapshotFail;        \
-        }                                                            \
+#define SET_FAULTY_SNAPSHOT()                                 \
+    {                                                         \
+        unsigned i;                                           \
+        for (i = 0; i < CLUSTER_N; i++) {                     \
+            CLUSTER_RAFT(i)->fsm->snapshot = fsmSnapshotFail; \
+        }                                                     \
     }
 
 /******************************************************************************
@@ -209,7 +209,12 @@ TEST(snapshot, installOneTimeOut, setUp, tearDown, 0, NULL)
 }
 
 /* Install snapshot to an offline node */
-TEST(snapshot, installOneDisconnectedFromBeginningReconnects, setUp, tearDown, 0, NULL)
+TEST(snapshot,
+     installOneDisconnectedFromBeginningReconnects,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     (void)params;
@@ -230,7 +235,8 @@ TEST(snapshot, installOneDisconnectedFromBeginningReconnects, setUp, tearDown, 0
     /* Wait a while so leader detects offline node */
     CLUSTER_STEP_UNTIL_ELAPSED(2000);
 
-    /* Assert that the leader doesn't try sending a snapshot to an offline node */
+    /* Assert that the leader doesn't try sending a snapshot to an offline node
+     */
     munit_assert_int(CLUSTER_N_SEND(0, RAFT_IO_INSTALL_SNAPSHOT), ==, 0);
     munit_assert_int(CLUSTER_N_RECV(2, RAFT_IO_INSTALL_SNAPSHOT), ==, 0);
 
@@ -247,7 +253,12 @@ TEST(snapshot, installOneDisconnectedFromBeginningReconnects, setUp, tearDown, 0
 }
 
 /* Install snapshot to an offline node that went down during operation */
-TEST(snapshot, installOneDisconnectedDuringOperationReconnects, setUp, tearDown, 0, NULL)
+TEST(snapshot,
+     installOneDisconnectedDuringOperationReconnects,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     (void)params;
@@ -320,7 +331,8 @@ TEST(snapshot, noSnapshotInstallToKilled, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-/* Install snapshot times out and leader retries, afterwards AppendEntries resume */
+/* Install snapshot times out and leader retries, afterwards AppendEntries
+ * resume */
 TEST(snapshot, installOneTimeOutAppendAfter, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -385,8 +397,8 @@ TEST(snapshot, installMultipleTimeOut, setUp, tearDown, 0, NULL)
     CLUSTER_STEP_UNTIL_ELAPSED(400);
 
     /* Apply another few of entries, to force a new snapshot to be taken. Drop
-     * all traffic between servers 0 and 2 in order for AppendEntries RPCs to not be
-     * replicated */
+     * all traffic between servers 0 and 2 in order for AppendEntries RPCs to
+     * not be replicated */
     CLUSTER_SATURATE_BOTHWAYS(0, 2);
     CLUSTER_MAKE_PROGRESS;
     CLUSTER_MAKE_PROGRESS;
@@ -431,8 +443,8 @@ TEST(snapshot, installMultipleTimeOutAppendAfter, setUp, tearDown, 0, NULL)
     CLUSTER_STEP_UNTIL_ELAPSED(400);
 
     /* Apply another few of entries, to force a new snapshot to be taken. Drop
-     * all traffic between servers 0 and 2 in order for AppendEntries RPCs to not be
-     * replicated */
+     * all traffic between servers 0 and 2 in order for AppendEntries RPCs to
+     * not be replicated */
     CLUSTER_SATURATE_BOTHWAYS(0, 2);
     CLUSTER_MAKE_PROGRESS;
     CLUSTER_MAKE_PROGRESS;
@@ -451,20 +463,23 @@ TEST(snapshot, installMultipleTimeOutAppendAfter, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-static bool server_installing_snapshot(struct raft_fixture *f, void* data) {
-    (void) f;
+static bool server_installing_snapshot(struct raft_fixture *f, void *data)
+{
+    (void)f;
     const struct raft *r = data;
     return r->snapshot.put.data != NULL && r->last_stored == 0;
 }
 
-static bool server_taking_snapshot(struct raft_fixture *f, void* data) {
-    (void) f;
+static bool server_taking_snapshot(struct raft_fixture *f, void *data)
+{
+    (void)f;
     const struct raft *r = data;
     return r->snapshot.put.data != NULL && r->last_stored != 0;
 }
 
-static bool server_snapshot_done(struct raft_fixture *f, void *data) {
-    (void) f;
+static bool server_snapshot_done(struct raft_fixture *f, void *data)
+{
+    (void)f;
     const struct raft *r = data;
     return r->snapshot.put.data == NULL;
 }
@@ -494,15 +509,15 @@ TEST(snapshot, installSnapshotHeartBeats, setUp, tearDown, 0, NULL)
     /* Step the cluster until server 1 installs a snapshot */
     const struct raft *r = CLUSTER_RAFT(1);
     CLUSTER_DESATURATE_BOTHWAYS(0, 1);
-    CLUSTER_STEP_UNTIL(server_installing_snapshot, (void*) r, 2000);
+    CLUSTER_STEP_UNTIL(server_installing_snapshot, (void *)r, 2000);
     munit_assert_uint(CLUSTER_N_RECV(1, RAFT_IO_INSTALL_SNAPSHOT), ==, 1);
 
     /* Count the number of AppendEntries RPCs received during the snapshot
      * install*/
     unsigned before = CLUSTER_N_RECV(1, RAFT_IO_APPEND_ENTRIES);
-    CLUSTER_STEP_UNTIL(server_snapshot_done, (void*) r, 5000);
+    CLUSTER_STEP_UNTIL(server_snapshot_done, (void *)r, 5000);
     unsigned after = CLUSTER_N_RECV(1, RAFT_IO_APPEND_ENTRIES);
-    munit_assert_uint(before, < , after);
+    munit_assert_uint(before, <, after);
 
     /* Check that the InstallSnapshot RPC was not resent */
     munit_assert_uint(CLUSTER_N_RECV(1, RAFT_IO_INSTALL_SNAPSHOT), ==, 1);
@@ -533,7 +548,7 @@ TEST(snapshot, installSnapshotDuringEntriesWrite, setUp, tearDown, 0, NULL)
     CLUSTER_MAKE_PROGRESS;
 
     /* Make sure leader can't succesfully send any more entries */
-    CLUSTER_DISCONNECT(0,1);
+    CLUSTER_DISCONNECT(0, 1);
     CLUSTER_MAKE_PROGRESS; /* Snapshot taken here */
     CLUSTER_MAKE_PROGRESS;
     CLUSTER_MAKE_PROGRESS; /* Snapshot taken here */
@@ -541,7 +556,7 @@ TEST(snapshot, installSnapshotDuringEntriesWrite, setUp, tearDown, 0, NULL)
 
     /* Snapshot with index 6 is sent while follower is still writing the entries
      * to disk that arrived before the disconnect. */
-    CLUSTER_RECONNECT(0,1);
+    CLUSTER_RECONNECT(0, 1);
 
     /* Make sure follower is up to date */
     CLUSTER_STEP_UNTIL_APPLIED(1, 7, 5000);
@@ -565,7 +580,12 @@ static MunitParameterEnum fsm_snapshot_only_async_params[] = {
 };
 
 /* Follower receives AppendEntries RPCs while taking a snapshot */
-TEST(snapshot, takeSnapshotAppendEntries, setUp, tearDown, 0, fsm_snapshot_async_params)
+TEST(snapshot,
+     takeSnapshotAppendEntries,
+     setUp,
+     tearDown,
+     0,
+     fsm_snapshot_async_params)
 {
     struct fixture *f = data;
     (void)params;
@@ -585,14 +605,14 @@ TEST(snapshot, takeSnapshotAppendEntries, setUp, tearDown, 0, fsm_snapshot_async
 
     /* Step the cluster until server 1 takes a snapshot */
     const struct raft *r = CLUSTER_RAFT(1);
-    CLUSTER_STEP_UNTIL(server_taking_snapshot, (void*) r, 3000);
+    CLUSTER_STEP_UNTIL(server_taking_snapshot, (void *)r, 3000);
 
     /* Send AppendEntries RPCs while server 1 is taking a snapshot */
     static struct raft_apply reqs[5];
     for (int i = 0; i < 5; i++) {
         CLUSTER_APPLY_ADD_X(CLUSTER_LEADER, &reqs[i], 1, NULL);
     }
-    CLUSTER_STEP_UNTIL(server_snapshot_done, (void*) r, 5000);
+    CLUSTER_STEP_UNTIL(server_snapshot_done, (void *)r, 5000);
 
     /* Make sure the AppendEntries are applied and we can make progress */
     CLUSTER_STEP_UNTIL_APPLIED(1, 9, 5000);
@@ -602,7 +622,12 @@ TEST(snapshot, takeSnapshotAppendEntries, setUp, tearDown, 0, fsm_snapshot_async
     return MUNIT_OK;
 }
 
-TEST(snapshot, takeSnapshotSnapshotPutFail, setUp, tearDown, 0, fsm_snapshot_async_params)
+TEST(snapshot,
+     takeSnapshotSnapshotPutFail,
+     setUp,
+     tearDown,
+     0,
+     fsm_snapshot_async_params)
 {
     struct fixture *f = data;
     (void)params;
@@ -622,7 +647,12 @@ TEST(snapshot, takeSnapshotSnapshotPutFail, setUp, tearDown, 0, fsm_snapshot_asy
     return MUNIT_OK;
 }
 
-TEST(snapshot, takeSnapshotAsyncWorkFail, setUp, tearDown, 0, fsm_snapshot_async_params)
+TEST(snapshot,
+     takeSnapshotAsyncWorkFail,
+     setUp,
+     tearDown,
+     0,
+     fsm_snapshot_async_params)
 {
     struct fixture *f = data;
     (void)params;
@@ -642,7 +672,12 @@ TEST(snapshot, takeSnapshotAsyncWorkFail, setUp, tearDown, 0, fsm_snapshot_async
     return MUNIT_OK;
 }
 
-TEST(snapshot, takeSnapshotAsyncFail, setUp, tearDown, 0, fsm_snapshot_only_async_params)
+TEST(snapshot,
+     takeSnapshotAsyncFail,
+     setUp,
+     tearDown,
+     0,
+     fsm_snapshot_only_async_params)
 {
     struct fixture *f = data;
     (void)params;
@@ -662,7 +697,12 @@ TEST(snapshot, takeSnapshotAsyncFail, setUp, tearDown, 0, fsm_snapshot_only_asyn
     return MUNIT_OK;
 }
 
-TEST(snapshot, takeSnapshotAsyncFailOnce, setUp, tearDown, 0, fsm_snapshot_only_async_params)
+TEST(snapshot,
+     takeSnapshotAsyncFailOnce,
+     setUp,
+     tearDown,
+     0,
+     fsm_snapshot_only_async_params)
 {
     struct fixture *f = data;
     (void)params;
@@ -718,7 +758,8 @@ TEST(snapshot, takeSnapshotFail, setUp, tearDown, 0, fsm_snapshot_async_params)
     return MUNIT_OK;
 }
 
-/* A follower doesn't convert to candidate state while it's installing a snapshot. */
+/* A follower doesn't convert to candidate state while it's installing a
+ * snapshot. */
 TEST(snapshot, snapshotBlocksCandidate, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -1,8 +1,8 @@
-#include "append_helpers.h"
+#include "../../src/uv.h"
+#include "../lib/aio.h"
 #include "../lib/runner.h"
 #include "../lib/uv.h"
-#include "../lib/aio.h"
-#include "../../src/uv.h"
+#include "append_helpers.h"
 
 #include <unistd.h>
 
@@ -27,7 +27,6 @@ struct fixture
     FIXTURE_UV;
     int count; /* To generate deterministic entry data */
 };
-
 
 /******************************************************************************
  *
@@ -149,9 +148,11 @@ TEST(append, unaligned, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     APPEND_SUBMIT_CB_DATA(0, 1, 9, NULL, NULL, RAFT_INVALID);
-    munit_assert_string_equal(f->io.errmsg, "entry buffers must be 8-byte aligned");
+    munit_assert_string_equal(f->io.errmsg,
+                              "entry buffers must be 8-byte aligned");
     APPEND_SUBMIT_CB_DATA(1, 3, 63, NULL, NULL, RAFT_INVALID);
-    munit_assert_string_equal(f->io.errmsg, "entry buffers must be 8-byte aligned");
+    munit_assert_string_equal(f->io.errmsg,
+                              "entry buffers must be 8-byte aligned");
     return MUNIT_OK;
 }
 
@@ -189,8 +190,7 @@ TEST(append, finalizeSegment, setUp, tearDown, 0, NULL)
     while (!DirHasFile(f->dir, "open-4")) {
         LOOP_RUN(1);
     }
-    munit_assert_true(
-        DirHasFile(f->dir, "0000000000000001-0000000000000004"));
+    munit_assert_true(DirHasFile(f->dir, "0000000000000001-0000000000000004"));
     munit_assert_false(DirHasFile(f->dir, "open-1"));
     munit_assert_true(DirHasFile(f->dir, "open-4"));
     return MUNIT_OK;
@@ -405,10 +405,8 @@ TEST(append, counter, setUp, tearDown, 0, NULL)
     for (i = 0; i < 10; i++) {
         APPEND(1, size);
     }
-    munit_assert_true(
-        DirHasFile(f->dir, "0000000000000001-0000000000000003"));
-    munit_assert_true(
-        DirHasFile(f->dir, "0000000000000004-0000000000000006"));
+    munit_assert_true(DirHasFile(f->dir, "0000000000000001-0000000000000003"));
+    munit_assert_true(DirHasFile(f->dir, "0000000000000004-0000000000000006"));
     munit_assert_true(DirHasFile(f->dir, "open-4"));
     return MUNIT_OK;
 }
@@ -583,8 +581,7 @@ TEST(append, currentSegment, setUp, tearDownDeps, 0, NULL)
 
     TEAR_DOWN_UV;
 
-    munit_assert_true(
-        DirHasFile(f->dir, "0000000000000001-0000000000000001"));
+    munit_assert_true(DirHasFile(f->dir, "0000000000000001-0000000000000001"));
 
     return MUNIT_OK;
 }
@@ -610,12 +607,12 @@ TEST(append, ioSetupError, setUp, tearDown, 0, NULL)
 
 struct barrierData
 {
-   int current;     /* Count the number of finished AppendEntries RPCs  */
-   int expected;    /* Expected number of finished AppendEntries RPCs   */
-   bool done;       /* @true if the Barrier CB has fired                */
-   bool expectDone; /* Expect the Barrier CB to have fired or not       */
-   char** files;    /* Expected files in the directory, NULL terminated */
-   struct uv *uv;
+    int current;     /* Count the number of finished AppendEntries RPCs  */
+    int expected;    /* Expected number of finished AppendEntries RPCs   */
+    bool done;       /* @true if the Barrier CB has fired                */
+    bool expectDone; /* Expect the Barrier CB to have fired or not       */
+    char **files;    /* Expected files in the directory, NULL terminated */
+    struct uv *uv;
 };
 
 static void barrierCbCompareCounter(struct UvBarrier *barrier)
@@ -646,10 +643,10 @@ static void appendCbIncreaseCounterAssertResult(struct raft_io_append *req,
     bd->current += 1;
 }
 
-static char* bools[] = { "0", "1", NULL };
+static char *bools[] = {"0", "1", NULL};
 static MunitParameterEnum blocking_bool_params[] = {
-    { "bool", bools },
-    { NULL, NULL },
+    {"bool", bools},
+    {NULL, NULL},
 };
 
 /* Fill up 3 segments worth of AppendEntries RPC's.
@@ -665,17 +662,22 @@ TEST(append, barrierOpenSegments, setUp, tearDown, 0, blocking_bool_params)
     bd.done = false;
     bd.expectDone = false;
     bd.uv = f->io.impl;
-    char* files[] = {"0000000000000001-0000000000000004", "0000000000000005-0000000000000008",
-		     "0000000000000009-0000000000000012", NULL};
+    char *files[] = {"0000000000000001-0000000000000004",
+                     "0000000000000005-0000000000000008",
+                     "0000000000000009-0000000000000012", NULL};
     bd.files = files;
 
-    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
-    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
-    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
 
     struct UvBarrier barrier = {0};
-    barrier.data = (void*) &bd;
-    barrier.blocking = (bool)strtoul(munit_parameters_get(params, "bool"), NULL, 0);
+    barrier.data = (void *)&bd;
+    barrier.blocking =
+        (bool)strtoul(munit_parameters_get(params, "bool"), NULL, 0);
     UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
 
     /* Make sure every callback fired */
@@ -686,9 +688,8 @@ TEST(append, barrierOpenSegments, setUp, tearDown, 0, blocking_bool_params)
     return MUNIT_OK;
 }
 
-
-/* Request a blocking Barrier and expect that the no AppendEntries RPC's are finished before
- * the Barrier callback is fired.
+/* Request a blocking Barrier and expect that the no AppendEntries RPC's are
+ * finished before the Barrier callback is fired.
  */
 TEST(append, blockingBarrierNoOpenSegments, setUp, tearDown, 0, NULL)
 {
@@ -701,13 +702,16 @@ TEST(append, blockingBarrierNoOpenSegments, setUp, tearDown, 0, NULL)
     bd.uv = f->io.impl;
 
     struct UvBarrier barrier = {0};
-    barrier.data = (void*) &bd;
+    barrier.data = (void *)&bd;
     barrier.blocking = true;
     UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
 
-    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
-    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
-    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);
@@ -717,8 +721,8 @@ TEST(append, blockingBarrierNoOpenSegments, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-/* Request a blocking Barrier and expect that the no AppendEntries RPC's are finished before
- * the Barrier callback is fired. */
+/* Request a blocking Barrier and expect that the no AppendEntries RPC's are
+ * finished before the Barrier callback is fired. */
 TEST(append, blockingBarrierSingleOpenSegment, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -728,7 +732,7 @@ TEST(append, blockingBarrierSingleOpenSegment, setUp, tearDown, 0, NULL)
     bd.done = false;
     bd.expectDone = true;
     bd.uv = f->io.impl;
-    char* files[] = { "0000000000000001-0000000000000001", NULL };
+    char *files[] = {"0000000000000001-0000000000000001", NULL};
     bd.files = files;
 
     /* Wait until there is at least 1 open segment otherwise
@@ -739,13 +743,16 @@ TEST(append, blockingBarrierSingleOpenSegment, setUp, tearDown, 0, NULL)
     }
 
     struct UvBarrier barrier = {0};
-    barrier.data = (void*) &bd;
+    barrier.data = (void *)&bd;
     barrier.blocking = true;
     UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
 
-    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
-    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
-    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE, appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendCbIncreaseCounterAssertResult, &bd, 0);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);
@@ -757,7 +764,7 @@ TEST(append, blockingBarrierSingleOpenSegment, setUp, tearDown, 0, NULL)
 
 static void longWorkCb(uv_work_t *work)
 {
-    (void) work;
+    (void)work;
     sleep(1);
 }
 
@@ -803,10 +810,12 @@ TEST(append, nonBlockingBarrierLongBlockingTask, setUp, tearDown, 0, NULL)
     bd.uv = f->io.impl;
 
     struct UvBarrier barrier = {0};
-    barrier.data = (void*) &bd;
+    barrier.data = (void *)&bd;
     barrier.blocking = false;
-    UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier, barrierCbLongWork);
-    APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd, 0);
+    UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier,
+              barrierCbLongWork);
+    APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd,
+                          0);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);
@@ -815,8 +824,9 @@ TEST(append, nonBlockingBarrierLongBlockingTask, setUp, tearDown, 0, NULL)
 }
 
 /* Request a blocking Barrier that triggers a long-running task, the barrier
- * is unblocked and removed when the long running task completes. This simulates a large
- * snapshot install. Ensure Append requests complete after the work completes.*/
+ * is unblocked and removed when the long running task completes. This simulates
+ * a large snapshot install. Ensure Append requests complete after the work
+ * completes.*/
 TEST(append, blockingBarrierLongBlockingTask, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -828,10 +838,12 @@ TEST(append, blockingBarrierLongBlockingTask, setUp, tearDown, 0, NULL)
     bd.uv = f->io.impl;
 
     struct UvBarrier barrier = {0};
-    barrier.data = (void*) &bd;
+    barrier.data = (void *)&bd;
     barrier.blocking = true;
-    UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier, barrierCbLongWork);
-    APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd, 0);
+    UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier,
+              barrierCbLongWork);
+    APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd,
+                          0);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);

--- a/test/integration/test_uv_load.c
+++ b/test/integration/test_uv_load.c
@@ -249,14 +249,14 @@ struct snapshot
         DirGrowFile(f->dir, _filename2, SEGMENT_SIZE);        \
     } while (0)
 
-#define LOAD_VARS                           \
-        int _rv;                            \
-        raft_term _term;                    \
-        raft_id _voted_for;                 \
-        struct raft_snapshot *_snapshot;    \
-        raft_index _start_index;            \
-        struct raft_entry *_entries;        \
-        size_t _n;
+#define LOAD_VARS                    \
+    int _rv;                         \
+    raft_term _term;                 \
+    raft_id _voted_for;              \
+    struct raft_snapshot *_snapshot; \
+    raft_index _start_index;         \
+    struct raft_entry *_entries;     \
+    size_t _n;
 
 /* Initialize the raft_io instance, then call raft_io->load() and assert that it
  * returns the given error code and message. */
@@ -290,43 +290,43 @@ struct snapshot
         munit_assert_string_equal(f->io.errmsg, ERRMSG);          \
     } while (0)
 
-#define _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)              \
-        _rv = f->io.load(&f->io, &_term, &_voted_for, &_snapshot,             \
-                         &_start_index, &_entries, &_n);                      \
-        munit_assert_int(_rv, ==, 0);                                         \
-        munit_assert_int(_term, ==, TERM);                                    \
-        munit_assert_int(_voted_for, ==, VOTED_FOR);                          \
-        munit_assert_int(_start_index, ==, START_INDEX);                      \
-        if (_snapshot != NULL) {                                              \
-            struct snapshot *_expected = (struct snapshot *)(SNAPSHOT);       \
-            munit_assert_ptr_not_null(_snapshot);                             \
-            munit_assert_int(_snapshot->term, ==, _expected->term);           \
-            munit_assert_int(_snapshot->index, ==, _expected->index);         \
-            munit_assert_int(_snapshot->n_bufs, ==, 1);                       \
-            munit_assert_int(*(uint64_t *)_snapshot->bufs[0].base, ==,        \
-                             _expected->data);                                \
-            raft_configuration_close(&_snapshot->configuration);              \
-            raft_free(_snapshot->bufs[0].base);                               \
-            raft_free(_snapshot->bufs);                                       \
-            raft_free(_snapshot);                                             \
-        }                                                                     \
-        if (_n != 0) {                                                        \
-            munit_assert_int(_n, ==, N_ENTRIES);                              \
-            for (_i = 0; _i < _n; _i++) {                                     \
-                struct raft_entry *_entry = &_entries[_i];                    \
-                uint64_t _value = *(uint64_t *)_entry->buf.base;              \
-                munit_assert_int(_value, ==, _data);                          \
-                _data++;                                                      \
-            }                                                                 \
-            for (_i = 0; _i < _n; _i++) {                                     \
-                struct raft_entry *_entry = &_entries[_i];                    \
-                if (_entry->batch != _batch) {                                \
-                    _batch = _entry->batch;                                   \
-                    raft_free(_batch);                                        \
-                }                                                             \
-            }                                                                 \
-            raft_free(_entries);                                              \
-        }                                                                     \
+#define _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)             \
+    _rv = f->io.load(&f->io, &_term, &_voted_for, &_snapshot, &_start_index, \
+                     &_entries, &_n);                                        \
+    munit_assert_int(_rv, ==, 0);                                            \
+    munit_assert_int(_term, ==, TERM);                                       \
+    munit_assert_int(_voted_for, ==, VOTED_FOR);                             \
+    munit_assert_int(_start_index, ==, START_INDEX);                         \
+    if (_snapshot != NULL) {                                                 \
+        struct snapshot *_expected = (struct snapshot *)(SNAPSHOT);          \
+        munit_assert_ptr_not_null(_snapshot);                                \
+        munit_assert_int(_snapshot->term, ==, _expected->term);              \
+        munit_assert_int(_snapshot->index, ==, _expected->index);            \
+        munit_assert_int(_snapshot->n_bufs, ==, 1);                          \
+        munit_assert_int(*(uint64_t *)_snapshot->bufs[0].base, ==,           \
+                         _expected->data);                                   \
+        raft_configuration_close(&_snapshot->configuration);                 \
+        raft_free(_snapshot->bufs[0].base);                                  \
+        raft_free(_snapshot->bufs);                                          \
+        raft_free(_snapshot);                                                \
+    }                                                                        \
+    if (_n != 0) {                                                           \
+        munit_assert_int(_n, ==, N_ENTRIES);                                 \
+        for (_i = 0; _i < _n; _i++) {                                        \
+            struct raft_entry *_entry = &_entries[_i];                       \
+            uint64_t _value = *(uint64_t *)_entry->buf.base;                 \
+            munit_assert_int(_value, ==, _data);                             \
+            _data++;                                                         \
+        }                                                                    \
+        for (_i = 0; _i < _n; _i++) {                                        \
+            struct raft_entry *_entry = &_entries[_i];                       \
+            if (_entry->batch != _batch) {                                   \
+                _batch = _entry->batch;                                      \
+                raft_free(_batch);                                           \
+            }                                                                \
+        }                                                                    \
+        raft_free(_entries);                                                 \
+    }
 
 /* Initialize the raft_io instance, then invoke raft_io->load() and assert that
  * it returns the given state. If non-NULL, SNAPSHOT points to a struct snapshot
@@ -343,25 +343,27 @@ struct snapshot
     } while (0)
 
 /* Same as LOAD but with auto_recovery set to false */
-#define LOAD_NO_RECOVER(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, ENTRIES_DATA, N_ENTRIES) \
-    do {                                                                                 \
-        LOAD_VARS;                                                                       \
-        void *_batch = NULL;                                                             \
-        uint64_t _data = ENTRIES_DATA;                                                   \
-        unsigned _i;                                                                     \
-        SETUP_UV;                                                                        \
-        raft_uv_set_auto_recovery(&f->io, false);                                        \
-        _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)                         \
+#define LOAD_NO_RECOVER(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, ENTRIES_DATA, \
+                        N_ENTRIES)                                            \
+    do {                                                                      \
+        LOAD_VARS;                                                            \
+        void *_batch = NULL;                                                  \
+        uint64_t _data = ENTRIES_DATA;                                        \
+        unsigned _i;                                                          \
+        SETUP_UV;                                                             \
+        raft_uv_set_auto_recovery(&f->io, false);                             \
+        _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)              \
     } while (0)
 
 /* Same as LOAD without SETUP_UV */
-#define LOAD_NO_SETUP(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, ENTRIES_DATA, N_ENTRIES) \
-    do {                                                                               \
-    	LOAD_VARS;                                                                     \
-        void *_batch = NULL;                                                           \
-        uint64_t _data = ENTRIES_DATA;                                                 \
-        unsigned _i;                                                                   \
-        _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)                       \
+#define LOAD_NO_SETUP(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, ENTRIES_DATA, \
+                      N_ENTRIES)                                            \
+    do {                                                                    \
+        LOAD_VARS;                                                          \
+        void *_batch = NULL;                                                \
+        uint64_t _data = ENTRIES_DATA;                                      \
+        unsigned _i;                                                        \
+        _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)            \
     } while (0)
 
 /******************************************************************************
@@ -435,23 +437,21 @@ TEST(load, ignoreUnknownFiles, setUp, tearDown, 0, unknownFilesParams)
     return MUNIT_OK;
 }
 
-static char *unusableFiles[] = {
-    "tmp-0000000001221212-0000000001221217",
-    "tmp-snapshot-15-8260687-512469866",
-    "snapshot-525-43326736-880259052",
-    "snapshot-999-13371337-880259052.meta",
-    "snapshot-20-8260687-512469866",
-    "snapshot-88-8260687-512469866.meta",
-    "snapshot-88-8260999-512469866.meta",
-    "tmp-snapshot-88-8260999-512469866.meta",
-    "tmp-snapshot-33-8260687-512469866",
-    "snapshot-33-8260687-512469866.meta",
-    "tmp-metadata1",
-    "tmp-metadata2",
-    "tmp-open1",
-    "tmp-open13",
-    NULL
-};
+static char *unusableFiles[] = {"tmp-0000000001221212-0000000001221217",
+                                "tmp-snapshot-15-8260687-512469866",
+                                "snapshot-525-43326736-880259052",
+                                "snapshot-999-13371337-880259052.meta",
+                                "snapshot-20-8260687-512469866",
+                                "snapshot-88-8260687-512469866.meta",
+                                "snapshot-88-8260999-512469866.meta",
+                                "tmp-snapshot-88-8260999-512469866.meta",
+                                "tmp-snapshot-33-8260687-512469866",
+                                "snapshot-33-8260687-512469866.meta",
+                                "tmp-metadata1",
+                                "tmp-metadata2",
+                                "tmp-open1",
+                                "tmp-open13",
+                                NULL};
 
 static MunitParameterEnum unusableFilesParams[] = {
     {"filename", unusableFiles},
@@ -651,7 +651,8 @@ TEST(load, secondOpenSegmentIsAllZeros, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-/* The data directory has two open segments, the first one has a corrupt header. */
+/* The data directory has two open segments, the first one has a corrupt header.
+ */
 TEST(load, twoOpenSegmentsFirstCorrupt, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -664,11 +665,11 @@ TEST(load, twoOpenSegmentsFirstCorrupt, setUp, tearDown, 0, NULL)
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
     /* Load is successful and equals pristine condition. */
     LOAD(0,    /* term                           */
-	 0,    /* voted for                      */
-	 NULL, /* snapshot                       */
-	 1,    /* start index                    */
-	 0,    /* data for first loaded entry    */
-	 0     /* n entries                      */
+         0,    /* voted for                      */
+         NULL, /* snapshot                       */
+         1,    /* start index                    */
+         0,    /* data for first loaded entry    */
+         0     /* n entries                      */
     );
 
     /* The open segments are renamed, and there is no closed segment. */
@@ -679,7 +680,8 @@ TEST(load, twoOpenSegmentsFirstCorrupt, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-/* The data directory has two open segments, the first one has a corrupt header. */
+/* The data directory has two open segments, the first one has a corrupt header.
+ */
 TEST(load, twoOpenSegmentsFirstCorruptNoRecovery, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -690,8 +692,8 @@ TEST(load, twoOpenSegmentsFirstCorruptNoRecovery, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
 
     /* The open segments are renamed, and there is no closed segment. */
     munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
@@ -770,7 +772,7 @@ TEST(load, manySnapshots, setUp, tearDown, 0, NULL)
     /* The orphaned .meta file is removed */
     char meta_filename[128];
     sprintf(meta_filename, "%s%s", filename, UV__SNAPSHOT_META_SUFFIX);
-    munit_assert_false(DirHasFile(f->dir,meta_filename));
+    munit_assert_false(DirHasFile(f->dir, meta_filename));
 
     return MUNIT_OK;
 }
@@ -818,9 +820,9 @@ TEST(load, orphanedSnapshotFiles, setUp, tearDown, 0, NULL)
     uint64_t now = uv_now(&f->loop);
 
     struct snapshot expected_snapshot = {
-        2, /* term */
+        2,  /* term */
         16, /* index */
-        4  /* data */
+        4   /* data */
     };
 
     char filename1_removed[64];
@@ -831,7 +833,8 @@ TEST(load, orphanedSnapshotFiles, setUp, tearDown, 0, NULL)
     /* Take a snapshot but then remove the data file, as if the server crashed
      * before it could complete writing it. */
     sprintf(filename1_removed, "snapshot-2-18-%ju", now);
-    sprintf(metafilename1_removed, "snapshot-2-18-%ju%s", now, UV__SNAPSHOT_META_SUFFIX);
+    sprintf(metafilename1_removed, "snapshot-2-18-%ju%s", now,
+            UV__SNAPSHOT_META_SUFFIX);
     SNAPSHOT_PUT(2, 18, 1);
     munit_assert_true(DirHasFile(f->dir, filename1_removed));
     munit_assert_true(DirHasFile(f->dir, metafilename1_removed));
@@ -840,7 +843,8 @@ TEST(load, orphanedSnapshotFiles, setUp, tearDown, 0, NULL)
     /* Take a snapshot but then remove the .meta file */
     now = uv_now(&f->loop);
     sprintf(filename2_removed, "snapshot-2-19-%ju", now);
-    sprintf(metafilename2_removed, "snapshot-2-19-%ju%s", now, UV__SNAPSHOT_META_SUFFIX);
+    sprintf(metafilename2_removed, "snapshot-2-19-%ju%s", now,
+            UV__SNAPSHOT_META_SUFFIX);
     SNAPSHOT_PUT(2, 19, 2);
     munit_assert_true(DirHasFile(f->dir, filename2_removed));
     munit_assert_true(DirHasFile(f->dir, metafilename2_removed));
@@ -848,12 +852,12 @@ TEST(load, orphanedSnapshotFiles, setUp, tearDown, 0, NULL)
 
     /* Take a valid snapshot and make sure it's loaded */
     SNAPSHOT_PUT(2, 16, 4);
-    LOAD(0,                     /* term */
-         0,                     /* voted for */
-         &expected_snapshot,    /* snapshot */
-         17,                    /* start index */
-         0,                     /* data for first loaded entry */
-         0                      /* n entries */
+    LOAD(0,                  /* term */
+         0,                  /* voted for */
+         &expected_snapshot, /* snapshot */
+         17,                 /* start index */
+         0,                  /* data for first loaded entry */
+         0                   /* n entries */
     );
 
     /* The orphaned files are removed */
@@ -913,15 +917,21 @@ TEST(load, openSegmentWithEntriesPastSnapshot, setUp, tearDown, 0, NULL)
 
 /* The data directory has a closed segment whose filename encodes a number of
  * entries which is different then ones it actually contains. */
-TEST(load, closedSegmentWithInconsistentFilenameNoRecover, setUp, tearDown, 0, NULL)
+TEST(load,
+     closedSegmentWithInconsistentFilenameNoRecover,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     APPEND(3, 1);
     DirRenameFile(f->dir, "0000000000000001-0000000000000003",
                   "0000000000000001-0000000000000004");
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load closed segment 0000000000000001-0000000000000004: found 3 "
-               "entries (expected 4)");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT,
+        "load closed segment 0000000000000001-0000000000000004: found 3 "
+        "entries (expected 4)");
     return MUNIT_OK;
 }
 
@@ -934,12 +944,12 @@ TEST(load, closedSegmentWithInconsistentFilename, setUp, tearDown, 0, NULL)
     DirRenameFile(f->dir, "0000000000000001-0000000000000003",
                   "0000000000000001-0000000000000004");
     /* Load in pristine condition */
-    LOAD(0,         /* term */
-         0,         /* voted for */
+    LOAD(0,    /* term */
+         0,    /* voted for */
          NULL, /* snapshot */
-         1,         /* start index */
-         0,         /* data for first loaded entry */
-         0          /* n entries */
+         1,    /* start index */
+         0,    /* data for first loaded entry */
+         0     /* n entries */
     );
     return MUNIT_OK;
 }
@@ -948,16 +958,22 @@ TEST(load, closedSegmentWithInconsistentFilename, setUp, tearDown, 0, NULL)
  * needed, since they are included in a snapshot. It also has an open segment,
  * however that does not have enough entries to reach the snapshot last
  * index. */
-TEST(load, openSegmentWithEntriesBehindSnapshotNoRecover, setUp, tearDown, 0, NULL)
+TEST(load,
+     openSegmentWithEntriesBehindSnapshotNoRecover,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     APPEND(1, 1);
     APPEND(1, 2);
     SNAPSHOT_PUT(1, 3, 1);
     UNFINALIZE(2, 2, 1);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "last entry on disk has index 2, which is behind last "
-               "snapshot's index 3");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT,
+        "last entry on disk has index 2, which is behind last "
+        "snapshot's index 3");
     return MUNIT_OK;
 }
 
@@ -1012,7 +1028,12 @@ TEST(load, openSegmentNoClosedSegmentsSnapshotPresent, setUp, tearDown, 0, NULL)
 
 /* The data directory contains a snapshot and an open segment with a corrupt
  * format header and no closed segments. */
-TEST(load, corruptOpenSegmentNoClosedSegmentsSnapshotPresentNoRecover, setUp, tearDown, 0, NULL)
+TEST(load,
+     corruptOpenSegmentNoClosedSegmentsSnapshotPresentNoRecover,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     SNAPSHOT_PUT(1, 3, 1);
@@ -1022,14 +1043,19 @@ TEST(load, corruptOpenSegmentNoClosedSegmentsSnapshotPresentNoRecover, setUp, te
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
 /* The data directory contains a snapshot and an open segment with a corrupt
  * format header and no closed segments. */
-TEST(load, corruptOpenSegmentNoClosedSegmentsSnapshotPresent, setUp, tearDown, 0, NULL)
+TEST(load,
+     corruptOpenSegmentNoClosedSegmentsSnapshotPresent,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct snapshot snapshot = {
@@ -1057,7 +1083,12 @@ TEST(load, corruptOpenSegmentNoClosedSegmentsSnapshotPresent, setUp, tearDown, 0
 
 /* The data directory contains a snapshot and an open segment with a corrupt
  * format header and a closed segment. */
-TEST(load, corruptOpenSegmentClosedSegmentSnapshotPresentNoRecover, setUp, tearDown, 0, NULL)
+TEST(load,
+     corruptOpenSegmentClosedSegmentSnapshotPresentNoRecover,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     SNAPSHOT_PUT(1, 3, 1);
@@ -1068,14 +1099,19 @@ TEST(load, corruptOpenSegmentClosedSegmentSnapshotPresentNoRecover, setUp, tearD
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
 /* The data directory contains a snapshot and an open segment with a corrupt
  * format header and a closed segment. */
-TEST(load, corruptOpenSegmentClosedSegmentSnapshotPresent, setUp, tearDown, 0, NULL)
+TEST(load,
+     corruptOpenSegmentClosedSegmentSnapshotPresent,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct snapshot snapshot = {
@@ -1108,7 +1144,12 @@ TEST(load, corruptOpenSegmentClosedSegmentSnapshotPresent, setUp, tearDown, 0, N
 
 /* The data directory contains a snapshot and an open segment with a corrupt
  * format header and multiple closed segment. */
-TEST(load, corruptOpenSegmentClosedSegmentsSnapshotPresent, setUp, tearDown, 0, NULL)
+TEST(load,
+     corruptOpenSegmentClosedSegmentsSnapshotPresent,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct snapshot snapshot = {
@@ -1140,7 +1181,12 @@ TEST(load, corruptOpenSegmentClosedSegmentsSnapshotPresent, setUp, tearDown, 0, 
 
 /* The data directory contains a snapshot and an open segment with a corrupt
  * format header and multiple closed segment. */
-TEST(load, corruptOpenSegmentClosedSegmentsSnapshotPresentNoRecover, setUp, tearDown, 0, NULL)
+TEST(load,
+     corruptOpenSegmentClosedSegmentsSnapshotPresentNoRecover,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     SNAPSHOT_PUT(1, 3, 1);
@@ -1152,13 +1198,13 @@ TEST(load, corruptOpenSegmentClosedSegmentsSnapshotPresentNoRecover, setUp, tear
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
-/* The data directory contains a closed segment and an open segment with a corrupt
- * format header and no snapshot. */
+/* The data directory contains a closed segment and an open segment with a
+ * corrupt format header and no snapshot. */
 TEST(load, corruptOpenSegmentClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -1169,13 +1215,13 @@ TEST(load, corruptOpenSegmentClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
-/* The data directory contains a closed segment and an open segment with a corrupt
- * format header and no snapshot. */
+/* The data directory contains a closed segment and an open segment with a
+ * corrupt format header and no snapshot. */
 TEST(load, corruptOpenSegmentClosedSegments, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
@@ -1187,12 +1233,12 @@ TEST(load, corruptOpenSegmentClosedSegments, setUp, tearDown, 0, NULL)
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
     /* load is successful. */
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         NULL,      /* snapshot */
-         1,         /* start index */
-         1,         /* data for first loaded entry */
-         4          /* n entries */
+    LOAD(0,    /* term */
+         0,    /* voted for */
+         NULL, /* snapshot */
+         1,    /* start index */
+         1,    /* data for first loaded entry */
+         4     /* n entries */
     );
     /* Open segment has been renamed */
     munit_assert_false(DirHasFile(f->dir, "open-1"));
@@ -1213,8 +1259,8 @@ TEST(load, corruptOpenSegmentsClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
 
     return MUNIT_OK;
 }
@@ -1234,12 +1280,12 @@ TEST(load, corruptOpenSegmentsClosedSegments, setUp, tearDown, 0, NULL)
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
 
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         NULL,      /* snapshot */
-         1,         /* start index */
-         1,         /* data for first loaded entry */
-         3          /* n entries */
+    LOAD(0,    /* term */
+         0,    /* voted for */
+         NULL, /* snapshot */
+         1,    /* start index */
+         1,    /* data for first loaded entry */
+         3     /* n entries */
     );
 
     /* Open segments have been renamed */
@@ -1250,7 +1296,12 @@ TEST(load, corruptOpenSegmentsClosedSegments, setUp, tearDown, 0, NULL)
 
 /* The data directory contains a closed segment and two open segments.
  * The second open segment has a corrupt header. */
-TEST(load, corruptLastOpenSegmentClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
+TEST(load,
+     corruptLastOpenSegmentClosedSegmentsNoRecover,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     APPEND(3, 1);
@@ -1262,8 +1313,8 @@ TEST(load, corruptLastOpenSegmentClosedSegmentsNoRecover, setUp, tearDown, 0, NU
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-2", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-2: unexpected format version 0");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-2: unexpected format version 0");
 
     return MUNIT_OK;
 }
@@ -1283,12 +1334,12 @@ TEST(load, corruptLastOpenSegmentClosedSegments, setUp, tearDown, 0, NULL)
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-2", &version, sizeof version, 0);
 
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         NULL,      /* snapshot */
-         1,         /* start index */
-         1,         /* data for first loaded entry */
-         4          /* n entries */
+    LOAD(0,    /* term */
+         0,    /* voted for */
+         NULL, /* snapshot */
+         1,    /* start index */
+         1,    /* data for first loaded entry */
+         4     /* n entries */
     );
     /* Open segment has been renamed during the first load */
     munit_assert_false(DirHasFile(f->dir, "open-2"));
@@ -1321,7 +1372,12 @@ TEST(load, closedSegmentsOverlappingWithSnapshot, setUp, tearDown, 0, NULL)
 
 /* The data directory has several closed segments, the last of which is corrupt.
  * There is a snapshot. */
-TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptNoRecover, setUp, tearDown, 0, NULL)
+TEST(load,
+     closedSegmentsWithSnapshotLastSegmentCorruptNoRecover,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     SNAPSHOT_PUT(1, 4, 1);
@@ -1335,15 +1391,21 @@ TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptNoRecover, setUp, tearDow
     uint32_t corrupted = 123456789;
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 9), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load closed segment 0000000000000008-0000000000000009: entries "
-               "batch 1 starting at byte 8: data checksum mismatch");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT,
+        "load closed segment 0000000000000008-0000000000000009: entries "
+        "batch 1 starting at byte 8: data checksum mismatch");
     return MUNIT_OK;
 }
 
 /* The data directory has several closed segments, the last of which is corrupt.
  * There is a snapshot. */
-TEST(load, closedSegmentsWithSnapshotLastSegmentCorrupt, setUp, tearDown, 0, NULL)
+TEST(load,
+     closedSegmentsWithSnapshotLastSegmentCorrupt,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct snapshot snapshot = {
@@ -1374,7 +1436,12 @@ TEST(load, closedSegmentsWithSnapshotLastSegmentCorrupt, setUp, tearDown, 0, NUL
 
 /* The data directory has several closed segments, the last of which is corrupt.
  * There is an open segment and a snapshot. */
-TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptOpenSegment, setUp, tearDown, 0, NULL)
+TEST(load,
+     closedSegmentsWithSnapshotLastSegmentCorruptOpenSegment,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct snapshot snapshot = {
@@ -1410,7 +1477,12 @@ TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptOpenSegment, setUp, tearD
 
 /* The data directory has several closed segments, the last of which is corrupt.
  * There is an open segment and a snapshot. */
-TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptOpenSegmentNoRecover, setUp, tearDown, 0, NULL)
+TEST(load,
+     closedSegmentsWithSnapshotLastSegmentCorruptOpenSegmentNoRecover,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     SNAPSHOT_PUT(1, 4, 1);
@@ -1427,15 +1499,21 @@ TEST(load, closedSegmentsWithSnapshotLastSegmentCorruptOpenSegmentNoRecover, set
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 8), &corrupted,
                      sizeof corrupted, offset);
     munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load closed segment 0000000000000008-0000000000000008: entries "
-               "batch 1 starting at byte 8: data checksum mismatch");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT,
+        "load closed segment 0000000000000008-0000000000000008: entries "
+        "batch 1 starting at byte 8: data checksum mismatch");
     return MUNIT_OK;
 }
 
-/* The data directory has several closed segments, the second to last one of which is corrupt.
- * There is a snapshot. */
-TEST(load, closedSegmentsWithSnapshotSecondLastSegmentCorrupt, setUp, tearDown, 0, NULL)
+/* The data directory has several closed segments, the second to last one of
+ * which is corrupt. There is a snapshot. */
+TEST(load,
+     closedSegmentsWithSnapshotSecondLastSegmentCorrupt,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     SNAPSHOT_PUT(1, 4, 1);
@@ -1454,9 +1532,10 @@ TEST(load, closedSegmentsWithSnapshotSecondLastSegmentCorrupt, setUp, tearDown, 
                "batch 1 starting at byte 8: data checksum mismatch");
 
     /* Second load still fails. */
-    LOAD_ERROR_NO_SETUP(RAFT_CORRUPT,
-                        "load closed segment 0000000000000006-0000000000000007: entries "
-                        "batch 1 starting at byte 8: data checksum mismatch");
+    LOAD_ERROR_NO_SETUP(
+        RAFT_CORRUPT,
+        "load closed segment 0000000000000006-0000000000000007: entries "
+        "batch 1 starting at byte 8: data checksum mismatch");
 
     return MUNIT_OK;
 }
@@ -1578,9 +1657,10 @@ TEST(load, closedSegmentWithCorruptedBatchHeader, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load closed segment 0000000000000001-0000000000000001: entries "
-               "batch 1 starting at byte 8: header checksum mismatch");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT,
+        "load closed segment 0000000000000001-0000000000000001: entries "
+        "batch 1 starting at byte 8: header checksum mismatch");
     return MUNIT_OK;
 }
 
@@ -1594,9 +1674,10 @@ TEST(load, closedSegmentWithCorruptedBatchData, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load closed segment 0000000000000001-0000000000000001: entries "
-               "batch 1 starting at byte 8: data checksum mismatch");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT,
+        "load closed segment 0000000000000001-0000000000000001: entries "
+        "batch 1 starting at byte 8: data checksum mismatch");
     return MUNIT_OK;
 }
 
@@ -1608,9 +1689,10 @@ TEST(load, closedSegmentWithBadIndex, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     APPEND(1, 2);
     DirRemoveFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1));
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "unexpected closed segment 0000000000000002-0000000000000002: "
-               "first index should have been 1");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT,
+        "unexpected closed segment 0000000000000002-0000000000000002: "
+        "first index should have been 1");
     return MUNIT_OK;
 }
 
@@ -1631,9 +1713,10 @@ TEST(load, closedSegmentWithBadFormat, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     uint8_t buf[8] = {2, 0, 0, 0, 0, 0, 0, 0};
     DirWriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), buf, sizeof buf);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load closed segment 0000000000000001-0000000000000001: "
-               "unexpected format version 2");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT,
+        "load closed segment 0000000000000001-0000000000000001: "
+        "unexpected format version 2");
     return MUNIT_OK;
 }
 
@@ -1658,8 +1741,8 @@ TEST(load, openSegmentWithZeroFormatAndThenData, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     UNFINALIZE(1, 1, 1);
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
@@ -1671,7 +1754,7 @@ TEST(load, openSegmentWithBadFormat, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     UNFINALIZE(1, 1, 1);
     DirOverwriteFile(f->dir, "open-1", version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(RAFT_CORRUPT,
-               "load open segment open-1: unexpected format version 2");
+    LOAD_ERROR_NO_RECOVER(
+        RAFT_CORRUPT, "load open segment open-1: unexpected format version 2");
     return MUNIT_OK;
 }

--- a/test/integration/test_uv_snapshot_put.c
+++ b/test/integration/test_uv_snapshot_put.c
@@ -1,9 +1,9 @@
 #include <unistd.h>
 
-#include "append_helpers.h"
 #include "../lib/runner.h"
 #include "../lib/tcp.h"
 #include "../lib/uv.h"
+#include "append_helpers.h"
 
 /******************************************************************************
  *
@@ -260,8 +260,14 @@ TEST(snapshot_put, installWithoutPreviousEntries, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-/* Request to install a couple of snapshots in a row, no previous entry is present. */
-TEST(snapshot_put, installMultipleWithoutPreviousEntries, setUp, tearDown, 0, NULL)
+/* Request to install a couple of snapshots in a row, no previous entry is
+ * present. */
+TEST(snapshot_put,
+     installMultipleWithoutPreviousEntries,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     SNAPSHOT_PUT(0, /* trailing */
@@ -270,15 +276,20 @@ TEST(snapshot_put, installMultipleWithoutPreviousEntries, setUp, tearDown, 0, NU
     SNAPSHOT_PUT(0, /* trailing */
                  3  /* index */
     );
-    SNAPSHOT_PUT(0,    /* trailing */
-                 1337  /* index */
+    SNAPSHOT_PUT(0,   /* trailing */
+                 1337 /* index */
     );
     return MUNIT_OK;
 }
 
 /* Request to install a couple of snapshots in a row, AppendEntries Requests
  * happen before, meanwhile and after */
-TEST(snapshot_put, installMultipleAppendEntriesInBetween, setUp, tearDown, 0, NULL)
+TEST(snapshot_put,
+     installMultipleAppendEntriesInBetween,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
 
@@ -291,8 +302,8 @@ TEST(snapshot_put, installMultipleAppendEntriesInBetween, setUp, tearDown, 0, NU
     APPEND_WAIT(1);
     APPEND_SUBMIT(2, 256, 8);
     APPEND_SUBMIT(3, 256, 8);
-    SNAPSHOT_PUT(0, /* trailing */
-                 100  /* index */
+    SNAPSHOT_PUT(0,  /* trailing */
+                 100 /* index */
     );
     APPEND_WAIT(2);
     APPEND_WAIT(3);

--- a/test/integration/test_uv_tcp_connect.c
+++ b/test/integration/test_uv_tcp_connect.c
@@ -60,9 +60,9 @@ static void connectCbAssertResult(struct raft_uv_connect *req,
         f->closed = false;                                           \
     } while (0)
 
-#define CLOSE_SUBMIT                            \
-    munit_assert_false(f->closed);              \
-    f->transport.close(&f->transport, closeCb); 
+#define CLOSE_SUBMIT               \
+    munit_assert_false(f->closed); \
+    f->transport.close(&f->transport, closeCb);
 
 #define CLOSE_WAIT LOOP_RUN_UNTIL(&f->closed)
 #define CLOSE     \

--- a/test/integration/test_uv_tcp_listen.c
+++ b/test/integration/test_uv_tcp_listen.c
@@ -61,7 +61,7 @@ static void acceptCb(struct raft_uv_transport *t,
 #define INIT                                                                  \
     do {                                                                      \
         int _rv;                                                              \
-        f->transport.version = 1;                                    \
+        f->transport.version = 1;                                             \
         _rv = raft_uv_tcp_init(&f->transport, &f->loop);                      \
         munit_assert_int(_rv, ==, 0);                                         \
         const char *bind_addr = munit_parameters_get(params, "bind-address"); \

--- a/test/integration/test_uv_work.c
+++ b/test/integration/test_uv_work.c
@@ -1,10 +1,10 @@
 #include <unistd.h>
 
+#include "../../src/uv.h"
 #include "../lib/dir.h"
 #include "../lib/loop.h"
 #include "../lib/runner.h"
 #include "../lib/uv.h"
-#include "../../src/uv.h"
 
 /******************************************************************************
  *
@@ -83,10 +83,10 @@ static int asyncWorkFn(struct raft_io_async_work *req)
 
 SUITE(UvAsyncWork)
 
-static char* rvs[] = { "-1", "0", "1", "37", NULL };
+static char *rvs[] = {"-1", "0", "1", "37", NULL};
 static MunitParameterEnum rvs_params[] = {
-    { "rv", rvs },
-    { NULL, NULL },
+    {"rv", rvs},
+    {NULL, NULL},
 };
 
 TEST(UvAsyncWork, work, setUp, tearDown, 0, rvs_params)

--- a/test/lib/addrinfo.h
+++ b/test/lib/addrinfo.h
@@ -1,16 +1,14 @@
-/* Support for getaddrinfo injection for test purpose 
+/* Support for getaddrinfo injection for test purpose
  *
- * Provide a local bound version to capture teh getaddrinfo/freeaddrinfo incovation
- * The helper may operate in three different modes:
- * a) Transparent forward calls to system getaddrinfo/freeaddrinfo function,
- *    if the SET_UP_ADDRINFO/TEAR_DOWN_ADDRINFO is not added to the test
- *    test case setup teardown.
- * b) Check, if all results requested by getaddrinfo are freed using freeaddrinfo.
- *    Activated by adding the SET_UP_ADDRINFO/SET_UP_ADDRINFO macros to the test
- *    fixture.
- * c) Inject artifical responses into the the getaddrinfo requests for test purpose
- *    additionally to b) by using AddrinfoInjectSetResponse before triggering the 
- *    getaddrinfo calls.
+ * Provide a local bound version to capture teh getaddrinfo/freeaddrinfo
+ * incovation The helper may operate in three different modes: a) Transparent
+ * forward calls to system getaddrinfo/freeaddrinfo function, if the
+ * SET_UP_ADDRINFO/TEAR_DOWN_ADDRINFO is not added to the test test case setup
+ * teardown. b) Check, if all results requested by getaddrinfo are freed using
+ * freeaddrinfo. Activated by adding the SET_UP_ADDRINFO/SET_UP_ADDRINFO macros
+ * to the test fixture. c) Inject artifical responses into the the getaddrinfo
+ * requests for test purpose additionally to b) by using
+ * AddrinfoInjectSetResponse before triggering the getaddrinfo calls.
  */
 
 #ifndef TEST_ADDRINFO_H

--- a/test/lib/aio.h
+++ b/test/lib/aio.h
@@ -9,8 +9,8 @@
  * @io_setup.
  *
  * Return -1 if it looks like there is another process already using the AIO
- * subsystem, which would most probably make the calling test flaky because there
- * won't be exactly @n events available anymore. */
+ * subsystem, which would most probably make the calling test flaky because
+ * there won't be exactly @n events available anymore. */
 int AioFill(aio_context_t *ctx, unsigned n);
 
 /* Destroy the given AIO context. */

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -37,8 +37,7 @@
                 atoi(munit_parameters_get(params, CLUSTER_PRE_VOTE_PARAM));    \
         }                                                                      \
         if (munit_parameters_get(params, CLUSTER_HEARTBEAT_PARAM) != NULL) {   \
-            _hb =                                                              \
-                atoi(munit_parameters_get(params, CLUSTER_HEARTBEAT_PARAM));   \
+            _hb = atoi(munit_parameters_get(params, CLUSTER_HEARTBEAT_PARAM)); \
         }                                                                      \
         if (munit_parameters_get(params, CLUSTER_SS_ASYNC_PARAM) != NULL) {    \
             _ss_async =                                                        \

--- a/test/lib/fsm.c
+++ b/test/lib/fsm.c
@@ -100,8 +100,8 @@ static int fsmEncodeSnapshot(int x,
 
 /* For use with fsm->version 1 */
 static int fsmSnapshot_v1(struct raft_fsm *fsm,
-                       struct raft_buffer *bufs[],
-                       unsigned *n_bufs)
+                          struct raft_buffer *bufs[],
+                          unsigned *n_bufs)
 {
     struct fsm *f = fsm->data;
     return fsmEncodeSnapshot(f->x, f->y, bufs, n_bufs);
@@ -109,8 +109,8 @@ static int fsmSnapshot_v1(struct raft_fsm *fsm,
 
 /* For use with fsmSnapshotFinalize and fsm->version >= 2 */
 static int fsmSnapshot_v2(struct raft_fsm *fsm,
-                       struct raft_buffer *bufs[],
-                       unsigned *n_bufs)
+                          struct raft_buffer *bufs[],
+                          unsigned *n_bufs)
 {
     struct fsm *f = fsm->data;
     munit_assert_int(f->lock, ==, 0);
@@ -121,11 +121,11 @@ static int fsmSnapshot_v2(struct raft_fsm *fsm,
 }
 
 static int fsmSnapshotInitialize(struct raft_fsm *fsm,
-	                         struct raft_buffer *bufs[],
-	                         unsigned *n_bufs)
+                                 struct raft_buffer *bufs[],
+                                 unsigned *n_bufs)
 {
-    (void) bufs;
-    (void) n_bufs;
+    (void)bufs;
+    (void)n_bufs;
     struct fsm *f = fsm->data;
     munit_assert_int(f->lock, ==, 0);
     f->lock = 1;
@@ -136,19 +136,19 @@ static int fsmSnapshotInitialize(struct raft_fsm *fsm,
 }
 
 static int fsmSnapshotAsync(struct raft_fsm *fsm,
-	                    struct raft_buffer *bufs[],
-	                    unsigned *n_bufs)
+                            struct raft_buffer *bufs[],
+                            unsigned *n_bufs)
 {
     struct fsm *f = fsm->data;
     return fsmEncodeSnapshot(f->x, f->y, bufs, n_bufs);
 }
 
 static int fsmSnapshotFinalize(struct raft_fsm *fsm,
-	                         struct raft_buffer *bufs[],
-	                         unsigned *n_bufs)
+                               struct raft_buffer *bufs[],
+                               unsigned *n_bufs)
 {
-    (void) bufs;
-    (void) n_bufs;
+    (void)bufs;
+    (void)n_bufs;
     struct fsm *f = fsm->data;
     if (*bufs != NULL) {
         for (unsigned i = 0; i < *n_bufs; ++i) {

--- a/test/lib/heap.c
+++ b/test/lib/heap.c
@@ -7,8 +7,8 @@
 
 struct heap
 {
-    int n;                   /* Number of outstanding allocations. */
-    size_t alignment;        /* Value of last aligned alloc */
+    int n;              /* Number of outstanding allocations. */
+    size_t alignment;   /* Value of last aligned alloc */
     struct Fault fault; /* Fault trigger. */
 };
 

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -89,14 +89,15 @@ extern int _main_suites_n;
     }
 
 /* Add a test case to the MunitTest[] array of suite S. */
-#define TEST__ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)             \
-    __attribute__((constructor(103))) static void _##S##_tests_##C##_init(void) \
-    {                                                                           \
-        MunitTest *tests = _##S##_tests;                                        \
-        int n = _##S##_tests_n;                                                 \
-        TEST__SET_IN_ARRAY(tests, n, "/" #C, test_##S##_##C, SETUP, TEAR_DOWN,  \
-                           OPTIONS, PARAMS);                                    \
-        _##S##_tests_n = n + 1;                                                 \
+#define TEST__ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)            \
+    __attribute__((constructor(103))) static void _##S##_tests_##C##_init(     \
+        void)                                                                  \
+    {                                                                          \
+        MunitTest *tests = _##S##_tests;                                       \
+        int n = _##S##_tests_n;                                                \
+        TEST__SET_IN_ARRAY(tests, n, "/" #C, test_##S##_##C, SETUP, TEAR_DOWN, \
+                           OPTIONS, PARAMS);                                   \
+        _##S##_tests_n = n + 1;                                                \
     }
 
 /* Set the values of the I'th test case slot in the given test array */

--- a/test/lib/tcp.h
+++ b/test/lib/tcp.h
@@ -28,7 +28,7 @@
 
 struct TcpServer
 {
-    int socket;        /* Socket listening to incoming connections */
+    int socket; /* Socket listening to incoming connections */
     int port;
     char address[128]; /* IPv4 address of the server, with port */
 };

--- a/test/lib/tracer.h
+++ b/test/lib/tracer.h
@@ -6,7 +6,9 @@
 #include "../../include/raft.h"
 
 #define FIXTURE_TRACER struct raft_tracer tracer
-#define SET_UP_TRACER f->tracer.emit = TracerEmit; f->tracer.enabled = true
+#define SET_UP_TRACER            \
+    f->tracer.emit = TracerEmit; \
+    f->tracer.enabled = true
 #define TEAR_DOWN_TRACER
 
 void TracerEmit(struct raft_tracer *t,

--- a/test/lib/uv.h
+++ b/test/lib/uv.h
@@ -11,12 +11,12 @@
 #include "tracer.h"
 
 #define FIXTURE_UV_TRANSPORT struct raft_uv_transport transport
-#define SETUP_UV_TRANSPORT                                \
-    do {                                                  \
-        int rv_;                                          \
-        f->transport.version = 1;                         \
-        rv_ = raft_uv_tcp_init(&f->transport, &f->loop);  \
-        munit_assert_int(rv_, ==, 0);                     \
+#define SETUP_UV_TRANSPORT                               \
+    do {                                                 \
+        int rv_;                                         \
+        f->transport.version = 1;                        \
+        rv_ = raft_uv_tcp_init(&f->transport, &f->loop); \
+        munit_assert_int(rv_, ==, 0);                    \
     } while (0)
 #define TEAR_DOWN_UV_TRANSPORT raft_uv_tcp_close(&f->transport)
 

--- a/test/unit/test_compress.c
+++ b/test/unit/test_compress.c
@@ -21,8 +21,8 @@ struct raft_buffer getBufWithRandom(size_t len)
 
     size_t offset = 0;
     /* Write as many random ints in buf as possible */
-    for(size_t n = buf.len / sizeof(int); n > 0; n--) {
-        *((int*)(buf.base) + offset) = rand();
+    for (size_t n = buf.len / sizeof(int); n > 0; n--) {
+        *((int *)(buf.base) + offset) = rand();
         offset += 1;
     }
 
@@ -33,7 +33,7 @@ struct raft_buffer getBufWithRandom(size_t len)
     if (rem) {
         int r_int = rand();
         for (unsigned i = 0; i < rem; i++) {
-            *((char*)buf.base + offset) = *((char*)&r_int + i);
+            *((char *)buf.base + offset) = *((char *)&r_int + i);
             offset++;
         }
     }
@@ -62,7 +62,8 @@ static void sha1(struct raft_buffer bufs[], unsigned n_bufs, uint8_t value[20])
     struct byteSha1 sha;
     byteSha1Init(&sha);
     for (unsigned i = 0; i < n_bufs; i++) {
-        byteSha1Update(&sha, (const uint8_t *)bufs[i].base, (uint32_t)bufs[i].len);
+        byteSha1Update(&sha, (const uint8_t *)bufs[i].base,
+                       (uint32_t)bufs[i].len);
     }
     byteSha1Digest(&sha, value);
 }
@@ -70,34 +71,35 @@ static void sha1(struct raft_buffer bufs[], unsigned n_bufs, uint8_t value[20])
 TEST(Compress, compressDecompressZeroLength, NULL, NULL, 0, NULL)
 {
     char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
-    struct raft_buffer bufs1[2] = {{NULL, 0},{(void*)0xDEADBEEF, 0}}; /* 0 length */
-    struct raft_buffer bufs2[2] = {{(void*)0xDEADBEEF, 0},{NULL, 0}}; /* 0 length */
+    struct raft_buffer bufs1[2] = {{NULL, 0},
+                                   {(void *)0xDEADBEEF, 0}}; /* 0 length */
+    struct raft_buffer bufs2[2] = {{(void *)0xDEADBEEF, 0},
+                                   {NULL, 0}}; /* 0 length */
     struct raft_buffer compressed = {0};
-    munit_assert_int(Compress(&bufs1[0], 1, &compressed, errmsg), ==, RAFT_INVALID);
-    munit_assert_int(Compress(&bufs1[1], 1, &compressed, errmsg), ==, RAFT_INVALID);
+    munit_assert_int(Compress(&bufs1[0], 1, &compressed, errmsg), ==,
+                     RAFT_INVALID);
+    munit_assert_int(Compress(&bufs1[1], 1, &compressed, errmsg), ==,
+                     RAFT_INVALID);
     munit_assert_int(Compress(bufs1, 2, &compressed, errmsg), ==, RAFT_INVALID);
     munit_assert_int(Compress(bufs2, 2, &compressed, errmsg), ==, RAFT_INVALID);
     return MUNIT_OK;
 }
 
-static char* len_one_params[] = {
-/*    16B   1KB     64KB     4MB        128MB */
-      "16", "1024", "65536", "4194304", "134217728",
-/*    Around Blocksize*/
-      "65516", "65517", "65518", "65521", "65535",
-      "65537", "65551", "65555", "65556",
-/*    Ugly lengths */
-      "0", "1", "9", "123450", "1337", "6655111",
-      NULL
-};
+static char *len_one_params[] = {
+    /*    16B   1KB     64KB     4MB        128MB */
+    "16", "1024", "65536", "4194304", "134217728",
+    /*    Around Blocksize*/
+    "65516", "65517", "65518", "65521", "65535", "65537", "65551", "65555",
+    "65556",
+    /*    Ugly lengths */
+    "0", "1", "9", "123450", "1337", "6655111", NULL};
 
 static MunitParameterEnum random_one_params[] = {
-    { "len_one", len_one_params },
-    { NULL, NULL },
+    {"len_one", len_one_params},
+    {NULL, NULL},
 };
 
-TEST(Compress, compressDecompressRandomOne, NULL, NULL, 0,
-     random_one_params)
+TEST(Compress, compressDecompressRandomOne, NULL, NULL, 0, random_one_params)
 {
     char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
     struct raft_buffer compressed = {0};
@@ -127,28 +129,32 @@ TEST(Compress, compressDecompressRandomOne, NULL, NULL, 0,
     return MUNIT_OK;
 }
 
-static char* len_nonrandom_one_params[] = {
-#if !defined(__LP64__) && (defined(__arm__) || defined(__i386__) || defined(__mips__))
-/*    4KB     64KB     4MB        1GB           INT_MAX (larger allocations fail on 32-bit archs */
-      "4096", "65536", "4194304", "1073741824", "2147483647",
+static char *len_nonrandom_one_params[] = {
+#if !defined(__LP64__) && \
+    (defined(__arm__) || defined(__i386__) || defined(__mips__))
+    /*    4KB     64KB     4MB        1GB           INT_MAX (larger allocations
+       fail on 32-bit archs */
+    "4096", "65536", "4194304", "1073741824", "2147483647",
 #else
-/*    4KB     64KB     4MB        1GB           2GB + 200MB */
-      "4096", "65536", "4194304", "1073741824", "2357198848",
+    /*    4KB     64KB     4MB        1GB           2GB + 200MB */
+    "4096", "65536", "4194304", "1073741824", "2357198848",
 #endif
-/*    Around Blocksize*/
-      "65516", "65517", "65518", "65521", "65535",
-      "65537", "65551", "65555", "65556",
-/*    Ugly lengths */
-      "0", "993450", "31337", "83883825",
-      NULL
-};
+    /*    Around Blocksize*/
+    "65516", "65517", "65518", "65521", "65535", "65537", "65551", "65555",
+    "65556",
+    /*    Ugly lengths */
+    "0", "993450", "31337", "83883825", NULL};
 
 static MunitParameterEnum nonrandom_one_params[] = {
-    { "len_one", len_nonrandom_one_params },
-    { NULL, NULL },
+    {"len_one", len_nonrandom_one_params},
+    {NULL, NULL},
 };
 
-TEST(Compress, compressDecompressNonRandomOne, NULL, NULL, 0,
+TEST(Compress,
+     compressDecompressNonRandomOne,
+     NULL,
+     NULL,
+     0,
      nonrandom_one_params)
 {
     char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
@@ -183,19 +189,15 @@ TEST(Compress, compressDecompressNonRandomOne, NULL, NULL, 0,
     return MUNIT_OK;
 }
 
-static char* len_two_params[] = {
-      "4194304", "13373", "66", "0",
-      NULL
-};
+static char *len_two_params[] = {"4194304", "13373", "66", "0", NULL};
 
 static MunitParameterEnum random_two_params[] = {
-    { "len_one", len_one_params },
-    { "len_two", len_two_params },
-    { NULL, NULL },
+    {"len_one", len_one_params},
+    {"len_two", len_two_params},
+    {NULL, NULL},
 };
 
-TEST(Compress, compressDecompressRandomTwo, NULL, NULL, 0,
-     random_two_params)
+TEST(Compress, compressDecompressRandomTwo, NULL, NULL, 0, random_two_params)
 {
     char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
     struct raft_buffer compressed = {0};
@@ -212,7 +214,7 @@ TEST(Compress, compressDecompressRandomTwo, NULL, NULL, 0,
     }
     struct raft_buffer buf1 = getBufWithRandom(len1);
     struct raft_buffer buf2 = getBufWithRandom(len2);
-    struct raft_buffer bufs[2] = { buf1, buf2 };
+    struct raft_buffer bufs[2] = {buf1, buf2};
 
     /* If one of the buffers is empty ensure data is identical to single buffer
      * case. */
@@ -258,10 +260,11 @@ TEST(Compress, compressDecompressCorruption, NULL, NULL, 0, NULL)
 
     /* Corrupt the a data byte after the header */
     munit_assert_ulong(LZ4F_HEADER_SIZE_MAX_RAFT, <, compressed.len);
-    ((char*)compressed.base)[LZ4F_HEADER_SIZE_MAX_RAFT] += 1;
+    ((char *)compressed.base)[LZ4F_HEADER_SIZE_MAX_RAFT] += 1;
 
     munit_assert_int(Decompress(compressed, &decompressed, errmsg), !=, 0);
-    munit_assert_string_equal(errmsg, "LZ4F_decompress ERROR_contentChecksum_invalid");
+    munit_assert_string_equal(errmsg,
+                              "LZ4F_decompress ERROR_contentChecksum_invalid");
     munit_assert_ptr_null(decompressed.base);
 
     raft_free(compressed.base);
@@ -292,7 +295,7 @@ TEST(Compress, lz4Disabled, NULL, NULL, 0, NULL)
 static const char LZ4_MAGIC[4] = {0x04, 0x22, 0x4d, 0x18};
 TEST(Compress, isCompressedTooSmall, NULL, NULL, 0, NULL)
 {
-    munit_assert_false(IsCompressed(&LZ4_MAGIC[1], sizeof(LZ4_MAGIC)-1));
+    munit_assert_false(IsCompressed(&LZ4_MAGIC[1], sizeof(LZ4_MAGIC) - 1));
     return MUNIT_OK;
 }
 

--- a/test/unit/test_log.c
+++ b/test/unit/test_log.c
@@ -29,15 +29,15 @@ struct fixture
 #define GET(INDEX) logGet(f->log, INDEX)
 
 /* Append one command entry with the given term and a hard-coded payload. */
-#define APPEND(TERM)                                               \
-    {                                                              \
-        struct raft_buffer buf_;                                   \
-        int rv_;                                                   \
-        buf_.base = raft_malloc(8);                                \
-        buf_.len = 8;                                              \
-        strcpy(buf_.base, "hello");                                \
+#define APPEND(TERM)                                              \
+    {                                                             \
+        struct raft_buffer buf_;                                  \
+        int rv_;                                                  \
+        buf_.base = raft_malloc(8);                               \
+        buf_.len = 8;                                             \
+        strcpy(buf_.base, "hello");                               \
         rv_ = logAppend(f->log, TERM, RAFT_COMMAND, &buf_, NULL); \
-        munit_assert_int(rv_, ==, 0);                              \
+        munit_assert_int(rv_, ==, 0);                             \
     }
 
 /* Same as APPEND, but repeated N times. */
@@ -50,44 +50,44 @@ struct fixture
     }
 
 /* Invoke append and assert that it returns the given error. */
-#define APPEND_ERROR(TERM, RV)                                     \
-    {                                                              \
-        struct raft_buffer buf_;                                   \
-        int rv_;                                                   \
-        buf_.base = raft_malloc(8);                                \
-        buf_.len = 8;                                              \
+#define APPEND_ERROR(TERM, RV)                                    \
+    {                                                             \
+        struct raft_buffer buf_;                                  \
+        int rv_;                                                  \
+        buf_.base = raft_malloc(8);                               \
+        buf_.len = 8;                                             \
         rv_ = logAppend(f->log, TERM, RAFT_COMMAND, &buf_, NULL); \
-        munit_assert_int(rv_, ==, RV);                             \
-        raft_free(buf_.base);                                      \
+        munit_assert_int(rv_, ==, RV);                            \
+        raft_free(buf_.base);                                     \
     }
 
 /* Append N entries all belonging to the same batch. Each entry will have 64-bit
  * payload set to i * 1000, where i is the index of the entry in the batch. */
-#define APPEND_BATCH(N)                                            \
-    {                                                              \
-        void *batch;                                               \
-        size_t offset;                                             \
-        int i;                                                     \
-        batch = raft_malloc(8 * N);                                \
-        munit_assert_ptr_not_null(batch);                          \
-        offset = 0;                                                \
-        for (i = 0; i < N; i++) {                                  \
-            struct raft_buffer buf;                                \
-            int rv;                                                \
-            buf.base = (uint8_t *)batch + offset;                  \
-            buf.len = 8;                                           \
-            *(uint64_t *)buf.base = i * 1000;                      \
+#define APPEND_BATCH(N)                                           \
+    {                                                             \
+        void *batch;                                              \
+        size_t offset;                                            \
+        int i;                                                    \
+        batch = raft_malloc(8 * N);                               \
+        munit_assert_ptr_not_null(batch);                         \
+        offset = 0;                                               \
+        for (i = 0; i < N; i++) {                                 \
+            struct raft_buffer buf;                               \
+            int rv;                                               \
+            buf.base = (uint8_t *)batch + offset;                 \
+            buf.len = 8;                                          \
+            *(uint64_t *)buf.base = i * 1000;                     \
             rv = logAppend(f->log, 1, RAFT_COMMAND, &buf, batch); \
-            munit_assert_int(rv, ==, 0);                           \
-            offset += 8;                                           \
-        }                                                          \
+            munit_assert_int(rv, ==, 0);                          \
+            offset += 8;                                          \
+        }                                                         \
     }
 
-#define ACQUIRE(INDEX)                                  \
-    {                                                   \
-        int rv2;                                        \
+#define ACQUIRE(INDEX)                                 \
+    {                                                  \
+        int rv2;                                       \
         rv2 = logAcquire(f->log, INDEX, &entries, &n); \
-        munit_assert_int(rv2, ==, 0);                   \
+        munit_assert_int(rv2, ==, 0);                  \
     }
 
 #define RELEASE(INDEX) logRelease(f->log, INDEX, entries, n);
@@ -129,7 +129,7 @@ static void tearDown(void *data)
 
 /* Assert the state of the fixture's log in terms of size, front/back indexes,
  * offset and number of entries. */
-#define ASSERT(SIZE, FRONT, BACK, OFFSET, N)     \
+#define ASSERT(SIZE, FRONT, BACK, OFFSET, N)      \
     munit_assert_int(f->log->size, ==, SIZE);     \
     munit_assert_int(f->log->front, ==, FRONT);   \
     munit_assert_int(f->log->back, ==, BACK);     \
@@ -137,7 +137,7 @@ static void tearDown(void *data)
     munit_assert_int(logNumEntries(f->log), ==, N)
 
 /* Assert the last index and term of the most recent snapshot. */
-#define ASSERT_SNAPSHOT(INDEX, TERM)                         \
+#define ASSERT_SNAPSHOT(INDEX, TERM)                          \
     munit_assert_int(f->log->snapshot.last_index, ==, INDEX); \
     munit_assert_int(f->log->snapshot.last_term, ==, TERM)
 
@@ -145,7 +145,7 @@ static void tearDown(void *data)
 #define ASSERT_TERM_OF(INDEX, TERM)              \
     {                                            \
         const struct raft_entry *entry;          \
-        entry = logGet(f->log, INDEX);          \
+        entry = logGet(f->log, INDEX);           \
         munit_assert_ptr_not_null(entry);        \
         munit_assert_int(entry->term, ==, TERM); \
     }
@@ -155,14 +155,14 @@ static void tearDown(void *data)
 #define ASSERT_REFCOUNT(INDEX, COUNT)                                 \
     {                                                                 \
         size_t i;                                                     \
-        munit_assert_ptr_not_null(f->log->refs);                       \
-        for (i = 0; i < f->log->refs_size; i++) {                      \
-            if (f->log->refs[i].index == INDEX) {                      \
-                munit_assert_int(f->log->refs[i].count, ==, COUNT);    \
+        munit_assert_ptr_not_null(f->log->refs);                      \
+        for (i = 0; i < f->log->refs_size; i++) {                     \
+            if (f->log->refs[i].index == INDEX) {                     \
+                munit_assert_int(f->log->refs[i].count, ==, COUNT);   \
                 break;                                                \
             }                                                         \
         }                                                             \
-        if (i == f->log->refs_size) {                                  \
+        if (i == f->log->refs_size) {                                 \
             munit_errorf("no refcount found for entry with index %d", \
                          (int)INDEX);                                 \
         }                                                             \

--- a/test/unit/test_queue.c
+++ b/test/unit/test_queue.c
@@ -218,7 +218,10 @@ TEST(QUEUE_FOREACH, zero, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     queue *head;
     int count = 0;
-    QUEUE_FOREACH(head, &f->queue) { count++; }
+    QUEUE_FOREACH(head, &f->queue)
+    {
+        count++;
+    }
     munit_assert_int(count, ==, 0);
     return MUNIT_OK;
 }
@@ -230,7 +233,10 @@ TEST(QUEUE_FOREACH, one, setUp, tearDown, 0, NULL)
     queue *head;
     int count = 0;
     PUSH(1);
-    QUEUE_FOREACH(head, &f->queue) { count++; }
+    QUEUE_FOREACH(head, &f->queue)
+    {
+        count++;
+    }
     munit_assert_int(count, ==, 1);
     return MUNIT_OK;
 }

--- a/test/unit/test_queue.c
+++ b/test/unit/test_queue.c
@@ -218,8 +218,7 @@ TEST(QUEUE_FOREACH, zero, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     queue *head;
     int count = 0;
-    QUEUE_FOREACH(head, &f->queue)
-    {
+    QUEUE_FOREACH (head, &f->queue) {
         count++;
     }
     munit_assert_int(count, ==, 0);
@@ -233,8 +232,7 @@ TEST(QUEUE_FOREACH, one, setUp, tearDown, 0, NULL)
     queue *head;
     int count = 0;
     PUSH(1);
-    QUEUE_FOREACH(head, &f->queue)
-    {
+    QUEUE_FOREACH (head, &f->queue) {
         count++;
     }
     munit_assert_int(count, ==, 1);
@@ -250,8 +248,7 @@ TEST(QUEUE_FOREACH, two, setUp, tearDown, 0, NULL)
     int values[2] = {0, 0};
     int i = 0;
     PUSH(2);
-    QUEUE_FOREACH(head, &f->queue)
-    {
+    QUEUE_FOREACH (head, &f->queue) {
         struct item *item;
         item = QUEUE_DATA(head, struct item, queue);
         values[i] = item->value;

--- a/test/unit/test_uv_fs.c
+++ b/test/unit/test_uv_fs.c
@@ -352,14 +352,14 @@ TEST(UvFsProbeCapabilities, noResources, DirBtrfsSetUp, DirTearDown, 0, NULL)
     if (rv != 0) {
         return MUNIT_SKIP;
     }
-    PROBE_CAPABILITIES_ERROR(dir, RAFT_IOERR,
-                             "probe Async I/O: io_setup: resource temporarily unavailable");
+    PROBE_CAPABILITIES_ERROR(
+        dir, RAFT_IOERR,
+        "probe Async I/O: io_setup: resource temporarily unavailable");
     AioDestroy(ctx);
     return MUNIT_OK;
 }
 
 #endif /* RWF_NOWAIT */
-
 
 /******************************************************************************
  *
@@ -375,7 +375,7 @@ TEST(UvFsMakeFile, notExists, DirSetUp, DirTearDown, 0, NULL)
     const char *dir = data;
     int rv;
     char errmsg[RAFT_ERRMSG_BUF_SIZE];
-    struct raft_buffer bufs[2] = {{0},{0}};
+    struct raft_buffer bufs[2] = {{0}, {0}};
     rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
     munit_assert_int(rv, ==, 0);
     return MUNIT_OK;
@@ -387,7 +387,7 @@ TEST(UvFsMakeFile, exists, DirSetUp, DirTearDown, 0, NULL)
     const char *dir = data;
     int rv;
     char errmsg[RAFT_ERRMSG_BUF_SIZE];
-    struct raft_buffer bufs[2] = {{0},{0}};
+    struct raft_buffer bufs[2] = {{0}, {0}};
     rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
     munit_assert_int(rv, ==, 0);
     rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
@@ -408,7 +408,7 @@ TEST(UvFsRenameFile, rename, DirSetUp, DirTearDown, 0, NULL)
     const char *dir = data;
     int rv;
     char errmsg[RAFT_ERRMSG_BUF_SIZE];
-    struct raft_buffer bufs[2] = {{0},{0}};
+    struct raft_buffer bufs[2] = {{0}, {0}};
     rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
     munit_assert_int(rv, ==, 0);
     rv = UvFsRenameFile(dir, "foo", "bar", errmsg);
@@ -424,7 +424,7 @@ TEST(UvFsRenameFile, same, DirSetUp, DirTearDown, 0, NULL)
     const char *dir = data;
     int rv;
     char errmsg[RAFT_ERRMSG_BUF_SIZE];
-    struct raft_buffer bufs[2] = {{0},{0}};
+    struct raft_buffer bufs[2] = {{0}, {0}};
     rv = UvFsMakeFile(dir, "foo", bufs, 2, errmsg);
     munit_assert_int(rv, ==, 0);
     rv = UvFsRenameFile(dir, "foo", "foo", errmsg);

--- a/test/unit/test_uv_os.c
+++ b/test/unit/test_uv_os.c
@@ -20,9 +20,9 @@ TEST(UvOsJoin, dirTooLong, NULL, NULL, 0, NULL)
 {
     int rv;
     char path[UV__PATH_SZ];
-    char dir[UV__DIR_LEN+2]; /* Room for '\0' and then 1 char over limit. */
-    memset((char*)dir, '/', sizeof(dir));
-    dir[sizeof(dir)-1] = '\0';
+    char dir[UV__DIR_LEN + 2]; /* Room for '\0' and then 1 char over limit. */
+    memset((char *)dir, '/', sizeof(dir));
+    dir[sizeof(dir) - 1] = '\0';
     const char *filename = "testfile";
 
     rv = UvOsJoin(dir, filename, path);
@@ -35,9 +35,9 @@ TEST(UvOsJoin, filenameTooLong, NULL, NULL, 0, NULL)
     int rv;
     char path[UV__PATH_SZ];
     const char *dir = "testdir";
-    char filename[UV__FILENAME_LEN+2];
-    memset((char*)filename, 'a', sizeof(filename));
-    filename[sizeof(filename)-1] = '\0';
+    char filename[UV__FILENAME_LEN + 2];
+    memset((char *)filename, 'a', sizeof(filename));
+    filename[sizeof(filename) - 1] = '\0';
 
     rv = UvOsJoin(dir, filename, path);
     munit_assert_int(rv, !=, 0);
@@ -48,13 +48,13 @@ TEST(UvOsJoin, dirAndFilenameTooLong, NULL, NULL, 0, NULL)
 {
     int rv;
     char path[UV__PATH_SZ];
-    char dir[UV__DIR_LEN+2];
-    memset((char*)dir, '/', sizeof(dir));
-    dir[sizeof(dir)-1] = '\0';
+    char dir[UV__DIR_LEN + 2];
+    memset((char *)dir, '/', sizeof(dir));
+    dir[sizeof(dir) - 1] = '\0';
 
-    char filename[UV__FILENAME_LEN+2];
-    memset((char*)filename, 'a', sizeof(filename));
-    filename[sizeof(filename)-1] = '\0';
+    char filename[UV__FILENAME_LEN + 2];
+    memset((char *)filename, 'a', sizeof(filename));
+    filename[sizeof(filename) - 1] = '\0';
 
     rv = UvOsJoin(dir, filename, path);
     munit_assert_int(rv, !=, 0);
@@ -65,18 +65,19 @@ TEST(UvOsJoin, dirAndFilenameMax, NULL, NULL, 0, NULL)
 {
     int rv;
     char path[UV__PATH_SZ];
-    char dir[UV__DIR_LEN+1];
-    memset((char*)dir, '/', sizeof(dir));
-    dir[sizeof(dir)-1] = '\0';
+    char dir[UV__DIR_LEN + 1];
+    memset((char *)dir, '/', sizeof(dir));
+    dir[sizeof(dir) - 1] = '\0';
 
-    char filename[UV__FILENAME_LEN+1];
-    memset((char*)filename, 'a', sizeof(filename));
-    filename[sizeof(filename)-1] = '\0';
+    char filename[UV__FILENAME_LEN + 1];
+    memset((char *)filename, 'a', sizeof(filename));
+    filename[sizeof(filename) - 1] = '\0';
 
     rv = UvOsJoin(dir, filename, path);
     munit_assert_int(rv, ==, 0);
     char cmp_path[UV__DIR_LEN + UV__FILENAME_LEN + 1 + 1];
-    snprintf(cmp_path, UV__DIR_LEN + UV__FILENAME_LEN + 1 + 1, "%s/%s", dir, filename);
+    snprintf(cmp_path, UV__DIR_LEN + UV__FILENAME_LEN + 1 + 1, "%s/%s", dir,
+             filename);
     munit_assert_string_equal(path, cmp_path);
     return MUNIT_OK;
 }

--- a/test/unit/test_uv_writer.c
+++ b/test/unit/test_uv_writer.c
@@ -1,7 +1,7 @@
 #include "../../src/uv_fs.h"
 #include "../../src/uv_writer.h"
-#include "../lib/dir.h"
 #include "../lib/aio.h"
+#include "../lib/dir.h"
 #include "../lib/loop.h"
 #include "../lib/runner.h"
 


### PR DESCRIPTION
All source files where formatted, except for munit.c and munit.h which are vendored and should not be touched.
