### PR TITLE
compress.c: Allow to not use LZ4 even if available

### DIFF
--- a/src/compress.c
+++ b/src/compress.c
@@ -19,7 +19,7 @@ int Compress(struct raft_buffer bufs[],
              struct raft_buffer *compressed,
              char *errmsg)
 {
-#ifndef LZ4_AVAILABLE
+#if !defined(LZ4_AVAILABLE) || !defined(LZ4_ENABLED)
     (void)bufs;
     (void)n_bufs;
     (void)compressed;
@@ -169,7 +169,7 @@ int Decompress(struct raft_buffer buf,
                struct raft_buffer *decompressed,
                char *errmsg)
 {
-#ifndef LZ4_AVAILABLE
+#if !defined(LZ4_AVAILABLE) || !defined(LZ4_ENABLED)
     (void)buf;
     (void)decompressed;
     ErrMsgPrintf(errmsg, "LZ4 not available");

--- a/test/unit/test_compress.c
+++ b/test/unit/test_compress.c
@@ -4,7 +4,7 @@
 #include "../lib/runner.h"
 
 #include <sys/random.h>
-#ifdef LZ4_AVAILABLE
+#if defined(LZ4_AVAILABLE) && defined(LZ4_ENABLED)
 #include <lz4frame.h>
 #endif
 
@@ -55,7 +55,7 @@ struct raft_buffer getBufWithNonRandom(size_t len)
     return buf;
 }
 
-#ifdef LZ4_AVAILABLE
+#if defined(LZ4_AVAILABLE) && defined(LZ4_ENABLED)
 
 static void sha1(struct raft_buffer bufs[], unsigned n_bufs, uint8_t value[20])
 {


### PR DESCRIPTION
Hello,

I encountered this issue yesterday : I would like to use the lib without linking to LZ4, even if it is present on my system.
Hopefully it doesn't change much.

As `LZ4_ENABLED` is on by default if `LZ4_AVAILABLE` is defined, it does not change the previous behavior.