### PR TITLE
Remove blocking barrier

### DIFF
--- a/src/uv.c
+++ b/src/uv.c
@@ -364,6 +364,13 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
         goto err;
     }
 
+    /* Pristine server, see discussion in
+     * https://github.com/canonical/raft/pull/444#issuecomment-1608412517 */
+    if (!snapshots && !segments) {
+        uv->prepare_next_counter = 0;
+        return 0;
+    }
+
     /* Load the most recent snapshot, if any. */
     if (snapshots != NULL) {
         char snapshot_filename[UV__FILENAME_LEN];
@@ -395,7 +402,16 @@ static int uvLoadSnapshotAndEntries(struct uv *uv,
         }
         if (segments != NULL) {
             if (segments[0].is_open) {
-                *start_index = (*snapshot)->index + 1;
+                if (segments[0].counter == 0) {
+                    /* The snapshot is the result of normal operations and was taken
+                     * while the first open segment was not yet closed. */
+                    *start_index = 1;
+                } else {
+                    /* The snapshot is the result of a InstallSnapshotRPC that has
+                     * truncated the log. The open segments contains newer entries
+                     * than the snapshot. */
+                    *start_index = (*snapshot)->index + 1;
+                }
             } else {
                 *start_index = segments[0].first_index;
             }

--- a/src/uv.h
+++ b/src/uv.h
@@ -333,7 +333,6 @@ typedef void (*UvBarrierCb)(struct UvBarrier *req);
 struct UvBarrier
 {
     void *data;     /* User data */
-    bool blocking;  /* Whether this barrier should block future writes */
     UvBarrierCb cb; /* Completion callback */
 };
 

--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -331,13 +331,9 @@ start:
         return 0;
     }
 
-    /* If there's a blocking barrier in progress, and it's not waiting for this
-     * segment to be finalized, let's wait.
-     *
-     * FIXME shouldn't we wait even if segment->barrier == uv->barrier, if there
-     * are other open segments associated with the same barrier? */
-    if (uv->barrier != NULL && segment->barrier != uv->barrier &&
-        uv->barrier->blocking) {
+    /* If there's a barrier in progress, and it's not waiting for this
+     * segment to be finalized, let's wait. */
+    if (uv->barrier != NULL && segment->barrier != uv->barrier) {
         return 0;
     }
 
@@ -803,8 +799,7 @@ int UvBarrier(struct uv *uv,
 
 void UvUnblock(struct uv *uv)
 {
-    tracef("uv unblock");
-    tracef("clear uv barrier");
+    tracef("uv unblock - clear uv->barrier");
     uv->barrier = NULL;
     if (uv->closing) {
         uvMaybeFireCloseCb(uv);

--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -117,7 +117,6 @@ static int uvFinalizeStart(struct uvDyingSegment *segment)
     int rv;
 
     assert(uv->finalize_work.data == NULL);
-    assert(segment->counter > 0);
 
     uv->finalize_work.data = segment;
 

--- a/src/uv_prepare.c
+++ b/src/uv_prepare.c
@@ -265,7 +265,6 @@ static void uvPrepareDiscard(struct uv *uv, uv_file fd, uvCounter counter)
 {
     char errmsg[RAFT_ERRMSG_BUF_SIZE];
     char filename[UV__FILENAME_LEN];
-    assert(counter > 0);
     assert(fd >= 0);
     sprintf(filename, UV__OPEN_TEMPLATE, counter);
     UvOsClose(fd);

--- a/src/uv_snapshot.c
+++ b/src/uv_snapshot.c
@@ -579,6 +579,11 @@ static void uvSnapshotPutAfterWorkCb(uv_work_t *work, int status)
     assert(status == 0);
     uv->snapshot_put_work.data = NULL;
     uvSnapshotPutFinish(put);
+    /* The next entry in the first open segment will come after the snapshot
+     * entries. */
+    if (put->trailing == 0 && uv->prepare_next_counter == 0) {
+        uv->prepare_next_counter = 1;
+    }
     UvUnblock(uv);
 }
 

--- a/src/uv_truncate.c
+++ b/src/uv_truncate.c
@@ -175,7 +175,6 @@ int UvTruncate(struct raft_io *io, raft_index index)
     truncate->uv = uv;
     truncate->index = index;
     truncate->barrier.data = truncate;
-    truncate->barrier.blocking = true;
 
     /* Make sure that we wait for any inflight writes to finish and then close
      * the current segment. */


### PR DESCRIPTION
This is a draft PR that implements the approach to remove the (non)blocking barrier distinction discussed in #444 

I believe @cole-miller is not a huge fan of the approach. Alternatives would be:

- new segment format that encodes the index explicitly (more risky, think about downgrading raft versions, also need to be able to still handle old format segments)
- run a barrier on the first snapshot only, this carries a performance penalty as new writes will be blocked during the snapshot.
- ...