### PR TITLE
Respond if term changed when installing snapshot

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1233,7 +1233,6 @@ struct recvInstallSnapshot
 {
     struct raft *raft;
     struct raft_snapshot snapshot;
-    raft_term term; /* Used to check for state transitions. */
 };
 
 static void installSnapshotCb(struct raft_io_snapshot_put *req, int status)
@@ -1242,7 +1241,6 @@ static void installSnapshotCb(struct raft_io_snapshot_put *req, int status)
     struct raft *r = request->raft;
     struct raft_snapshot *snapshot = &request->snapshot;
     struct raft_append_entries_result result;
-    bool should_respond = true;
     int rv;
 
     /* We avoid converting to candidate state while installing a snapshot. */
@@ -1258,18 +1256,7 @@ static void installSnapshotCb(struct raft_io_snapshot_put *req, int status)
     /* If we are shutting down, let's discard the result. */
     if (r->state == RAFT_UNAVAILABLE) {
         tracef("shutting down -> discard result of snapshot installation");
-        should_respond = false;
         goto discard;
-    }
-    /* If the request is from a previous term, it means that someone else became
-     * a candidate while we were installing the snapshot. In that case, we want
-     * to install the snapshot anyway, but our "current leader" may no longer be
-     * the same as the server that sent the install request, so we shouldn't
-     * send a response to that server. */
-    if (request->term != r->current_term) {
-        tracef(
-            "new term since receiving snapshot -> install but don't respond");
-        should_respond = false;
     }
 
     if (status != 0) {
@@ -1304,7 +1291,7 @@ discard:
     raft_configuration_close(&snapshot->configuration);
 
 respond:
-    if (should_respond) {
+    if (r->state == RAFT_FOLLOWER) {
         result.last_log_index = r->last_stored;
         sendAppendEntriesResult(r, &result);
     }
@@ -1364,7 +1351,6 @@ int replicationInstallSnapshot(struct raft *r,
         goto err;
     }
     request->raft = r;
-    request->term = r->current_term;
 
     snapshot = &request->snapshot;
     snapshot->term = args->last_term;


### PR DESCRIPTION
This change simplifies slightly the logic for handling completions of `raft_io->snapshot_put()` requests on followers. It stops tracking the term that was in place when the request started, and instead just looks at the current situation, since it's not only harmless to send and AppendEntries RPC result to a different leader, but it might actually be useful since a new leader might get to now about the follower's state faster.

I don't expect this PR alone to fix #355, but it's an isolated change that I believe makes sense on its own. If merged, we can wait a bit to see how Jepsen behaves (I'd expect no improvements but also no regressions).

Next step would be to do a similar change for the equivalent logic that we have after completing a `raft_io->append()` request. Then I'd like also to allow converting to candidate state while installing a snapshot, for consistency with what we do when appending entries and also because it's probably going to simplify logic and avoid unnecessary delays in elections. We can push these changes slowly to observe jepsen's reactions.