### PR TITLE
Clean-up configuration.h functions

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -311,9 +311,7 @@ int configurationDecode(const struct raft_buffer *buf,
     /* TODO: use 'if' instead of assert for checking buffer boundaries */
     assert(buf->len > 0);
 
-    /* Check that the target configuration is empty. */
-    assert(c->n == 0);
-    assert(c->servers == NULL);
+    configurationInit(c);
 
     cursor = buf->base;
 

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -281,6 +281,8 @@ void configurationEncodeToBuf(const struct raft_configuration *c, void *buf)
 int configurationEncode(const struct raft_configuration *c,
                         struct raft_buffer *buf)
 {
+    int rv;
+
     assert(c != NULL);
     assert(buf != NULL);
 
@@ -290,12 +292,17 @@ int configurationEncode(const struct raft_configuration *c,
     buf->len = configurationEncodedSize(c);
     buf->base = raft_malloc(buf->len);
     if (buf->base == NULL) {
-        return RAFT_NOMEM;
+        rv = RAFT_NOMEM;
+        goto err;
     }
 
     configurationEncodeToBuf(c, buf->base);
 
     return 0;
+
+err:
+    assert(rv == RAFT_NOMEM);
+    return rv;
 }
 
 int configurationDecode(const struct raft_buffer *buf,

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -348,6 +348,12 @@ int configurationDecode(const struct raft_buffer *buf,
 
         rv = configurationAdd(c, id, address, role);
         if (rv != 0) {
+            /* Only valid configurations should be ever be encoded, so in case
+             * configurationAdd() fails because of invalid data we return
+             * RAFT_MALFORMED. */
+            if (rv != RAFT_NOMEM) {
+                rv = RAFT_MALFORMED;
+            }
             goto err;
         }
     }
@@ -355,6 +361,7 @@ int configurationDecode(const struct raft_buffer *buf,
     return 0;
 
 err:
+    assert(rv == RAFT_MALFORMED || rv == RAFT_NOMEM);
     configurationClose(c);
     return rv;
 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -56,7 +56,18 @@ const struct raft_server *configurationGet(const struct raft_configuration *c,
                                            raft_id id);
 
 /* Remove a server from a raft configuration. The given ID must match the one of
- * an existing server in the configuration. */
+ * an existing server in the configuration.
+ *
+ * In case of error @c is left unchanged.
+ *
+ * Errors:
+ *
+ * RAFT_BADID
+ *     @c does not contain any server with the given @id
+ *
+ * RAFT_NOMEM
+ *     Memory to hold the new set of servers could not be allocated.
+ */
 int configurationRemove(struct raft_configuration *c, raft_id id);
 
 /* Deep copy @src to @dst.

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -85,7 +85,13 @@ void configurationEncodeToBuf(const struct raft_configuration *c, void *buf);
 
 /* Encode the given configuration object. The memory of the returned buffer is
  * allocated using raft_malloc(), and client code is responsible for releasing
- * it when no longer needed. */
+ * it when no longer needed.
+ *
+ * Errors:
+ *
+ * RAFT_NOMEM
+ *     Memory for the encoded buffer could not be allocated.
+ */
 int configurationEncode(const struct raft_configuration *c,
                         struct raft_buffer *buf);
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -91,7 +91,18 @@ int configurationEncode(const struct raft_configuration *c,
 
 /* Populate a configuration object by decoding the given serialized payload.
  *
- * The @c configuration object must be uninitialized or empty. */
+ * The @c configuration object must be uninitialized or empty.
+ *
+ * In case of error, @c will be left empty.
+ *
+ * Errors:
+ *
+ * RAFT_MALFORMED
+ *     The given buffer does not contain a valid encoded configuration.
+ *
+ * RAFT_NOMEM
+ *     Memory to populate the given configuration could not be allocated.
+ */
 int configurationDecode(const struct raft_buffer *buf,
                         struct raft_configuration *c);
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -89,7 +89,9 @@ void configurationEncodeToBuf(const struct raft_configuration *c, void *buf);
 int configurationEncode(const struct raft_configuration *c,
                         struct raft_buffer *buf);
 
-/* Populate a configuration object by decoding the given serialized payload. */
+/* Populate a configuration object by decoding the given serialized payload.
+ *
+ * The @c configuration object must be uninitialized or empty. */
 int configurationDecode(const struct raft_buffer *buf,
                         struct raft_configuration *c);
 

--- a/src/membership.c
+++ b/src/membership.c
@@ -68,7 +68,6 @@ int membershipFetchLastCommittedConfiguration(struct raft *r,
      * the content that the entry at r->configuration_committed_index had. */
     entry = logGet(r->log, r->configuration_committed_index);
     if (entry != NULL) {
-        configurationInit(conf);
         rv = configurationDecode(&entry->buf, conf);
     } else {
         assert(r->configuration_last_snapshot.n > 0);
@@ -151,8 +150,6 @@ int membershipUncommittedChange(struct raft *r,
     assert(r->state == RAFT_FOLLOWER);
     assert(entry != NULL);
     assert(entry->type == RAFT_CHANGE);
-
-    raft_configuration_init(&configuration);
 
     rv = configurationDecode(&entry->buf, &configuration);
     if (rv != 0) {

--- a/src/start.c
+++ b/src/start.c
@@ -20,7 +20,6 @@ static int restoreMostRecentConfigurationEntry(struct raft *r,
     struct raft_configuration configuration;
     int rv;
 
-    configurationInit(&configuration);
     rv = configurationDecode(&entry->buf, &configuration);
     if (rv != 0) {
         configurationClose(&configuration);

--- a/src/uv_encoding.c
+++ b/src/uv_encoding.c
@@ -456,7 +456,7 @@ static int decodeInstallSnapshot(const uv_buf_t *buf,
     args->conf_index = byteGet64(&cursor);
     conf.len = (size_t)byteGet64(&cursor);
     conf.base = (void *)cursor;
-    configurationInit(&args->conf);
+
     rv = configurationDecode(&conf, &args->conf);
     if (rv != 0) {
         return rv;

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -292,7 +292,6 @@ static int uvSnapshotLoadMeta(struct uv *uv,
         goto err_after_buf_malloc;
     }
 
-    configurationInit(&snapshot->configuration);
     rv = configurationDecode(&buf, &snapshot->configuration);
     if (rv != 0) {
         goto err_after_buf_malloc;

--- a/test/unit/test_configuration.c
+++ b/test/unit/test_configuration.c
@@ -616,3 +616,23 @@ TEST(configurationDecode, badAddress, setUp, tearDownNoClose, 0, NULL)
     DECODE_ERROR(RAFT_MALFORMED, &buf);
     return MUNIT_OK;
 }
+
+/* The encoded configuration is invalid because it has a duplicated server
+ * ID. In that case RAFT_MALFORMED is returned. */
+TEST(configurationDecode, duplicatedID, setUp, tearDownNoClose, 0, NULL)
+{
+    struct fixture *f = data;
+    uint8_t bytes[] = {1,                            /* Version */
+                       2,   0,   0,   0, 0, 0, 0, 0, /* Number of servers */
+                       5,   0,   0,   0, 0, 0, 0, 0, /* Server ID */
+                       'x', '.', 'y', 0,             /* Server address */
+                       1,                            /* Role code */
+                       5,   0,   0,   0, 0, 0, 0, 0, /* Server ID */
+                       'z', '.', 'w', 0,             /* Server address */
+                       0};                           /* Role code */
+    struct raft_buffer buf;
+    buf.base = bytes;
+    buf.len = sizeof bytes;
+    DECODE_ERROR(RAFT_MALFORMED, &buf);
+    return MUNIT_OK;
+}

--- a/test/unit/test_configuration.c
+++ b/test/unit/test_configuration.c
@@ -519,13 +519,11 @@ TEST(configurationDecode, one_server, setUp, tearDown, 0, NULL)
                        'x', '.', 'y', 0,             /* Server address */
                        1};                           /* Role code */
     struct raft_buffer buf;
-    int rv;
 
     buf.base = bytes;
     buf.len = sizeof bytes;
 
-    rv = configurationDecode(&buf, &f->configuration);
-    munit_assert_int(rv, ==, 0);
+    DECODE(&buf);
 
     ASSERT_N(1);
     ASSERT_SERVER(0, 5, "x.y", RAFT_VOTER);


### PR DESCRIPTION
This branch sports a few cleanups of the various functions in `src/configuration.{c,h}`. It's mainly about error reporting/propagation and memory leaks. Please review the individual commit messages and diffs for details.