### PR TITLE
configure: Use only pkg-config to detect lz4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,38 +26,7 @@ AC_ARG_ENABLE(lz4, AS_HELP_STRING([--disable-lz4], [do not use lz4 compression])
 # Allow not linking to liblz4 even if it's present.
 AC_ARG_WITH([lz4], AS_HELP_STRING([--without-lz4], [never link to liblz4]))
 
-# Thanks to the OpenVPN configure.ac file for this part.
-# If this fails, we will do another test next.
-# We also add set LZ4_LIBS otherwise linker will not know about the lz4 library
-PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4="yes"], [LZ4_LIBS="-llz4"])
-if test "${have_lz4}" != "yes" ; then
-    AC_CHECK_HEADERS([lz4.h],
-                     [have_lz4h="yes"],
-                     [])
-    if test "${have_lz4h}" = "yes" ; then
-        AC_MSG_CHECKING([additionally if system LZ4 version >= 1.7.1])
-        AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM([[
-#include <lz4.h>
-                         ]],
-                         [[
-/* Version encoding: MMNNPP (Major miNor Patch) - see lz4.h for details */
-#if LZ4_VERSION_NUMBER < 10701L
-#error LZ4 is too old
-#endif
-                         ]]
-                        )],
-         [
-             AC_MSG_RESULT([ok])
-             have_lz4="yes"
-         ],
-         [
-             AC_MSG_RESULT([system LZ4 library is too old])
-             have_lz4="no"
-         ]
-        )
-    fi
-fi
+PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4="yes"], [have_lz4="no"])
 
 AS_IF([test "x$enable_lz4" != "xno" -a "x$have_lz4" != "xyes"],
       [AC_MSG_ERROR([liblz4 required but not found])], [])


### PR DESCRIPTION
The lz4 upstream project has had pkg-config support since about 9 years:

https://github.com/lz4/lz4/commit/dc107107f73942574a0b2d1d9c1edd05b0ff1796

which is included in the r120 release from July 2014.

(the first lz4 release which isn't labeled with the rNNN pattern is v1.7.3 from November 2016, see https://github.com/lz4/lz4/tags?after=v1.8.0).

The oldest lz4 release still in the Ubuntu archive is r131, from 2015, see:

http://archive.ubuntu.com/ubuntu/pool/main/l/lz4/?C=M;O=A

which was included in Ubuntu 16.04 and sports pkg-config support.

It's safe to assume than any real-world consumer will have an lz4 version with pkg-config support.