### PR TITLE
raft.h: Allow overriding RAFT_API

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -7,7 +7,9 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifndef RAFT_API
 #define RAFT_API __attribute__((visibility("default")))
+#endif
 
 /**
  * Version.


### PR DESCRIPTION
See also libuv:

https://github.com/libuv/libuv/blob/3f331e97da5b1cc2e24765dcb6d26c9dd313418f/include/uv.h#L34

Signed-off-by: Cole Miller <cole.miller@canonical.com>