### PR TITLE
raft.h: Introduce raft_tracer_v2 for more flexible tracing

### DIFF
--- a/include/raft/uv.h
+++ b/include/raft/uv.h
@@ -124,6 +124,8 @@ RAFT_API void raft_uv_set_connect_retry_delay(struct raft_io *io, unsigned msecs
 
 /**
  * Emit low-level debug messages using the given tracer.
+ *
+ * The considerations around raft_tracer_v2 described in raft.h also apply here.
  */
 RAFT_API void raft_uv_set_tracer(struct raft_io *io,
                                  struct raft_tracer *tracer);


### PR DESCRIPTION
Here is a stab at introducing a more flexible tracing scheme for raft, that should hopefully support our plans to revamp and integrate tracing across raft and dqlite. It is backwards-compatible.

Signed-off-by: Cole Miller <cole.miller@canonical.com>