### PR TITLE
raft_fixture_init(): set the n field to 0

### DIFF
--- a/src/fixture.c
+++ b/src/fixture.c
@@ -1040,6 +1040,7 @@ static void serverConnectToAll(struct raft_fixture *f, unsigned i)
 int raft_fixture_init(struct raft_fixture *f)
 {
     f->time = 0;
+    f->n = 0;
     f->log = logInit();
     if (f->log == NULL) {
         return RAFT_NOMEM;


### PR DESCRIPTION
This was done implicitely because we always use `munit_malloc()` to allocate the memory for a `struct raft_fixture` object, and `munit_malloc()` in turn uses `calloc()` which sets the allocated memory to 0.