### PR TITLE
Skip lz4 check when unnecessary

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -22,22 +22,102 @@ jobs:
       run: |
         autoreconf -i
 
-    - name: Run ./configure --enable-uv
+    - name: With no deps ./configure
       run: |
-        # Fail if --enable-uv is passed, since libuv is not installed.
+        # Succeed, since we are not explicitly requiring libuv.
+        ./configure
+
+    - name: With no deps ./configure --enable-uv
+      run: |
+        # Fail, since libuv is not installed.
         ! ./configure --enable-uv 2>errors
         tail -1 errors | grep -q "libuv required but not found" || (cat errors && false)
+
+    - name: With no deps ./configure --with-lz4
+      run: |
+        # Fail, since using lz4 makes sense only if libuv is used too.
+        ! ./configure --with-lz4 2>errors
+        tail -1 errors | grep -q "liblz4 can be used only if libuv is used too" || (cat errors && false)
 
     - name: Install libuv
       run: |
         sudo apt-get install -qq linux-libc-dev libuv1-dev
 
-    - name: Run ./configure
+    - name: With libuv only ./configure
       run: |
-        # Fail if no flags are passed, since libuv is installed but liblz4 is not.
+        # Fail, since libuv is installed but liblz4 is not.
         ! ./configure 2>errors
+        tail -1 errors | grep -q "liblz4 required but not found" || (cat errors && false)
+
+    - name: With libuv only ./configure --with-lz4
+      run: |
+        # Fail, since liblz4 is not installed.
+        ! ./configure --with-lz4 2>errors
+        tail -1 errors | grep -q "liblz4 required but not found" || (cat errors && false)
+
+    - name: With libuv only ./configure --without-lz4
+      run: |
+        # Succeed, since we support building without lz4 even if libuv is found,
+        # as long --without-lz4 is passed.
+        ./configure --without-lz4
+
+    - name: With libuv only ./configure --disable-uv --with-lz4
+      run: |
+        # Fail, since using lz4 makes sense only if libuv is used too.
+        ! ./configure --disable-uv --with-lz4 2>errors
+        tail -1 errors | grep -q "liblz4 can be used only if libuv is used too" || (cat errors && false)
+
+    - name: With libuv only ./configure --enable-lz4
+      run: |
+        # Fail, since liblz4 is not installed.
+        ! ./configure --enable-lz4 2>errors
         tail -1 errors | grep -q "liblz4 required but not found" || (cat errors && false)
 
     - name: Install liblz4
       run: |
         sudo apt-get install -qq liblz4-dev
+
+    - name: With libuv and liblz4 ./configure
+      run: |
+        # Succeed, since all optional dependencies are found and used.
+        ./configure
+
+    - name: With libuv and liblz4 ./configure --without-lz4
+      run: |
+        # Succeed, since we support building without lz4 even if both libuv and
+        # liblz4 are found.
+        ./configure --without-lz4
+
+    - name: With libuv and liblz4 ./configure --without-lz4 --enable-lz4
+      run: |
+        # Fail, since enabling compression by default only makes sense if liblz4
+        # is used.
+        ! ./configure --without-lz4 --enable-lz4 2>errors
+        tail -1 errors | grep -q "snapshot compression (either by default or not) requires liblz4" || (cat errors && false)
+
+    - name: With libuv and liblz4 ./configure --without-lz4 --disable-lz4
+      run: |
+        # Fail, since disabling compression by default only makes sense if
+        # liblz4 is used.
+        ! ./configure --without-lz4 --disable-lz4 2>errors
+        tail -1 errors | grep -q "snapshot compression (either by default or not) requires liblz4" || (cat errors && false)
+
+    - name: With libuv and liblz4 ./configure --with-lz4 --enable-lz4
+      run: |
+        # Succeed, since liblz4 is found and used.
+        ./configure --with-lz4 --enable-lz4
+
+    - name: With libuv and liblz4 ./configure --with-lz4 --disable-lz4
+      run: |
+        # Succeed, since liblz4 is found and used.
+        ./configure --with-lz4 --disable-lz4
+
+    - name: With libuv and liblz4 ./configure --enable-lz4
+      run: |
+        # Succeed, since liblz4 is used by default if found.
+        ./configure --enable-lz4
+
+    - name: With libuv and liblz4 ./configure --disable-lz4
+      run: |
+        # Succeed, since liblz4 is used by default if found.
+        ./configure --disable-lz4

--- a/configure.ac
+++ b/configure.ac
@@ -42,8 +42,9 @@ AS_IF([test "x$have_uv" = "xyes"],
              [])
        have_lz4=no])
 
-AS_IF([test "x$enable_lz4" != "xno" -a "x$have_lz4" != "xyes"],
-      [AC_MSG_ERROR([liblz4 required but not found])], [])
+AS_IF([test "x$enable_lz4" != "x" -a "x$have_lz4" = "xno"],
+      [AC_MSG_ERROR([snapshot compression (either by default or not) requires liblz4])],
+      [])
 # LZ4 Can be available without being enabled, this allows a user to activate
 # it at a later stage through an API call.
 AM_CONDITIONAL(LZ4_AVAILABLE, test "x$have_lz4" = "xyes" -a "x$with_lz4" != "xno")

--- a/configure.ac
+++ b/configure.ac
@@ -24,9 +24,15 @@ AM_CONDITIONAL(UV_ENABLED, test "x$have_uv" = "xyes")
 AC_ARG_ENABLE(lz4, AS_HELP_STRING([--disable-lz4], [do not use lz4 compression]))
 
 # Allow not linking to liblz4 even if it's present.
+#
+# We try to detect if lz4 is installed only if the libuv raft_io implementation
+# is enabled, since that's the only place where we use lz4.
 AC_ARG_WITH([lz4], AS_HELP_STRING([--without-lz4], [never link to liblz4]))
-
-PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4="yes"], [have_lz4="no"])
+AS_IF([test "x$have_uv" = "xyes"],
+      [AS_IF([test "x$with_lz4" != "xno"],
+             [PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4=yes], [have_lz4=no])],
+             [have_lz4=no])],
+      [have_lz4=no])
 
 AS_IF([test "x$enable_lz4" != "xno" -a "x$have_lz4" != "xyes"],
       [AC_MSG_ERROR([liblz4 required but not found])], [])

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AM_CONDITIONAL(UV_ENABLED, test "x$have_uv" = "xyes")
 
 # The libuv raft_io implementation is built by default to compress snapshots if liblz4 is found, unless
 # explicitly disabled.
-AC_ARG_ENABLE(lz4, AS_HELP_STRING([--disable-lz4], [do not use lz4 compression]))
+AC_ARG_ENABLE(lz4, AS_HELP_STRING([--disable-lz4], [when building with lz4, do not compress snapshots by default]))
 
 # Allow not linking to liblz4 even if it's present.
 #

--- a/configure.ac
+++ b/configure.ac
@@ -29,10 +29,18 @@ AC_ARG_ENABLE(lz4, AS_HELP_STRING([--disable-lz4], [do not use lz4 compression])
 # is enabled, since that's the only place where we use lz4.
 AC_ARG_WITH([lz4], AS_HELP_STRING([--without-lz4], [never link to liblz4]))
 AS_IF([test "x$have_uv" = "xyes"],
+      # libuv is used
       [AS_IF([test "x$with_lz4" != "xno"],
              [PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4=yes], [have_lz4=no])],
-             [have_lz4=no])],
-      [have_lz4=no])
+             [have_lz4=no])
+       AS_IF([test "x$with_lz4" != "xno" -a "x$have_lz4" = "xno"],
+             [AC_MSG_ERROR([liblz4 required but not found])],
+             [])],
+      # libuv is not used
+      [AS_IF([test "x$with_lz4" = "xyes"],
+             [AC_MSG_ERROR([liblz4 can be used only if libuv is used too])],
+             [])
+       have_lz4=no])
 
 AS_IF([test "x$enable_lz4" != "xno" -a "x$have_lz4" != "xyes"],
       [AC_MSG_ERROR([liblz4 required but not found])], [])


### PR DESCRIPTION
This change improves `./configure` in a few ways:

- lz4 detection via pkg-config is performed only when it makes sense (i.e. when libuv is available and --without-lz4 is not passed)
- the documentation and checks for --enable-uv / --disable-uv are now more clear about the fact that these flags are about enabling or disabling compression by default, not about enabling or disabling compression support altogether (which is controlled by --with-lz4 / --without-lz4)
- several tests have been put in place to ensure that ./configure succeeds or fails as expected in a number of scenarios

The changes of individual commits should be a bit easier to parse than the full change set.

With these improvements combined, this fixes #441.