### PR TITLE
configure: Remove redundant with_lz4 checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,10 +47,10 @@ AS_IF([test "x$enable_lz4" != "x" -a "x$have_lz4" = "xno"],
       [])
 # LZ4 Can be available without being enabled, this allows a user to activate
 # it at a later stage through an API call.
-AM_CONDITIONAL(LZ4_AVAILABLE, test "x$have_lz4" = "xyes" -a "x$with_lz4" != "xno")
+AM_CONDITIONAL(LZ4_AVAILABLE, test "x$have_lz4" = "xyes")
 # `LZ4_ENABLED` will cause the libuv snapshot implementation to use lz4
 # compression by default.
-AM_CONDITIONAL(LZ4_ENABLED, test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xyes" -a "x$with_lz4" != "xno")
+AM_CONDITIONAL(LZ4_ENABLED, test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xyes")
 
 AC_ARG_ENABLE(backtrace, AS_HELP_STRING([--enable-backtrace[=ARG]], [print backtrace on assertion failure [default=no]]))
 AM_CONDITIONAL(BACKTRACE_ENABLED, test "x$enable_backtrace" = "xyes")


### PR DESCRIPTION
If `$have_lz4` is set to `"yes"`, then `$with_lz4` must be different than `"no"` and there's no need to explicitly check that.

That's because the only time that `$have_lz4` can be `"yes"` is when `$with_lz4` is different than `"no"`, due to this AS_IF:

```
AS_IF([test "x$have_uv" = "xyes"],
      # libuv is used
      [AS_IF([test "x$with_lz4" != "xno"],
             [PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4=yes], [have_lz4=no])],
             [have_lz4=no])
```

If `$with_lz4` is `"no"`, then `$have_lz4` is guaranteed to be `"no"` as well.

Note that the various `have_xxx` variables are basically the "result" of processing the associated `enable_xxx`/`with_xxx` variables (which map directly to command line arguments). So once a `have_xxx` has been set, there is generally no need to inspect again the associated command line flags.