### PR TITLE
test: Skip permission-related tests when running as root

### DIFF
--- a/test/integration/test_uv_load.c
+++ b/test/integration/test_uv_load.c
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include "../../src/byte.h"
 #include "../../src/uv.h"
 #include "../lib/runner.h"
@@ -1724,6 +1726,14 @@ TEST(load, closedSegmentWithBadFormat, setUp, tearDown, 0, NULL)
 TEST(load, openSegmentWithNoAccessPermission, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
+
+    /* Skip the test when running as root, since EACCES would not be triggered
+     * in that case. */
+    if (getuid() == 0) {
+        SETUP_UV; /* Setup the uv object since teardown expects it. */
+        return MUNIT_SKIP;
+    }
+
     APPEND(1, 1);
     UNFINALIZE(1, 1, 1);
     DirMakeFileUnreadable(f->dir, "open-1");

--- a/test/unit/test_uv_fs.c
+++ b/test/unit/test_uv_fs.c
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include "../../src/uv_fs.h"
 #include "../../src/uv_os.h"
 #include "../lib/aio.h"
@@ -312,6 +314,13 @@ TEST(UvFsProbeCapabilities, aio, DirSetUp, DirTearDown, 0, DirAioParams)
 TEST(UvFsProbeCapabilities, noAccess, DirSetUp, DirTearDown, 0, NULL)
 {
     const char *dir = data;
+
+    /* Skip the test when running as root, since EACCES would not be triggered
+     * in that case. */
+    if (getuid() == 0) {
+        return MUNIT_SKIP;
+    }
+
     DirMakeUnexecutable(dir);
     PROBE_CAPABILITIES_ERROR(
         dir, RAFT_IOERR,


### PR DESCRIPTION
The load/openSegmentWithNoAccessPermission and UvFsProbeCapabilitie/noAccess tests would fail when running as root, since EACCES wouldn't be returned.
