### PR TITLE
Add new configure.yml workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,23 +104,3 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         verbose: true
-
-  build-nolz4-fail:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Setup dependencies
-      run: |
-          sudo apt-get update -qq
-          # make sure liblz4 is not there
-          sudo apt-get remove liblz4-dev || true
-          sudo apt-get install -qq lcov linux-libc-dev libuv1-dev btrfs-progs xfsprogs zfsutils-linux
-          sudo ldconfig
-
-    # Expect the configure step to fail
-    - name: Build
-      env:
-        CC: gcc
-      run: |
-          autoreconf -i
-          ! ./configure --enable-example --enable-debug --enable-code-coverage --enable-sanitize

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -32,6 +32,12 @@ jobs:
       run: |
         sudo apt-get install -qq linux-libc-dev libuv1-dev
 
+    - name: Run ./configure
+      run: |
+        # Fail if no flags are passed, since libuv is installed but liblz4 is not.
+        ! ./configure 2>errors
+        tail -1 errors | grep -q "liblz4 required but not found" || (cat errors && false)
+
     - name: Install liblz4
       run: |
         sudo apt-get install -qq liblz4-dev

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -22,6 +22,12 @@ jobs:
       run: |
         autoreconf -i
 
+    - name: Run ./configure --enable-uv
+      run: |
+        # Fail if --enable-uv is passed, since libuv is not installed.
+        ! ./configure --enable-uv 2>errors
+        tail -1 errors | grep -q "libuv required but not found" || (cat errors && false)
+
     - name: Install libuv
       run: |
         sudo apt-get install -qq linux-libc-dev libuv1-dev

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,0 +1,31 @@
+# Check that the ./configure script behaves as expected in various scenarios
+name: Configure
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check that no optional dependency is installed
+      run: |
+        # Remove liblz4-dev which is installed by default on the runner
+        sudo apt-get remove liblz4-dev
+        # Check that there are no dependencies installed
+        ! pkg-config --exists libuv
+        ! pkg-config --exists liblz4
+
+    - name: Run autoreconf
+      run: |
+        autoreconf -i
+
+    - name: Install libuv
+      run: |
+        sudo apt-get install -qq linux-libc-dev libuv1-dev
+
+    - name: Install liblz4
+      run: |
+        sudo apt-get install -qq liblz4-dev


### PR DESCRIPTION
This set of commits adds a new `configure.yml` GitHub actions workflow which is meant to exercise the `./configure` script with various flags under various scenarios.

It's basically intended to become a more comprehensive version of the former `build-nolz4-fail` job in the `build-and-test.yml` workflow.

There are already a few new scenarios that are being tested that were not covered before, and if this gets merged I'd like to add more checks.

Having a separate workflow makes it a bit easier to spot the failure when something goes wrong.

This workflow runs on ubuntu 22.04, instead of 20.04 as the former `build-nolz4-fail` job.

Please see individual commits for more details.
