### PR TITLE
Cleanup failure modes of configurationCopy and configurationAdd

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -99,15 +99,21 @@ int configurationCopy(const struct raft_configuration *src,
 {
     size_t i;
     int rv;
+
     configurationInit(dst);
     for (i = 0; i < src->n; i++) {
         struct raft_server *server = &src->servers[i];
         rv = configurationAdd(dst, server->id, server->address, server->role);
         if (rv != 0) {
-            return rv;
+            goto err;
         }
     }
+
     return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
 }
 
 int configurationAdd(struct raft_configuration *c,

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -112,6 +112,7 @@ int configurationCopy(const struct raft_configuration *src,
     return 0;
 
 err:
+    configurationClose(dst);
     assert(rv == RAFT_NOMEM);
     return rv;
 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -11,7 +11,26 @@ void configurationInit(struct raft_configuration *c);
 /* Release all memory used by the given configuration. */
 void configurationClose(struct raft_configuration *c);
 
-/* Add a server to the given configuration. */
+/* Add a server to the given configuration.
+ *
+ * The given @address is copied and no reference to it is kept. In case of
+ * error, @c is left unchanged.
+ *
+ * Errors:
+ *
+ * RAFT_DUPLICATEID
+ *     @c already has a server with the given id.
+ *
+ * RAFT_DUPLICATEADDRESS
+ *     @c already has a server with the given @address.
+ *
+ * RAFT_BADROLE
+ *     @role is not one of ROLE_STANDBY, ROLE_VOTER or ROLE_SPARE.
+ *
+ * RAFT_NOMEM
+ *     A copy of @address could not me made or the @c->servers could not
+ *     be extended
+ */
 int configurationAdd(struct raft_configuration *c,
                      raft_id id,
                      const char *address,

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -59,7 +59,20 @@ const struct raft_server *configurationGet(const struct raft_configuration *c,
  * an existing server in the configuration. */
 int configurationRemove(struct raft_configuration *c, raft_id id);
 
-/* Add all servers in c1 to c2 (which must be empty). */
+/* Deep copy @src to @dst.
+ *
+ * The configuration @src is assumed to be valid (i.e. each of its servers has a
+ * valid ID, address and role).
+ *
+ * The @dst configuration object must be uninitialized or empty.
+ *
+ * In case of error, both @src and @dst are left unchanged.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     Memory to copy all the servers could not be allocated.
+ */
 int configurationCopy(const struct raft_configuration *src,
                       struct raft_configuration *dst);
 

--- a/test/unit/test_configuration.c
+++ b/test/unit/test_configuration.c
@@ -331,6 +331,7 @@ TEST(configurationAdd, oom, setUp, tearDown, 0, add_oom_params)
     struct fixture *f = data;
     HeapFaultEnable(&f->heap);
     ADD_ERROR(RAFT_NOMEM, 1, "127.0.0.1:666", RAFT_VOTER);
+    munit_assert_null(f->configuration.servers);
     return MUNIT_OK;
 }
 

--- a/test/unit/test_configuration.c
+++ b/test/unit/test_configuration.c
@@ -248,14 +248,23 @@ TEST(configurationCopy, two, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
+static char *copy_oom_heap_fault_delay[] = {"0", "1", "2", NULL};
+static char *copy_oom_heap_fault_repeat[] = {"1", NULL};
+
+static MunitParameterEnum copy_oom_params[] = {
+    {TEST_HEAP_FAULT_DELAY, copy_oom_heap_fault_delay},
+    {TEST_HEAP_FAULT_REPEAT, copy_oom_heap_fault_repeat},
+    {NULL, NULL},
+};
+
 /* Out of memory */
-TEST(configurationCopy, oom, setUp, tearDown, 0, NULL)
+TEST(configurationCopy, oom, setUp, tearDown, 0, copy_oom_params)
 {
     struct fixture *f = data;
     struct raft_configuration configuration;
     ADD(1, "192.168.1.1:666", RAFT_STANDBY);
-    HeapFaultConfig(&f->heap, 0, 1);
-    HeapFaultEnable(&f->heap);
+    ADD(2, "192.168.1.2:666", RAFT_VOTER);
+    HEAP_FAULT_ENABLE;
     COPY_ERROR(RAFT_NOMEM, &configuration);
     return MUNIT_OK;
 }


### PR DESCRIPTION
This improves documentation of `configurationCopy` and `configurationAdd` and also fixes a couple of memory leaks that could happen in case of errors.

See the individual commit messages for more details. 