### PR TITLE
Rename configuration_index to configuration_uncommitted_index

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -630,10 +630,10 @@ struct raft
      * If a server is voting, the log entry with index 1 must always contain the
      * first committed configuration.
      *
-     * At all times #configuration_index is either zero or is the index of the
-     * most recent log entry of type #RAFT_CHANGE that we know to be
-     * committed. That means #configuration_index is always equal or lower than
-     * #commit_index.
+     * At all times #configuration_committed_index is either zero or is the
+     * index of the most recent log entry of type #RAFT_CHANGE that we know to
+     * be committed. That means #configuration_committed_index is always equal
+     * or lower than #commit_index.
      *
      * At all times #configuration_uncommitted_index is either zero or is the
      * index of an uncommitted log entry of type #RAFT_CHANGE. There can be at
@@ -645,34 +645,36 @@ struct raft
      *
      * The possible scenarios are:
      *
-     * 1. #configuration_index and #configuration_uncommitted_index are both
-     *    zero. This should only happen when a brand new server starts joining a
-     *    cluster and is waiting to receive log entries from the current
-     *    leader. In this case #configuration and #configuration_last_snapshot
-     *    must be empty and have no servers.
+     * 1. #configuration_committed_index and #configuration_uncommitted_index
+     *    are both zero. This should only happen when a brand new server starts
+     *    joining a cluster and is waiting to receive log entries from the
+     *    current leader. In this case #configuration and
+     *    #configuration_last_snapshot must be empty and have no servers.
      *
-     * 2. #configuration_index is non-zero and #configuration_uncommitted_index
-     *    is zero. This means that #configuration is committed and there is no
-     *    pending configuration change. The content of #configuration must match
-     *    the one of the log entry at #configuration_index.
+     * 2. #configuration_committed_index is non-zero and
+     *    #configuration_uncommitted_index is zero. This means that
+     *    #configuration is committed and there is no pending configuration
+     *    change. The content of #configuration must match the one of the log
+     *    entry at #configuration_committed_index.
      *
-     * 3. #configuration_index and #configuration_uncommitted_index are both
-     *    non-zero, with the latter being greater than the former. This means
-     *    that #configuration is uncommitted and represents a pending
+     * 3. #configuration_committed_index and #configuration_uncommitted_index
+     *    are both non-zero, with the latter being greater than the former. This
+     *    means that #configuration is uncommitted and represents a pending
      *    configuration change. The content of #configuration must match the one
      *    of the log entry at #configuration_uncommitted_index.
      *
      * When a snapshot is taken, a copy of the most recent configuration known
      * to be committed (i.e. the configuration contained in the log entry at
-     * #configuration_index) is saved in #configuration_last_snapshot, so it can
-     * be easily retrieved in case the log gets truncated because of compaction
-     * and does not contain the entry at #configuration_index anymore. Likewise,
-     * if a snapshot is restored its associated configuration is saved in
+     * #configuration_committed_index) is saved in #configuration_last_snapshot,
+     * so it can be easily retrieved in case the log gets truncated because of
+     * compaction and does not contain the entry at
+     * #configuration_committed_index anymore. Likewise, if a snapshot is
+     * restored its associated configuration is saved in
      * #configuration_last_snapshot.
      */
     struct raft_configuration configuration;
     struct raft_configuration configuration_last_snapshot;
-    raft_index configuration_index;
+    raft_index configuration_committed_index;
     raft_index configuration_uncommitted_index;
 
     /*

--- a/src/membership.h
+++ b/src/membership.h
@@ -11,7 +11,8 @@
 int membershipCanChangeConfiguration(struct raft *r);
 
 /* Populate the given configuration object with the most recent committed
- * configuration, the one contained in the entry at r->configuration_index. */
+ * configuration, the one contained in the entry at
+ * r->configuration_committed_index. */
 int membershipFetchLastCommittedConfiguration(struct raft *r,
                                               struct raft_configuration *conf);
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -74,7 +74,7 @@ int raft_init(struct raft *r,
 
     raft_configuration_init(&r->configuration);
     raft_configuration_init(&r->configuration_last_snapshot);
-    r->configuration_index = 0;
+    r->configuration_committed_index = 0;
     r->configuration_uncommitted_index = 0;
     r->election_timeout = DEFAULT_ELECTION_TIMEOUT;
     r->heartbeat_timeout = DEFAULT_HEARTBEAT_TIMEOUT;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1416,7 +1416,7 @@ static void applyChange(struct raft *r, const raft_index index)
         r->configuration_uncommitted_index = 0;
     }
 
-    r->configuration_index = index;
+    r->configuration_committed_index = index;
     r->last_applied = index;
 
     if (r->state == RAFT_LEADER) {
@@ -1581,7 +1581,7 @@ static int takeSnapshot(struct raft *r)
     if (rv != 0) {
         goto abort;
     }
-    snapshot->configuration_index = r->configuration_index;
+    snapshot->configuration_index = r->configuration_committed_index;
 
     rv = r->fsm->snapshot(r->fsm, &snapshot->bufs, &snapshot->n_bufs);
     if (rv != 0) {

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -42,13 +42,13 @@ int snapshotRestore(struct raft *r, struct raft_snapshot *snapshot)
 
     configurationClose(&r->configuration);
     r->configuration = snapshot->configuration;
-    r->configuration_index = snapshot->configuration_index;
+    r->configuration_committed_index = snapshot->configuration_index;
     r->configuration_uncommitted_index = 0;
 
     /* Make a copy of the configuration contained in the snapshot, in case
      * r->configuration gets overriden with an uncommitted configuration and we
      * then need to rollback, but the log does not contain anymore the entry at
-     * r->configuration_index because it was truncated. */
+     * r->configuration_committed_index because it was truncated. */
     configurationClose(&r->configuration_last_snapshot);
     rv = configurationCopy(&r->configuration, &r->configuration_last_snapshot);
     if (rv != 0) {

--- a/src/start.c
+++ b/src/start.c
@@ -35,9 +35,9 @@ static int restoreMostRecentConfigurationEntry(struct raft *r,
      * we can't know if it's committed or not and treat it as uncommitted. */
     if (index == 1) {
         assert(r->configuration_uncommitted_index == 0);
-        r->configuration_index = 1;
+        r->configuration_committed_index = 1;
     } else {
-        assert(r->configuration_index < index);
+        assert(r->configuration_committed_index < index);
         r->configuration_uncommitted_index = index;
     }
 
@@ -83,13 +83,13 @@ static int restoreEntries(struct raft *r,
         /* Only take into account configurations that are newer than the
          * configuration restored from the snapshot. */
         if (entry->type == RAFT_CHANGE &&
-            r->last_stored > r->configuration_index) {
+            r->last_stored > r->configuration_committed_index) {
             /* If there is a previous configuration it must have been committed
              * as we don't allow multiple uncommitted configurations. At the end
-             * of the loop r->configuration_index will point to the second to
-             * last configuration entry, if any. */
+             * of the loop r->configuration_committed_index will point to the
+             * second to last configuration entry, if any. */
             if (conf_index != 0) {
-                r->configuration_index = conf_index;
+                r->configuration_committed_index = conf_index;
             }
             conf = entry;
             conf_index = r->last_stored;

--- a/test/integration/test_assign.c
+++ b/test/integration/test_assign.c
@@ -130,12 +130,12 @@ static void tearDown(void *data)
 
 /* Assert the values of the committed and uncommitted configuration indexes on
  * the raft instance with the given index. */
-#define ASSERT_CONFIGURATION_INDEXES(I, COMMITTED, UNCOMMITTED)      \
-    {                                                                \
-        struct raft *raft_ = CLUSTER_RAFT(I);                        \
-        munit_assert_int(raft_->configuration_index, ==, COMMITTED); \
-        munit_assert_int(raft_->configuration_uncommitted_index, ==, \
-                         UNCOMMITTED);                               \
+#define ASSERT_CONFIGURATION_INDEXES(I, COMMITTED, UNCOMMITTED)                \
+    {                                                                          \
+        struct raft *raft_ = CLUSTER_RAFT(I);                                  \
+        munit_assert_int(raft_->configuration_committed_index, ==, COMMITTED); \
+        munit_assert_int(raft_->configuration_uncommitted_index, ==,           \
+                         UNCOMMITTED);                                         \
     }
 
 /* Assert that the state of the current catch up round matches the given

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -101,12 +101,12 @@ struct result
 
 /* Assert the values of the committed and uncommitted configuration indexes on
  * the raft instance with the given index. */
-#define ASSERT_CONFIGURATION_INDEXES(I, COMMITTED, UNCOMMITTED)      \
-    {                                                                \
-        struct raft *raft_ = CLUSTER_RAFT(I);                        \
-        munit_assert_int(raft_->configuration_index, ==, COMMITTED); \
-        munit_assert_int(raft_->configuration_uncommitted_index, ==, \
-                         UNCOMMITTED);                               \
+#define ASSERT_CONFIGURATION_INDEXES(I, COMMITTED, UNCOMMITTED)                \
+    {                                                                          \
+        struct raft *raft_ = CLUSTER_RAFT(I);                                  \
+        munit_assert_int(raft_->configuration_committed_index, ==, COMMITTED); \
+        munit_assert_int(raft_->configuration_uncommitted_index, ==,           \
+                         UNCOMMITTED);                                         \
     }
 
 /******************************************************************************


### PR DESCRIPTION
This should make it more clear that the index refers to the last committed configuration, as opposed to any pending uncommitted configuration, which is tracked by `configuration_uncommitted_index`.

See also this comment https://github.com/canonical/raft/pull/409#issuecomment-1516644987.