### PR TITLE
Remove unnecessary include of sys/uio.h

### DIFF
--- a/src/uv_os.c
+++ b/src/uv_os.c
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <sys/eventfd.h>
 #include <sys/types.h>
-#include <sys/uio.h>
 #include <sys/vfs.h>
 #include <unistd.h>
 #include <uv.h>

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <string.h>
-#include <sys/uio.h>
 
 #include "array.h"
 #include "assert.h"


### PR DESCRIPTION
In files that don't use iovecs.

Signed-off-by: Cole Miller <cole.miller@canonical.com>