### PR TITLE
New segment format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ benchmark/os-disk-write
 tmp
 conftest*
 doc/build
+recovery/downgrade_segment_format

--- a/Makefile.am
+++ b/Makefile.am
@@ -254,6 +254,18 @@ benchmark_os_disk_write_LDFLAGS = -luring
 
 endif # BENCHMARK_ENABLED
 
+if RECOVERY_ENABLED
+
+bin_PROGRAMS += \
+ recovery/downgrade_segment_format
+
+recovery_downgrade_segment_format_SOURCES = \
+  recovery/downgrade_segment_format.c \
+  ${libraft_la_SOURCES}
+recovery_downgrade_segment_format_LDFLAGS = $(UV_LIBS)
+
+endif # RECOVERY_ENABLED
+
 if DEBUG_ENABLED
   AM_CFLAGS += -Werror -Wall
 else

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,10 @@ AM_CONDITIONAL(EXAMPLE_ENABLED, test "x$enable_example" = "xyes")
 AC_ARG_ENABLE(benchmark, AS_HELP_STRING([--enable-benchmark[=ARG]], [build the benchmark programs [default=no]]))
 AM_CONDITIONAL(BENCHMARK_ENABLED, test "x$enable_benchmark" = "xyes")
 
+# The recovery programs are optional.
+AC_ARG_ENABLE(recovery, AS_HELP_STRING([--enable-recovery[=ARG]], [build the recovery programs [default=no]]))
+AM_CONDITIONAL(RECOVERY_ENABLED, test "x$enable_recovery" = "xyes")
+
 # Whether to enable debugging code.
 AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug[=ARG]], [enable debugging [default=no]]))
 AM_CONDITIONAL(DEBUG_ENABLED, test "x$enable_debug" = "xyes")

--- a/recovery/downgrade_segment_format.c
+++ b/recovery/downgrade_segment_format.c
@@ -1,0 +1,30 @@
+#include <malloc.h>
+
+#include "raft.h"
+#include "../src/uv.h"
+
+int main(int argc, char *argv[])
+{
+    int rv;
+    char errmsg[RAFT_ERRMSG_BUF_SIZE] = {0};
+    struct uv *uv = malloc(sizeof(*uv));
+    if (argc != 2) {
+        fprintf(stderr, "expect a single 'dir' argument.\n");
+        return 2;
+    }
+    if (uv == NULL) {
+        fprintf(stderr, "MALLOC\n");
+        return 1;
+    }
+
+    strncpy(uv->dir, argv[1], UV__DIR_LEN-1);
+    uv->dir[UV__DIR_LEN-1] = '\0';
+
+    rv = UvSegmentConvertDirToFormat(uv, 1, errmsg);
+    if (rv != 0) {
+        fprintf(stderr, "downgrading segments failed: %s\n", errmsg);
+    } else {
+        printf("downgrading segments success\n");
+    }
+    return rv;
+}

--- a/src/uv.c
+++ b/src/uv.c
@@ -239,102 +239,6 @@ static void uvClose(struct raft_io *io, raft_io_close_cb cb)
     uvMaybeFireCloseCb(uv);
 }
 
-/* Filter the given segment list to find the most recent contiguous chunk of
- * closed segments that overlaps with the given snapshot last index. */
-static int uvFilterSegments(struct uv *uv,
-                            raft_index last_index,
-                            const char *snapshot_filename,
-                            struct uvSegmentInfo **segments,
-                            size_t *n)
-{
-    struct uvSegmentInfo *segment;
-    size_t i; /* First valid closed segment. */
-    size_t j; /* Last valid closed segment. */
-
-    /* If there are not segments at all, or only open segments, there's nothing
-     * to do. */
-    if (*segments == NULL || (*segments)[0].is_open) {
-        return 0;
-    }
-
-    /* Find the index of the most recent closed segment. */
-    for (j = 0; j < *n; j++) {
-        segment = &(*segments)[j];
-        if (segment->is_open) {
-            break;
-        }
-    }
-    assert(j > 0);
-    j--;
-
-    segment = &(*segments)[j];
-    tracef("most recent closed segment is %s", segment->filename);
-
-    /* If the end index of the last closed segment is lower than the last
-     * snapshot index, there might be no entry that we can keep. We return an
-     * empty segment list, unless there is at least one open segment, in that
-     * case we keep everything hoping that they contain all the entries since
-     * the last closed segment (TODO: we should encode the starting entry in the
-     * open segment). */
-    if (segment->end_index < last_index) {
-        if (!(*segments)[*n - 1].is_open) {
-            tracef(
-                "discarding all closed segments, since most recent is behind "
-                "last snapshot");
-            raft_free(*segments);
-            *segments = NULL;
-            *n = 0;
-            return 0;
-        }
-        tracef(
-            "most recent closed segment %s is behind last snapshot, "
-            "yet there are open segments",
-            segment->filename);
-    }
-
-    /* Now scan the segments backwards, searching for the longest list of
-     * contiguous closed segments. */
-    if (j >= 1) {
-        for (i = j; i > 0; i--) {
-            struct uvSegmentInfo *newer;
-            struct uvSegmentInfo *older;
-            newer = &(*segments)[i];
-            older = &(*segments)[i - 1];
-            if (older->end_index != newer->first_index - 1) {
-                tracef("discarding non contiguous segment %s", older->filename);
-                break;
-            }
-        }
-    } else {
-        i = j;
-    }
-
-    /* Make sure that the first index of the first valid closed segment is not
-     * greater than the snapshot's last index plus one (so there are no
-     * missing entries). */
-    segment = &(*segments)[i];
-    if (segment->first_index > last_index + 1) {
-        ErrMsgPrintf(uv->io->errmsg,
-                     "closed segment %s is past last snapshot %s",
-                     segment->filename, snapshot_filename);
-        return RAFT_CORRUPT;
-    }
-
-    if (i != 0) {
-        size_t new_n = *n - i;
-        struct uvSegmentInfo *new_segments;
-        new_segments = raft_malloc(new_n * sizeof *new_segments);
-        if (new_segments == NULL) {
-            return RAFT_NOMEM;
-        }
-        memcpy(new_segments, &(*segments)[i], new_n * sizeof *new_segments);
-        raft_free(*segments);
-        *segments = new_segments;
-        *n = new_n;
-    }
-
-    return 0;
-}
 
 /* Load the last snapshot (if any) and all entries contained in all segment
  * files of the data directory. This function can be called recursively, `depth`
@@ -346,8 +250,10 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
                                     size_t *n,
                                     int depth)
 {
+    char snapshot_filename[UV__FILENAME_LEN] = {0};
     struct uvSnapshotInfo *snapshots;
     struct uvSegmentInfo *segments;
+    raft_index snapshot_index = 0;
     size_t n_snapshots;
     size_t n_segments;
     int rv;
@@ -366,7 +272,6 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
 
     /* Load the most recent snapshot, if any. */
     if (snapshots != NULL) {
-        char snapshot_filename[UV__FILENAME_LEN];
         *snapshot = RaftHeapMalloc(sizeof **snapshot);
         if (*snapshot == NULL) {
             rv = RAFT_NOMEM;
@@ -380,57 +285,32 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
             goto err;
         }
         uvSnapshotFilenameOf(&snapshots[n_snapshots - 1], snapshot_filename);
-        tracef("most recent snapshot at %lld", (*snapshot)->index);
+        snapshot_index = (*snapshot)->index;
+        tracef("most recent snapshot at %lld", snapshot_index);
         RaftHeapFree(snapshots);
         snapshots = NULL;
-
-        /* Update the start index. If there are closed segments on disk let's
-         * make sure that the first index of the first closed segment is not
-         * greater than the snapshot's last index plus one (so there are no
-         * missing entries), and update the start index accordingly. */
-        rv = uvFilterSegments(uv, (*snapshot)->index, snapshot_filename,
-                              &segments, &n_segments);
-        if (rv != 0) {
-            goto err;
-        }
-        if (segments != NULL) {
-            if (segments[0].is_open) {
-                *start_index = (*snapshot)->index + 1;
-            } else {
-                *start_index = segments[0].first_index;
-            }
-        } else {
-            *start_index = (*snapshot)->index + 1;
-        }
     }
+
+    /* If there are closed segments on disk let's ensure that the first
+     * index of the first closed segment is not greater than the snapshot's
+     * last index plus one (so there are no missing entries). */
+    rv = uvSegmentFilter(uv, snapshot_index, snapshot_filename,
+                         &segments, &n_segments);
+    if (rv != 0) {
+        goto err;
+    }
+
+    *start_index = uvSegmentStartIndex(uv, segments, snapshot_index);
 
     /* Read data from segments, closing any open segments. */
-    if (segments != NULL) {
-        raft_index last_index;
-        rv = uvSegmentLoadAll(uv, *start_index, segments, n_segments, entries,
-                              n);
-        if (rv != 0) {
-            goto err;
-        }
-
-        /* Check if all entries that we loaded are actually behind the last
-         * snapshot. This can happen if the last closed segment was behind the
-         * last snapshot and there were open segments, but the entries in the
-         * open segments turned out to be behind the snapshot as well.  */
-        last_index = *start_index + *n - 1;
-        if (*snapshot != NULL && last_index < (*snapshot)->index) {
-            ErrMsgPrintf(uv->io->errmsg,
-                         "last entry on disk has index %llu, which is behind "
-                         "last snapshot's index %llu",
-                         last_index, (*snapshot)->index);
-            rv = RAFT_CORRUPT;
-            goto err;
-        }
-
-        raft_free(segments);
-        segments = NULL;
+    rv = uvSegmentLoadAll(uv, *start_index, snapshot_index,
+                          segments, n_segments, entries, n);
+    if (rv != 0) {
+        goto err;
     }
 
+    raft_free(segments);
+    segments = NULL;
     return 0;
 
 err:

--- a/src/uv.h
+++ b/src/uv.h
@@ -178,6 +178,12 @@ int uvSegmentLoadAll(struct uv *uv,
                      struct raft_entry **entries,
                      size_t *n_entries);
 
+/* Converts all segments in the uv dir to the specified format. Valid values for
+ * @format are 1 or the macros UV__DISK_FORMAT (1) and UV__SEGMENT_DISK_FORMAT_LEGACY (1).
+ * Returns 0 on success. */
+int UvSegmentConvertDirToFormat(struct uv *uv, int format,
+                                char errmsg[RAFT_ERRMSG_BUF_SIZE]);
+
 /* Return the number of blocks in a segments. */
 #define uvSegmentBlocks(UV) (UV->segment_size / UV->block_size)
 

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -165,7 +165,7 @@ static int uvAliveSegmentEncodeEntriesToWriteBuf(struct uvAliveSegment *segment,
     /* If this is the very first write to the segment, we need to include the
      * format version */
     if (segment->pending.n == 0 && segment->next_block == 0) {
-        rv = uvSegmentBufferFormat(&segment->pending);
+        rv = uvSegmentBufferFormat(&segment->pending, segment->first_index);
         if (rv != 0) {
             return rv;
         }

--- a/src/uv_encoding.h
+++ b/src/uv_encoding.h
@@ -10,6 +10,9 @@
 /* Current disk format version. */
 #define UV__DISK_FORMAT 1
 
+#define UV__SEGMENT_DISK_FORMAT_LEGACY UV__DISK_FORMAT
+#define UV__SEGMENT_DISK_FORMAT_2 2
+
 int uvEncodeMessage(const struct raft_message *message,
                     uv_buf_t **bufs,
                     unsigned *n_bufs);
@@ -56,4 +59,14 @@ void uvEncodeBatchHeader(const struct raft_entry *entries,
                          unsigned n,
                          void *buf);
 
+/* Validates the contents of the segment header in @buf of len @n.
+ * Returns 0 when the segment header is valid. When the segment is valid,
+ * @format contains the format version that can potentially be 0 and valid when
+ * the file contains all 0's. It's the caller's responsibility to do further
+ * validation. */
+int uvDecodeSegmentHeaderValidate(void *buf, size_t n, uint64_t *format, char errmsg[RAFT_ERRMSG_BUF_SIZE]);
+
+size_t uvSizeofSegmentHeader(uint64_t format);
+
+void uvEncodeSegmentHeaderFormat2(uint64_t first_index, void *buf);
 #endif /* UV_ENCODING_H_ */

--- a/src/uv_segment.c
+++ b/src/uv_segment.c
@@ -1350,6 +1350,7 @@ int UvSegmentConvertDirToFormat(struct uv *uv, int target_format,
     size_t n_snapshots;
     size_t n_segments;
     uint64_t format;
+    bool empty;
     struct raft_buffer buf = {0};
     uint8_t format_buf[8] = {1,0,0,0,0,0,0,0};
     struct raft_buffer fmt_buf = {format_buf, 8};
@@ -1380,6 +1381,15 @@ int UvSegmentConvertDirToFormat(struct uv *uv, int target_format,
     for (size_t i = 0; i < n_segments; i++) {
         struct uvSegmentInfo *info = &segments[i];
         printf("segment %s: start conversion ...\n", info->filename);
+        rv = UvFsFileIsEmpty(uv->dir, info->filename, &empty, errmsg);
+        if (rv != 0) {
+            ErrMsgPrintf(errmsg, "failed to read %s", info->filename);
+            goto out;
+        }
+        if (empty) {
+            printf("segment %s: empty\n", info->filename);
+            continue;
+        }
         rv = uvReadSegmentFile(uv, info->filename, &buf, &format);
         if (rv != 0) {
             ErrMsgPrintf(errmsg, "failed to read %s", info->filename);


### PR DESCRIPTION
This is work in progress I started a while ago to encode the start index in the segment header, leading to a new on-disk segment format.

The 24 byte header would look like: the crc is over the format and the first index header fields.

```
  _________________________________________
 |[0 - 7] |      [8-15] | [16-19] | [20-23]|
 |FORMAT  | FIRST_INDEX |     CRC |  UNUSED|
 |________|_____________|_________|________|

```

old 8 byte header
```
  ________
 |[0 - 7] | 
 |FORMAT  |
 |________|

```
It's quite a big change and would lead to the following consequences:

- Breaking change, newer raft versions would have a hard time rolling back to previous versions with the old disk format -> the idea was to include a recovery binary to convert modern segments to legacy segments.
- We can do direct calculations with the start index of open segments for example instead of trying to deduce the start index, this leads to simplified logic in a couple of places.
- We can remove the UvBarrier when taking a snapshot, that was introduced to close all open-segments when taking a snapshot, because in some cases the start index of the open segments was unclear, when they were all closed following the barrier, this problem didn't pose itself see #264 
- We can remove the concept of a `non-blocking barrier`, a barrier that still allows writes to new segments and simplify the code.
- get rid of [TODO](https://github.com/canonical/raft/blob/ba504976d685772a4784a9f65b759eb9f697929d/src/uv.c#L277)

The goal is not to review this PR, but start discussion if this is a worthwhile change to do. The barrier logic is already hard enough as it is, and the blocking / non-blocking stuff makes it harder, especially when multiple barriers can be interacting with each other. I'm thinking a "blocking" truncate barrier following an already active non-blocking barrier, then I think we should upgrade the non-blocking barrier to blocking because we don't want to append any new writes etc.... but this just becomes a huge mess that could be avoided if we got rid of that distinction altogether.

edit: I could also just remove the non-blocking barrier and only fire a barrier for the very first snapshot like free suggests here https://github.com/canonical/raft/pull/264#issuecomment-1036332414 and then live with the fact that writes will be blocked when that snapshot is being taken, but that doesn't sound like a huge problem. I mainly opened this PR and discussion to simplify the barrier logic because I need to touch it to solve #372  and the blocking / non-blocking distinction is complicating matters.