### PR TITLE
Fix callback for second barrier not being attached

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -208,6 +208,7 @@ test_integration_uv_SOURCES = \
   test/integration/test_uv_tcp_listen.c \
   test/integration/test_uv_snapshot_put.c \
   test/integration/test_uv_truncate.c \
+  test/integration/test_uv_truncate_snapshot.c \
   test/integration/test_uv_work.c
 test_integration_uv_CFLAGS = $(AM_CFLAGS) -Wno-type-limits -Wno-conversion
 test_integration_uv_LDFLAGS = -no-install

--- a/src/uv.h
+++ b/src/uv.h
@@ -360,6 +360,9 @@ int UvBarrier(struct uv *uv,
               struct UvBarrier *barrier,
               UvBarrierCb cb);
 
+/* Trigger all associated callbacks for this @barrier. */
+void UvBarrierTrigger(struct UvBarrier *barrier);
+
 /* Returns @true if there are no more segments referencing uv->barrier */
 bool UvBarrierReady(struct uv *uv);
 

--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -90,9 +90,9 @@ static void uvFinalizeAfterWorkCb(uv_work_t *work, int status)
      * barrier to unblock or if we are done closing. */
     if (QUEUE_IS_EMPTY(&uv->finalize_reqs)) {
         tracef("unblock barrier or close");
-        if (uv->barrier != NULL && UvBarrierReady(uv) &&
-            uv->barrier->cb != NULL) {
-            uv->barrier->cb(uv->barrier);
+        if (uv->barrier != NULL && UvBarrierReady(uv)) {
+            UvBarrierTrigger(uv->barrier);
+            /* TODO set barrier to NULL here? */
         }
         uvMaybeFireCloseCb(uv);
         return;

--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -75,7 +75,8 @@ static void uvFinalizeAfterWorkCb(uv_work_t *work, int status)
 {
     struct uvDyingSegment *segment = work->data;
     struct uv *uv = segment->uv;
-    tracef("uv finalize after work cb status:%d", status);
+    tracef("uv finalize after work segment %p cb status:%d", (void *)segment,
+           status);
     queue *head;
     int rv;
 
@@ -91,8 +92,7 @@ static void uvFinalizeAfterWorkCb(uv_work_t *work, int status)
     if (QUEUE_IS_EMPTY(&uv->finalize_reqs)) {
         tracef("unblock barrier or close");
         if (uv->barrier != NULL && UvBarrierReady(uv)) {
-            UvBarrierTrigger(uv->barrier);
-            /* TODO set barrier to NULL here? */
+            UvBarrierMaybeTrigger(uv->barrier);
         }
         uvMaybeFireCloseCb(uv);
         return;

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -613,7 +613,6 @@ static void uvSnapshotPutBarrierCb(struct UvBarrier *barrier)
     }
 
     struct uv *uv = put->uv;
-    assert((barrier->blocking && put->trailing == 0) || !barrier->blocking);
     put->barrier.data = NULL;
     /* If we're closing, abort the request. */
     if (uv->closing) {

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -393,7 +393,7 @@ struct uvSnapshotPut
     } meta;
     char errmsg[RAFT_ERRMSG_BUF_SIZE];
     int status;
-    struct UvBarrier barrier;
+    struct UvBarrierReq barrier;
 };
 
 struct uvSnapshotGet
@@ -603,7 +603,7 @@ static void uvSnapshotPutStart(struct uvSnapshotPut *put)
     }
 }
 
-static void uvSnapshotPutBarrierCb(struct UvBarrier *barrier)
+static void uvSnapshotPutBarrierCb(struct UvBarrierReq *barrier)
 {
     /* Ensure that we don't invoke this callback more than once. */
     barrier->cb = NULL;
@@ -658,6 +658,7 @@ int UvSnapshotPut(struct raft_io *io,
     put->trailing = trailing;
     put->barrier.data = put;
     put->barrier.blocking = trailing == 0;
+    put->barrier.cb = uvSnapshotPutBarrierCb;
 
     req->cb = cb;
 
@@ -691,7 +692,7 @@ int UvSnapshotPut(struct raft_io *io,
      * and we don't change append_next_index. */
     next_index =
         (trailing == 0) ? (snapshot->index + 1) : uv->append_next_index;
-    rv = UvBarrier(uv, next_index, &put->barrier, uvSnapshotPutBarrierCb);
+    rv = UvBarrier(uv, next_index, &put->barrier);
     if (rv != 0) {
         goto err_after_configuration_encode;
     }

--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -132,6 +132,7 @@ static void uvTruncateBarrierCb(struct UvBarrierReq *barrier)
     if (uv->closing) {
         tracef("closing => don't truncate");
         RaftHeapFree(truncate);
+        uvMaybeFireCloseCb(uv);
         return;
     }
 

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -615,7 +615,7 @@ struct barrierData
     struct uv *uv;
 };
 
-static void barrierCbCompareCounter(struct UvBarrier *barrier)
+static void barrierCbCompareCounter(struct UvBarrierReq *barrier)
 {
     struct barrierData *bd = barrier->data;
     munit_assert_false(bd->done);
@@ -632,6 +632,13 @@ static void barrierCbCompareCounter(struct UvBarrier *barrier)
     }
 }
 
+static void barrierDoneCb(struct UvBarrierReq *barrier)
+{
+    struct barrierData *bd = barrier->data;
+    munit_assert_false(bd->done);
+    bd->done = true;
+}
+
 static void appendCbIncreaseCounterAssertResult(struct raft_io_append *req,
                                                 int status)
 {
@@ -641,6 +648,12 @@ static void appendCbIncreaseCounterAssertResult(struct raft_io_append *req,
     struct barrierData *bd = result->data;
     munit_assert_true(bd->done == bd->expectDone);
     bd->current += 1;
+}
+
+static void appendDummyCb(struct raft_io_append *req, int status)
+{
+    (void)req;
+    (void)status;
 }
 
 static char *bools[] = {"0", "1", NULL};
@@ -674,17 +687,56 @@ TEST(append, barrierOpenSegments, setUp, tearDown, 0, blocking_bool_params)
     APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
                           appendCbIncreaseCounterAssertResult, &bd, 0);
 
-    struct UvBarrier barrier = {0};
+    struct UvBarrierReq barrier = {0};
     barrier.data = (void *)&bd;
     barrier.blocking =
         (bool)strtoul(munit_parameters_get(params, "bool"), NULL, 0);
-    UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
+    barrier.cb = barrierCbCompareCounter;
+    UvBarrier(f->io.impl, 1, &barrier);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd.done);
     APPEND_WAIT(0);
     APPEND_WAIT(1);
     APPEND_WAIT(2);
+    return MUNIT_OK;
+}
+
+/* Fill up 3 segments worth of AppendEntries RPC's.
+ * Request a Barrier and stop early.
+ */
+TEST(append, barrierOpenSegmentsExitEarly, setUp, NULL, 0, blocking_bool_params)
+{
+    struct fixture *f = data;
+    struct barrierData bd = {0};
+    bd.current = 0;
+    bd.expected = 3;
+    bd.done = false;
+    bd.expectDone = false;
+    bd.uv = f->io.impl;
+    char *files[] = {"0000000000000001-0000000000000004",
+                     "0000000000000005-0000000000000008",
+                     "0000000000000009-0000000000000012", NULL};
+    bd.files = files;
+
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendDummyCb, NULL, 0);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendDummyCb, NULL, 0);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendDummyCb, NULL, 0);
+
+    struct UvBarrierReq barrier = {0};
+    barrier.data = (void *)&bd;
+    barrier.blocking =
+        (bool)strtoul(munit_parameters_get(params, "bool"), NULL, 0);
+    barrier.cb = barrierDoneCb;
+    UvBarrier(f->io.impl, 1, &barrier);
+
+    /* Exit early. */
+    tearDown(data);
+    munit_assert_true(bd.done);
+
     return MUNIT_OK;
 }
 
@@ -715,16 +767,18 @@ TEST(append, twoBarriersOpenSegments, setUp, tearDown, 0, blocking_bool_params)
     APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
                           appendCbIncreaseCounterAssertResult, &bd1, 0);
 
-    struct UvBarrier barrier1 = {0};
+    struct UvBarrierReq barrier1 = {0};
     barrier1.data = (void *)&bd1;
     barrier1.blocking =
         (bool)strtoul(munit_parameters_get(params, "bool"), NULL, 0);
-    UvBarrier(f->io.impl, 1, &barrier1, barrierCbCompareCounter);
-    struct UvBarrier barrier2 = {0};
+    barrier1.cb = barrierCbCompareCounter;
+    UvBarrier(f->io.impl, 1, &barrier1);
+    struct UvBarrierReq barrier2 = {0};
     barrier2.data = (void *)&bd2;
     barrier2.blocking =
         (bool)strtoul(munit_parameters_get(params, "bool"), NULL, 0);
-    UvBarrier(f->io.impl, 1, &barrier2, barrierCbCompareCounter);
+    barrier2.cb = barrierCbCompareCounter;
+    UvBarrier(f->io.impl, 1, &barrier2);
 
     /* Make sure every callback fired */
     LOOP_RUN_UNTIL(&bd1.done);
@@ -732,6 +786,54 @@ TEST(append, twoBarriersOpenSegments, setUp, tearDown, 0, blocking_bool_params)
     APPEND_WAIT(0);
     APPEND_WAIT(1);
     APPEND_WAIT(2);
+    return MUNIT_OK;
+}
+
+/* Fill up 3 segments worth of AppendEntries RPC's.
+ * Request 2 barriers and exit early.
+ */
+TEST(append, twoBarriersExitEarly, setUp, NULL, 0, blocking_bool_params)
+{
+    struct fixture *f = data;
+    struct barrierData bd1 = {0};
+    bd1.current = 0;
+    bd1.expected = 3;
+    bd1.done = false;
+    bd1.expectDone = false;
+    bd1.uv = f->io.impl;
+    char *files[] = {"0000000000000001-0000000000000004",
+                     "0000000000000005-0000000000000008",
+                     "0000000000000009-0000000000000012", NULL};
+    bd1.files = files;
+    /* Only expect the callback to eventually fire. */
+    struct barrierData bd2 = {0};
+    bd2.uv = f->io.impl;
+
+    APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendDummyCb, NULL, 0);
+    APPEND_SUBMIT_CB_DATA(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendDummyCb, NULL, 0);
+    APPEND_SUBMIT_CB_DATA(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
+                          appendDummyCb, NULL, 0);
+
+    struct UvBarrierReq barrier1 = {0};
+    barrier1.data = (void *)&bd1;
+    barrier1.blocking =
+        (bool)strtoul(munit_parameters_get(params, "bool"), NULL, 0);
+    barrier1.cb = barrierDoneCb;
+    UvBarrier(f->io.impl, 1, &barrier1);
+    struct UvBarrierReq barrier2 = {0};
+    barrier2.data = (void *)&bd2;
+    barrier2.blocking =
+        (bool)strtoul(munit_parameters_get(params, "bool"), NULL, 0);
+    barrier2.cb = barrierDoneCb;
+    UvBarrier(f->io.impl, 1, &barrier2);
+
+    /* Exit early. */
+    tearDown(data);
+    munit_assert_true(bd1.done);
+    munit_assert_true(bd2.done);
+
     return MUNIT_OK;
 }
 
@@ -748,10 +850,11 @@ TEST(append, blockingBarrierNoOpenSegments, setUp, tearDown, 0, NULL)
     bd.expectDone = true;
     bd.uv = f->io.impl;
 
-    struct UvBarrier barrier = {0};
+    struct UvBarrierReq barrier = {0};
     barrier.data = (void *)&bd;
     barrier.blocking = true;
-    UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
+    barrier.cb = barrierCbCompareCounter;
+    UvBarrier(f->io.impl, 1, &barrier);
 
     APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
                           appendCbIncreaseCounterAssertResult, &bd, 0);
@@ -789,10 +892,11 @@ TEST(append, blockingBarrierSingleOpenSegment, setUp, tearDown, 0, NULL)
         LOOP_RUN(1);
     }
 
-    struct UvBarrier barrier = {0};
+    struct UvBarrierReq barrier = {0};
     barrier.data = (void *)&bd;
     barrier.blocking = true;
-    UvBarrier(f->io.impl, 1, &barrier, barrierCbCompareCounter);
+    barrier.cb = barrierCbCompareCounter;
+    UvBarrier(f->io.impl, 1, &barrier);
 
     APPEND_SUBMIT_CB_DATA(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE,
                           appendCbIncreaseCounterAssertResult, &bd, 0);
@@ -827,7 +931,7 @@ static void longAfterWorkCb(uv_work_t *work, int status)
     free(work);
 }
 
-static void barrierCbLongWork(struct UvBarrier *barrier)
+static void barrierCbLongWork(struct UvBarrierReq *barrier)
 {
     struct barrierData *bd = barrier->data;
     munit_assert_false(bd->done);
@@ -856,11 +960,11 @@ TEST(append, nonBlockingBarrierLongBlockingTask, setUp, tearDown, 0, NULL)
     bd.expectDone = false;
     bd.uv = f->io.impl;
 
-    struct UvBarrier barrier = {0};
+    struct UvBarrierReq barrier = {0};
     barrier.data = (void *)&bd;
     barrier.blocking = false;
-    UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier,
-              barrierCbLongWork);
+    barrier.cb = barrierCbLongWork;
+    UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier);
     APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd,
                           0);
 
@@ -884,11 +988,11 @@ TEST(append, blockingBarrierLongBlockingTask, setUp, tearDown, 0, NULL)
     bd.expectDone = true;
     bd.uv = f->io.impl;
 
-    struct UvBarrier barrier = {0};
+    struct UvBarrierReq barrier = {0};
     barrier.data = (void *)&bd;
     barrier.blocking = true;
-    UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier,
-              barrierCbLongWork);
+    barrier.cb = barrierCbLongWork;
+    UvBarrier(f->io.impl, bd.uv->append_next_index, &barrier);
     APPEND_SUBMIT_CB_DATA(0, 1, 64, appendCbIncreaseCounterAssertResult, &bd,
                           0);
 

--- a/test/integration/test_uv_truncate_snapshot.c
+++ b/test/integration/test_uv_truncate_snapshot.c
@@ -1,0 +1,247 @@
+#include "../lib/runner.h"
+#include "../lib/uv.h"
+
+/******************************************************************************
+ *
+ * Fixture
+ *
+ *****************************************************************************/
+
+struct fixture
+{
+    FIXTURE_UV_DEPS;
+    FIXTURE_UV;
+    int count; /* To generate deterministic entry data */
+};
+
+/******************************************************************************
+ *
+ * Helper macros
+ *
+ *****************************************************************************/
+
+/* Maximum number of blocks a segment can have */
+#define MAX_SEGMENT_BLOCKS 4
+
+/* This block size should work fine for all file systems. */
+#define SEGMENT_BLOCK_SIZE 4096
+
+/* Default segment size */
+#define SEGMENT_SIZE 4096 * MAX_SEGMENT_BLOCKS
+
+struct result
+{
+    int status;
+    bool done;
+    void *data;
+};
+
+static void appendCbAssertResult(struct raft_io_append *req, int status)
+{
+    struct result *result = req->data;
+    munit_assert_int(status, ==, result->status);
+    result->done = true;
+}
+
+static void snapshotPutCbAssertResult(struct raft_io_snapshot_put *req,
+                                      int status)
+{
+    struct result *result = req->data;
+    munit_assert_int(status, ==, result->status);
+    result->done = true;
+}
+
+/* Declare and fill the entries array for the append request identified by
+ * I. The array will have N entries, and each entry will have a data buffer of
+ * SIZE bytes.*/
+#define ENTRIES(I, N, SIZE)                                 \
+    struct raft_entry _entries##I[N];                       \
+    uint8_t _entries_data##I[N * SIZE];                     \
+    do {                                                    \
+        int _i;                                             \
+        for (_i = 0; _i < N; _i++) {                        \
+            struct raft_entry *entry = &_entries##I[_i];    \
+            entry->term = 1;                                \
+            entry->type = RAFT_COMMAND;                     \
+            entry->buf.base = &_entries_data##I[_i * SIZE]; \
+            entry->buf.len = SIZE;                          \
+            entry->batch = NULL;                            \
+            munit_assert_ptr_not_null(entry->buf.base);     \
+            memset(entry->buf.base, 0, entry->buf.len);     \
+            f->count++;                                     \
+            *(uint64_t *)entry->buf.base = f->count;        \
+        }                                                   \
+    } while (0)
+
+/* Submit an append request identified by I, with N_ENTRIES entries, each one of
+ * size ENTRY_SIZE). */
+#define APPEND_SUBMIT(I, N_ENTRIES, ENTRY_SIZE)                     \
+    struct raft_io_append _req##I;                                  \
+    struct result _result##I = {0, false, NULL};                    \
+    int _rv##I;                                                     \
+    ENTRIES(I, N_ENTRIES, ENTRY_SIZE);                              \
+    _req##I.data = &_result##I;                                     \
+    _rv##I = f->io.append(&f->io, &_req##I, _entries##I, N_ENTRIES, \
+                          appendCbAssertResult);                    \
+    munit_assert_int(_rv##I, ==, 0)
+
+#define TRUNCATE(N)                      \
+    do {                                 \
+        int rv_;                         \
+        rv_ = f->io.truncate(&f->io, N); \
+        munit_assert_int(rv_, ==, 0);    \
+    } while (0)
+
+/******************************************************************************
+ *
+ * Set up and tear down.
+ *
+ *****************************************************************************/
+
+static void *setUp(const MunitParameter params[], void *user_data)
+{
+    struct fixture *f = munit_malloc(sizeof *f);
+    SETUP_UV_DEPS;
+    SETUP_UV;
+    raft_uv_set_block_size(&f->io, SEGMENT_BLOCK_SIZE);
+    raft_uv_set_segment_size(&f->io, SEGMENT_SIZE);
+    f->count = 0;
+    return f;
+}
+
+static void tearDownDeps(void *data)
+{
+    struct fixture *f = data;
+    TEAR_DOWN_UV_DEPS;
+    free(f);
+}
+
+/******************************************************************************
+ *
+ * Assertions
+ *
+ *****************************************************************************/
+
+/* Shutdown the fixture's raft_io instance, then load all entries on disk using
+ * a new raft_io instance, and assert that there are N entries with data
+ * matching the DATA array. */
+#define ASSERT_ENTRIES(N, ...)                                            \
+    TEAR_DOWN_UV;                                                         \
+    do {                                                                  \
+        struct uv_loop_s _loop;                                           \
+        struct raft_uv_transport _transport;                              \
+        struct raft_io _io;                                               \
+        struct raft_tracer _tracer;                                       \
+        raft_term _term;                                                  \
+        raft_id _voted_for;                                               \
+        struct raft_snapshot *_snap;                                      \
+        raft_index _start_index;                                          \
+        struct raft_entry *_entries;                                      \
+        size_t _i;                                                        \
+        size_t _n;                                                        \
+        void *_batch = NULL;                                              \
+        unsigned _data[N] = {__VA_ARGS__};                                \
+        int _ret;                                                         \
+                                                                          \
+        _ret = uv_loop_init(&_loop);                                      \
+        munit_assert_int(_ret, ==, 0);                                    \
+        _transport.version = 1;                                           \
+        _ret = raft_uv_tcp_init(&_transport, &_loop);                     \
+        munit_assert_int(_ret, ==, 0);                                    \
+        _ret = raft_uv_init(&_io, &_loop, f->dir, &_transport);           \
+        munit_assert_int(_ret, ==, 0);                                    \
+        _tracer.emit = TracerEmit;                                        \
+        raft_uv_set_tracer(&_io, &_tracer);                               \
+        _ret = _io.init(&_io, 1, "1");                                    \
+        munit_assert_int(_ret, ==, 0);                                    \
+        _ret = _io.load(&_io, &_term, &_voted_for, &_snap, &_start_index, \
+                        &_entries, &_n);                                  \
+        munit_assert_int(_ret, ==, 0);                                    \
+        _io.close(&_io, NULL);                                            \
+        uv_run(&_loop, UV_RUN_NOWAIT);                                    \
+        raft_uv_close(&_io);                                              \
+        raft_uv_tcp_close(&_transport);                                   \
+        uv_loop_close(&_loop);                                            \
+                                                                          \
+        munit_assert_size(_n, ==, N);                                     \
+        for (_i = 0; _i < _n; _i++) {                                     \
+            struct raft_entry *_entry = &_entries[_i];                    \
+            uint64_t _value = *(uint64_t *)_entry->buf.base;              \
+            munit_assert_int(_entry->term, ==, 1);                        \
+            munit_assert_int(_entry->type, ==, RAFT_COMMAND);             \
+            munit_assert_int(_value, ==, _data[_i]);                      \
+            munit_assert_ptr_not_null(_entry->batch);                     \
+        }                                                                 \
+        for (_i = 0; _i < _n; _i++) {                                     \
+            struct raft_entry *_entry = &_entries[_i];                    \
+            if (_entry->batch != _batch) {                                \
+                _batch = _entry->batch;                                   \
+                raft_free(_batch);                                        \
+            }                                                             \
+        }                                                                 \
+        raft_free(_entries);                                              \
+        if (_snap != NULL) {                                              \
+            raft_configuration_close(&_snap->configuration);              \
+            munit_assert_int(_snap->n_bufs, ==, 1);                       \
+            raft_free(_snap->bufs[0].base);                               \
+            raft_free(_snap->bufs);                                       \
+            raft_free(_snap);                                             \
+        }                                                                 \
+    } while (0);
+
+#define SNAPSHOT_PUT_REQ(TRAILING, INDEX, RV, STATUS)              \
+    struct raft_snapshot _snapshot;                                \
+    struct raft_buffer _snapshot_buf;                              \
+    uint64_t _snapshot_data;                                       \
+    struct raft_io_snapshot_put _req;                              \
+    struct result _result = {STATUS, false, NULL};                 \
+    int _rv;                                                       \
+    _snapshot.term = 1;                                            \
+    _snapshot.index = INDEX;                                       \
+    raft_configuration_init(&_snapshot.configuration);             \
+    _rv = raft_configuration_add(&_snapshot.configuration, 1, "1", \
+                                 RAFT_STANDBY);                    \
+    munit_assert_int(_rv, ==, 0);                                  \
+    _snapshot.bufs = &_snapshot_buf;                               \
+    _snapshot.n_bufs = 1;                                          \
+    _snapshot_buf.base = &_snapshot_data;                          \
+    _snapshot_buf.len = sizeof _snapshot_data;                     \
+    _req.data = &_result;                                          \
+    _rv = f->io.snapshot_put(&f->io, TRAILING, &_req, &_snapshot,  \
+                             snapshotPutCbAssertResult);           \
+    munit_assert_int(_rv, ==, RV)
+
+#define SNAPSHOT_CLEANUP() raft_configuration_close(&_snapshot.configuration)
+
+/******************************************************************************
+ *
+ * test interaction of raft_io->snapshot_put and raft_io->truncate()
+ *
+ *****************************************************************************/
+
+SUITE(snapshot_truncate)
+
+/* Fill up 3 segments worth of data, then take a snapshot.
+ * While the snapshot is taken, start a truncate request. */
+TEST(snapshot_truncate, snapshotThenTruncate, setUp, tearDownDeps, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND_SUBMIT(0, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE);
+    APPEND_SUBMIT(1, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE);
+    APPEND_SUBMIT(2, MAX_SEGMENT_BLOCKS, SEGMENT_BLOCK_SIZE);
+
+    /* Take a snapshot, this will use a uv_barrier. */
+    SNAPSHOT_PUT_REQ(8192, 6, 0, 0);
+
+    /* Truncate, this will use a uv_barrier too.  */
+    TRUNCATE(8);
+
+    /* There's no truncate callback to wait for, loop for a while. */
+    LOOP_RUN(1000);
+
+    /* Check that truncate has done its job. */
+    ASSERT_ENTRIES(7, 1, 2, 3, 4, 5, 6, 7);
+
+    SNAPSHOT_CLEANUP();
+    return MUNIT_OK;
+}


### PR DESCRIPTION
Related to https://github.com/canonical/raft/issues/372 and possibly https://github.com/canonical/raft/issues/431

The test in this PR fails because when all active open segments are already involved in a barrier, the next barrier will fail to be attached to an open segment and the barrier callback will never fire. My first - hacky - idea, would be to push a new open segment and attach the barrier to that one. Any other inspiration?