### PR TITLE
Turn off auto-recovery-by-default during integration tests

### DIFF
--- a/test/integration/test_uv_load.c
+++ b/test/integration/test_uv_load.c
@@ -285,7 +285,6 @@ struct snapshot
     do {                                                          \
         LOAD_VARS;                                                \
         SETUP_UV;                                                 \
-        raft_uv_set_auto_recovery(&f->io, false);                 \
         _rv = f->io.load(&f->io, &_term, &_voted_for, &_snapshot, \
                          &_start_index, &_entries, &_n);          \
         munit_assert_int(_rv, ==, RV);                            \
@@ -344,17 +343,17 @@ struct snapshot
         _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)              \
     } while (0)
 
-/* Same as LOAD but with auto_recovery set to false */
-#define LOAD_NO_RECOVER(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, ENTRIES_DATA, \
-                        N_ENTRIES)                                            \
-    do {                                                                      \
-        LOAD_VARS;                                                            \
-        void *_batch = NULL;                                                  \
-        uint64_t _data = ENTRIES_DATA;                                        \
-        unsigned _i;                                                          \
-        SETUP_UV;                                                             \
-        raft_uv_set_auto_recovery(&f->io, false);                             \
-        _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)              \
+/* Same as LOAD but with auto recovery turned on. */
+#define LOAD_WITH_AUTO_RECOVERY(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, \
+                                ENTRIES_DATA, N_ENTRIES)                \
+    do {                                                                \
+        LOAD_VARS;                                                      \
+        void *_batch = NULL;                                            \
+        uint64_t _data = ENTRIES_DATA;                                  \
+        unsigned _i;                                                    \
+        SETUP_UV;                                                       \
+        raft_uv_set_auto_recovery(&f->io, true);                        \
+        _LOAD(TERM, VOTED_FOR, SNAPSHOT, START_INDEX, N_ENTRIES)        \
     } while (0)
 
 /* Same as LOAD without SETUP_UV */
@@ -653,9 +652,9 @@ TEST(load, secondOpenSegmentIsAllZeros, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-/* The data directory has two open segments, the first one has a corrupt header.
- */
-TEST(load, twoOpenSegmentsFirstCorrupt, setUp, tearDown, 0, NULL)
+/* The data directory has two open segments, the first one has a corrupt header
+ * and auto-recovery is on. */
+TEST(load, twoOpenSegmentsFirstCorruptAutoRecovery, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     APPEND(1, 1);
@@ -666,12 +665,12 @@ TEST(load, twoOpenSegmentsFirstCorrupt, setUp, tearDown, 0, NULL)
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
     /* Load is successful and equals pristine condition. */
-    LOAD(0,    /* term                           */
-         0,    /* voted for                      */
-         NULL, /* snapshot                       */
-         1,    /* start index                    */
-         0,    /* data for first loaded entry    */
-         0     /* n entries                      */
+    LOAD_WITH_AUTO_RECOVERY(0,    /* term                           */
+                            0,    /* voted for                      */
+                            NULL, /* snapshot                       */
+                            1,    /* start index                    */
+                            0,    /* data for first loaded entry    */
+                            0     /* n entries                      */
     );
 
     /* The open segments are renamed, and there is no closed segment. */
@@ -684,7 +683,7 @@ TEST(load, twoOpenSegmentsFirstCorrupt, setUp, tearDown, 0, NULL)
 
 /* The data directory has two open segments, the first one has a corrupt header.
  */
-TEST(load, twoOpenSegmentsFirstCorruptNoRecovery, setUp, tearDown, 0, NULL)
+TEST(load, twoOpenSegmentsFirstCorrupt, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     APPEND(1, 1);
@@ -694,8 +693,8 @@ TEST(load, twoOpenSegmentsFirstCorruptNoRecovery, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
 
     /* The open segments are renamed, and there is no closed segment. */
     munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
@@ -919,8 +918,23 @@ TEST(load, openSegmentWithEntriesPastSnapshot, setUp, tearDown, 0, NULL)
 
 /* The data directory has a closed segment whose filename encodes a number of
  * entries which is different then ones it actually contains. */
+TEST(load, closedSegmentWithInconsistentFilename, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    APPEND(3, 1);
+    DirRenameFile(f->dir, "0000000000000001-0000000000000003",
+                  "0000000000000001-0000000000000004");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load closed segment 0000000000000001-0000000000000004: found 3 "
+               "entries (expected 4)");
+    return MUNIT_OK;
+}
+
+/* The data directory has a closed segment whose filename encodes a number of
+ * entries which is different then ones it actually contains, and auto-recovery
+ * is turned on. */
 TEST(load,
-     closedSegmentWithInconsistentFilenameNoRecover,
+     closedSegmentWithInconsistentFilenameAutoRecovery,
      setUp,
      tearDown,
      0,
@@ -930,28 +944,13 @@ TEST(load,
     APPEND(3, 1);
     DirRenameFile(f->dir, "0000000000000001-0000000000000003",
                   "0000000000000001-0000000000000004");
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT,
-        "load closed segment 0000000000000001-0000000000000004: found 3 "
-        "entries (expected 4)");
-    return MUNIT_OK;
-}
-
-/* The data directory has a closed segment whose filename encodes a number of
- * entries which is different then ones it actually contains. */
-TEST(load, closedSegmentWithInconsistentFilename, setUp, tearDown, 0, NULL)
-{
-    struct fixture *f = data;
-    APPEND(3, 1);
-    DirRenameFile(f->dir, "0000000000000001-0000000000000003",
-                  "0000000000000001-0000000000000004");
     /* Load in pristine condition */
-    LOAD(0,    /* term */
-         0,    /* voted for */
-         NULL, /* snapshot */
-         1,    /* start index */
-         0,    /* data for first loaded entry */
-         0     /* n entries */
+    LOAD_WITH_AUTO_RECOVERY(0,    /* term */
+                            0,    /* voted for */
+                            NULL, /* snapshot */
+                            1,    /* start index */
+                            0,    /* data for first loaded entry */
+                            0     /* n entries */
     );
     return MUNIT_OK;
 }
@@ -960,30 +959,29 @@ TEST(load, closedSegmentWithInconsistentFilename, setUp, tearDown, 0, NULL)
  * needed, since they are included in a snapshot. It also has an open segment,
  * however that does not have enough entries to reach the snapshot last
  * index. */
-TEST(load,
-     openSegmentWithEntriesBehindSnapshotNoRecover,
-     setUp,
-     tearDown,
-     0,
-     NULL)
+TEST(load, openSegmentWithEntriesBehindSnapshot, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     APPEND(1, 1);
     APPEND(1, 2);
     SNAPSHOT_PUT(1, 3, 1);
     UNFINALIZE(2, 2, 1);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT,
-        "last entry on disk has index 2, which is behind last "
-        "snapshot's index 3");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "last entry on disk has index 2, which is behind last "
+               "snapshot's index 3");
     return MUNIT_OK;
 }
 
 /* The data directory has a closed segment with entries that are no longer
  * needed, since they are included in a snapshot. It also has an open segment,
  * however that does not have enough entries to reach the snapshot last
- * index. */
-TEST(load, openSegmentWithEntriesBehindSnapshot, setUp, tearDown, 0, NULL)
+ * index, and auto-receovery is turned on. */
+TEST(load,
+     openSegmentWithEntriesBehindSnapshotAutoRecovery,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
     struct snapshot snapshot = {
@@ -995,12 +993,12 @@ TEST(load, openSegmentWithEntriesBehindSnapshot, setUp, tearDown, 0, NULL)
     APPEND(1, 2);
     SNAPSHOT_PUT(1, 3, 1);
     UNFINALIZE(2, 2, 1);
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         &snapshot, /* snapshot */
-         4,         /* start index */
-         0,         /* data for first loaded entry */
-         0          /* n entries */
+    LOAD_WITH_AUTO_RECOVERY(0,         /* term */
+                            0,         /* voted for */
+                            &snapshot, /* snapshot */
+                            4,         /* start index */
+                            0,         /* data for first loaded entry */
+                            0          /* n entries */
     );
     return MUNIT_OK;
 }
@@ -1031,7 +1029,7 @@ TEST(load, openSegmentNoClosedSegmentsSnapshotPresent, setUp, tearDown, 0, NULL)
 /* The data directory contains a snapshot and an open segment with a corrupt
  * format header and no closed segments. */
 TEST(load,
-     corruptOpenSegmentNoClosedSegmentsSnapshotPresentNoRecover,
+     corruptOpenSegmentNoClosedSegmentsSnapshotPresent,
      setUp,
      tearDown,
      0,
@@ -1045,15 +1043,15 @@ TEST(load,
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
 /* The data directory contains a snapshot and an open segment with a corrupt
- * format header and no closed segments. */
+ * format header and no closed segments. Auto-recovery is turned on. */
 TEST(load,
-     corruptOpenSegmentNoClosedSegmentsSnapshotPresent,
+     corruptOpenSegmentNoClosedSegmentsSnapshotPresentWithAutoRecovery,
      setUp,
      tearDown,
      0,
@@ -1073,36 +1071,13 @@ TEST(load,
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
     /* Load is successful. */
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         &snapshot, /* snapshot */
-         4,         /* start index */
-         1,         /* data for first loaded entry */
-         1          /* n entries */
+    LOAD_WITH_AUTO_RECOVERY(0,         /* term */
+                            0,         /* voted for */
+                            &snapshot, /* snapshot */
+                            4,         /* start index */
+                            1,         /* data for first loaded entry */
+                            1          /* n entries */
     );
-    return MUNIT_OK;
-}
-
-/* The data directory contains a snapshot and an open segment with a corrupt
- * format header and a closed segment. */
-TEST(load,
-     corruptOpenSegmentClosedSegmentSnapshotPresentNoRecover,
-     setUp,
-     tearDown,
-     0,
-     NULL)
-{
-    struct fixture *f = data;
-    SNAPSHOT_PUT(1, 3, 1);
-    APPEND(1, 4);
-    APPEND(1, 5);
-    UNFINALIZE(5, 5, 1);
-
-    /* Corrupt open segment */
-    uint64_t version = 0 /* Format version */;
-    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
@@ -1116,6 +1091,29 @@ TEST(load,
      NULL)
 {
     struct fixture *f = data;
+    SNAPSHOT_PUT(1, 3, 1);
+    APPEND(1, 4);
+    APPEND(1, 5);
+    UNFINALIZE(5, 5, 1);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
+    return MUNIT_OK;
+}
+
+/* The data directory contains a snapshot and an open segment with a corrupt
+ * format header and a closed segment. Auto-recovery is turned on. */
+TEST(load,
+     corruptOpenSegmentClosedSegmentSnapshotPresentWithAutoRecovery,
+     setUp,
+     tearDown,
+     0,
+     NULL)
+{
+    struct fixture *f = data;
     struct snapshot snapshot = {
         1, /* term */
         3, /* index */
@@ -1131,15 +1129,52 @@ TEST(load,
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
 
     /* Load is successful. */
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         &snapshot, /* snapshot */
-         4,         /* start index */
-         4,         /* data for first loaded entry */
-         1          /* n entries */
+    LOAD_WITH_AUTO_RECOVERY(0,         /* term */
+                            0,         /* voted for */
+                            &snapshot, /* snapshot */
+                            4,         /* start index */
+                            4,         /* data for first loaded entry */
+                            1          /* n entries */
     );
 
     /* Open segment has been renamed */
+    munit_assert_false(DirHasFile(f->dir, "open-1"));
+    return MUNIT_OK;
+}
+
+/* The data directory contains a snapshot and an open segment with a corrupt
+ * format header and multiple closed segment. Auto-recovery is turned on. */
+TEST(load,
+     corruptOpenSegmentClosedSegmentsSnapshotPresentWithAutoRecovery,
+     setUp,
+     tearDown,
+     0,
+     NULL)
+{
+    struct fixture *f = data;
+    struct snapshot snapshot = {
+        1, /* term */
+        3, /* index */
+        1  /* data */
+    };
+    SNAPSHOT_PUT(1, 3, 1);
+    APPEND(1, 4);
+    APPEND(1, 5);
+    APPEND(1, 6);
+    UNFINALIZE(6, 6, 1);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+
+    LOAD_WITH_AUTO_RECOVERY(0,         /* term */
+                            0,         /* voted for */
+                            &snapshot, /* snapshot */
+                            4,         /* start index */
+                            4,         /* data for first loaded entry */
+                            2          /* n entries */
+    );
+    /* Open segment has been renamed during the first load */
     munit_assert_false(DirHasFile(f->dir, "open-1"));
     return MUNIT_OK;
 }
@@ -1154,11 +1189,6 @@ TEST(load,
      NULL)
 {
     struct fixture *f = data;
-    struct snapshot snapshot = {
-        1, /* term */
-        3, /* index */
-        1  /* data */
-    };
     SNAPSHOT_PUT(1, 3, 1);
     APPEND(1, 4);
     APPEND(1, 5);
@@ -1168,57 +1198,8 @@ TEST(load,
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         &snapshot, /* snapshot */
-         4,         /* start index */
-         4,         /* data for first loaded entry */
-         2          /* n entries */
-    );
-    /* Open segment has been renamed during the first load */
-    munit_assert_false(DirHasFile(f->dir, "open-1"));
-    return MUNIT_OK;
-}
-
-/* The data directory contains a snapshot and an open segment with a corrupt
- * format header and multiple closed segment. */
-TEST(load,
-     corruptOpenSegmentClosedSegmentsSnapshotPresentNoRecover,
-     setUp,
-     tearDown,
-     0,
-     NULL)
-{
-    struct fixture *f = data;
-    SNAPSHOT_PUT(1, 3, 1);
-    APPEND(1, 4);
-    APPEND(1, 5);
-    APPEND(1, 6);
-    UNFINALIZE(6, 6, 1);
-
-    /* Corrupt open segment */
-    uint64_t version = 0 /* Format version */;
-    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
-    return MUNIT_OK;
-}
-
-/* The data directory contains a closed segment and an open segment with a
- * corrupt format header and no snapshot. */
-TEST(load, corruptOpenSegmentClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
-{
-    struct fixture *f = data;
-    APPEND(4, 1);
-    APPEND(1, 5);
-    UNFINALIZE(5, 5, 1);
-
-    /* Corrupt open segment */
-    uint64_t version = 0 /* Format version */;
-    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
@@ -1234,36 +1215,38 @@ TEST(load, corruptOpenSegmentClosedSegments, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    /* load is successful. */
-    LOAD(0,    /* term */
-         0,    /* voted for */
-         NULL, /* snapshot */
-         1,    /* start index */
-         1,    /* data for first loaded entry */
-         4     /* n entries */
-    );
-    /* Open segment has been renamed */
-    munit_assert_false(DirHasFile(f->dir, "open-1"));
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
-/* The data directory contains a closed segment and two open segments.
- * The first open segment has a corrupt header. */
-TEST(load, corruptOpenSegmentsClosedSegmentsNoRecover, setUp, tearDown, 0, NULL)
+/* The data directory contains a closed segment and an open segment with a
+ * corrupt format header and no snapshot. Auto-recovery is turned on. */
+TEST(load,
+     corruptOpenSegmentClosedSegmentsWithAutoRecovery,
+     setUp,
+     tearDown,
+     0,
+     NULL)
 {
     struct fixture *f = data;
-    APPEND(3, 1);
-    APPEND(1, 4);
+    APPEND(4, 1);
     APPEND(1, 5);
-    UNFINALIZE(4, 4, 1);
-    UNFINALIZE(5, 5, 2);
+    UNFINALIZE(5, 5, 1);
 
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
-
+    /* load is successful. */
+    LOAD_WITH_AUTO_RECOVERY(0,    /* term */
+                            0,    /* voted for */
+                            NULL, /* snapshot */
+                            1,    /* start index */
+                            1,    /* data for first loaded entry */
+                            4     /* n entries */
+    );
+    /* Open segment has been renamed */
+    munit_assert_false(DirHasFile(f->dir, "open-1"));
     return MUNIT_OK;
 }
 
@@ -1281,25 +1264,16 @@ TEST(load, corruptOpenSegmentsClosedSegments, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
 
-    LOAD(0,    /* term */
-         0,    /* voted for */
-         NULL, /* snapshot */
-         1,    /* start index */
-         1,    /* data for first loaded entry */
-         3     /* n entries */
-    );
-
-    /* Open segments have been renamed */
-    munit_assert_false(DirHasFile(f->dir, "open-1"));
-    munit_assert_false(DirHasFile(f->dir, "open-2"));
     return MUNIT_OK;
 }
 
 /* The data directory contains a closed segment and two open segments.
- * The second open segment has a corrupt header. */
+ * The first open segment has a corrupt header. Auto-recovery is turned on. */
 TEST(load,
-     corruptLastOpenSegmentClosedSegmentsNoRecover,
+     corruptOpenSegmentsClosedSegmentsWithAutoRecovery,
      setUp,
      tearDown,
      0,
@@ -1314,10 +1288,19 @@ TEST(load,
 
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
-    DirOverwriteFile(f->dir, "open-2", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-2: unexpected format version 0");
+    DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
 
+    LOAD_WITH_AUTO_RECOVERY(0,    /* term */
+                            0,    /* voted for */
+                            NULL, /* snapshot */
+                            1,    /* start index */
+                            1,    /* data for first loaded entry */
+                            3     /* n entries */
+    );
+
+    /* Open segments have been renamed */
+    munit_assert_false(DirHasFile(f->dir, "open-1"));
+    munit_assert_false(DirHasFile(f->dir, "open-2"));
     return MUNIT_OK;
 }
 
@@ -1335,13 +1318,38 @@ TEST(load, corruptLastOpenSegmentClosedSegments, setUp, tearDown, 0, NULL)
     /* Corrupt open segment */
     uint64_t version = 0 /* Format version */;
     DirOverwriteFile(f->dir, "open-2", &version, sizeof version, 0);
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-2: unexpected format version 0");
 
-    LOAD(0,    /* term */
-         0,    /* voted for */
-         NULL, /* snapshot */
-         1,    /* start index */
-         1,    /* data for first loaded entry */
-         4     /* n entries */
+    return MUNIT_OK;
+}
+
+/* The data directory contains a closed segment and two open segments.
+ * The second open segment has a corrupt header. Auto-recovery is turned on. */
+TEST(load,
+     corruptLastOpenSegmentClosedSegmentsWithAutoRecovery,
+     setUp,
+     tearDown,
+     0,
+     NULL)
+{
+    struct fixture *f = data;
+    APPEND(3, 1);
+    APPEND(1, 4);
+    APPEND(1, 5);
+    UNFINALIZE(4, 4, 1);
+    UNFINALIZE(5, 5, 2);
+
+    /* Corrupt open segment */
+    uint64_t version = 0 /* Format version */;
+    DirOverwriteFile(f->dir, "open-2", &version, sizeof version, 0);
+
+    LOAD_WITH_AUTO_RECOVERY(0,    /* term */
+                            0,    /* voted for */
+                            NULL, /* snapshot */
+                            1,    /* start index */
+                            1,    /* data for first loaded entry */
+                            4     /* n entries */
     );
     /* Open segment has been renamed during the first load */
     munit_assert_false(DirHasFile(f->dir, "open-2"));
@@ -1375,7 +1383,7 @@ TEST(load, closedSegmentsOverlappingWithSnapshot, setUp, tearDown, 0, NULL)
 /* The data directory has several closed segments, the last of which is corrupt.
  * There is a snapshot. */
 TEST(load,
-     closedSegmentsWithSnapshotLastSegmentCorruptNoRecover,
+     closedSegmentsWithSnapshotLastSegmentCorrupt,
      setUp,
      tearDown,
      0,
@@ -1393,17 +1401,16 @@ TEST(load,
     uint32_t corrupted = 123456789;
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 9), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT,
-        "load closed segment 0000000000000008-0000000000000009: entries "
-        "batch 1 starting at byte 8: data checksum mismatch");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load closed segment 0000000000000008-0000000000000009: entries "
+               "batch 1 starting at byte 8: data checksum mismatch");
     return MUNIT_OK;
 }
 
 /* The data directory has several closed segments, the last of which is corrupt.
- * There is a snapshot. */
+ * There is a snapshot. Auto-recovery is turned on. */
 TEST(load,
-     closedSegmentsWithSnapshotLastSegmentCorrupt,
+     closedSegmentsWithSnapshotLastSegmentCorruptAutoRecovery,
      setUp,
      tearDown,
      0,
@@ -1426,13 +1433,54 @@ TEST(load,
     uint32_t corrupted = 123456789;
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 9), &corrupted,
                      sizeof corrupted, offset);
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         &snapshot, /* snapshot */
-         5,         /* start index */
-         5,         /* data for first loaded entry */
-         3          /* n entries */
+    LOAD_WITH_AUTO_RECOVERY(0,         /* term */
+                            0,         /* voted for */
+                            &snapshot, /* snapshot */
+                            5,         /* start index */
+                            5,         /* data for first loaded entry */
+                            3          /* n entries */
     );
+    return MUNIT_OK;
+}
+
+/* The data directory has several closed segments, the last of which is corrupt.
+ * There is an open segment and a snapshot. Auto-recovery is turned on. */
+TEST(load,
+     closedSegmentsWithSnapshotLastSegmentCorruptOpenSegmentWithAutoRecovery,
+     setUp,
+     tearDown,
+     0,
+     NULL)
+{
+    struct fixture *f = data;
+    struct snapshot snapshot = {
+        1, /* term */
+        4, /* index */
+        1  /* data */
+    };
+    SNAPSHOT_PUT(1, 4, 1);
+    APPEND(1, 5);
+    APPEND(2, 6);
+    APPEND(1, 8);
+    APPEND(1, 9);
+    UNFINALIZE(9, 9, 1);
+
+    /* Corrupt the last closed segment */
+    size_t offset =
+        WORD_SIZE /* Format version */ + WORD_SIZE / 2 /* Header checksum */;
+    uint32_t corrupted = 123456789;
+    DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 8), &corrupted,
+                     sizeof corrupted, offset);
+    munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
+
+    LOAD_WITH_AUTO_RECOVERY(0,         /* term */
+                            0,         /* voted for */
+                            &snapshot, /* snapshot */
+                            5,         /* start index */
+                            5,         /* data for first loaded entry */
+                            3          /* n entries */
+    );
+    munit_assert_false(HAS_OPEN_SEGMENT_FILE(1));
     return MUNIT_OK;
 }
 
@@ -1446,11 +1494,6 @@ TEST(load,
      NULL)
 {
     struct fixture *f = data;
-    struct snapshot snapshot = {
-        1, /* term */
-        4, /* index */
-        1  /* data */
-    };
     SNAPSHOT_PUT(1, 4, 1);
     APPEND(1, 5);
     APPEND(2, 6);
@@ -1465,46 +1508,9 @@ TEST(load,
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 8), &corrupted,
                      sizeof corrupted, offset);
     munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
-
-    LOAD(0,         /* term */
-         0,         /* voted for */
-         &snapshot, /* snapshot */
-         5,         /* start index */
-         5,         /* data for first loaded entry */
-         3          /* n entries */
-    );
-    munit_assert_false(HAS_OPEN_SEGMENT_FILE(1));
-    return MUNIT_OK;
-}
-
-/* The data directory has several closed segments, the last of which is corrupt.
- * There is an open segment and a snapshot. */
-TEST(load,
-     closedSegmentsWithSnapshotLastSegmentCorruptOpenSegmentNoRecover,
-     setUp,
-     tearDown,
-     0,
-     NULL)
-{
-    struct fixture *f = data;
-    SNAPSHOT_PUT(1, 4, 1);
-    APPEND(1, 5);
-    APPEND(2, 6);
-    APPEND(1, 8);
-    APPEND(1, 9);
-    UNFINALIZE(9, 9, 1);
-
-    /* Corrupt the last closed segment */
-    size_t offset =
-        WORD_SIZE /* Format version */ + WORD_SIZE / 2 /* Header checksum */;
-    uint32_t corrupted = 123456789;
-    DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(8, 8), &corrupted,
-                     sizeof corrupted, offset);
-    munit_assert_true(HAS_OPEN_SEGMENT_FILE(1));
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT,
-        "load closed segment 0000000000000008-0000000000000008: entries "
-        "batch 1 starting at byte 8: data checksum mismatch");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load closed segment 0000000000000008-0000000000000008: entries "
+               "batch 1 starting at byte 8: data checksum mismatch");
     return MUNIT_OK;
 }
 
@@ -1659,10 +1665,9 @@ TEST(load, closedSegmentWithCorruptedBatchHeader, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT,
-        "load closed segment 0000000000000001-0000000000000001: entries "
-        "batch 1 starting at byte 8: header checksum mismatch");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load closed segment 0000000000000001-0000000000000001: entries "
+               "batch 1 starting at byte 8: header checksum mismatch");
     return MUNIT_OK;
 }
 
@@ -1676,10 +1681,9 @@ TEST(load, closedSegmentWithCorruptedBatchData, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     DirOverwriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), &corrupted,
                      sizeof corrupted, offset);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT,
-        "load closed segment 0000000000000001-0000000000000001: entries "
-        "batch 1 starting at byte 8: data checksum mismatch");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load closed segment 0000000000000001-0000000000000001: entries "
+               "batch 1 starting at byte 8: data checksum mismatch");
     return MUNIT_OK;
 }
 
@@ -1691,10 +1695,9 @@ TEST(load, closedSegmentWithBadIndex, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     APPEND(1, 2);
     DirRemoveFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1));
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT,
-        "unexpected closed segment 0000000000000002-0000000000000002: "
-        "first index should have been 1");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "unexpected closed segment 0000000000000002-0000000000000002: "
+               "first index should have been 1");
     return MUNIT_OK;
 }
 
@@ -1703,7 +1706,7 @@ TEST(load, emptyClosedSegment, setUp, tearDown, 0, NULL)
 {
     struct fixture *f = data;
     DirWriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), NULL, 0);
-    LOAD_ERROR_NO_RECOVER(
+    LOAD_ERROR(
         RAFT_CORRUPT,
         "load closed segment 0000000000000001-0000000000000001: file is empty");
     return MUNIT_OK;
@@ -1715,10 +1718,9 @@ TEST(load, closedSegmentWithBadFormat, setUp, tearDown, 0, NULL)
     struct fixture *f = data;
     uint8_t buf[8] = {2, 0, 0, 0, 0, 0, 0, 0};
     DirWriteFile(f->dir, CLOSED_SEGMENT_FILENAME(1, 1), buf, sizeof buf);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT,
-        "load closed segment 0000000000000001-0000000000000001: "
-        "unexpected format version 2");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load closed segment 0000000000000001-0000000000000001: "
+               "unexpected format version 2");
     return MUNIT_OK;
 }
 
@@ -1751,8 +1753,8 @@ TEST(load, openSegmentWithZeroFormatAndThenData, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     UNFINALIZE(1, 1, 1);
     DirOverwriteFile(f->dir, "open-1", &version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-1: unexpected format version 0");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 0");
     return MUNIT_OK;
 }
 
@@ -1764,7 +1766,7 @@ TEST(load, openSegmentWithBadFormat, setUp, tearDown, 0, NULL)
     APPEND(1, 1);
     UNFINALIZE(1, 1, 1);
     DirOverwriteFile(f->dir, "open-1", version, sizeof version, 0);
-    LOAD_ERROR_NO_RECOVER(
-        RAFT_CORRUPT, "load open segment open-1: unexpected format version 2");
+    LOAD_ERROR(RAFT_CORRUPT,
+               "load open segment open-1: unexpected format version 2");
     return MUNIT_OK;
 }

--- a/test/lib/uv.h
+++ b/test/lib/uv.h
@@ -47,6 +47,7 @@
         rv_ = raft_uv_init(&f->io, &f->loop, f->dir, &f->transport); \
         munit_assert_int(rv_, ==, 0);                                \
         raft_uv_set_tracer(&f->io, &f->tracer);                      \
+        raft_uv_set_auto_recovery(&f->io, false);                    \
         rv_ = f->io.init(&f->io, 1, "127.0.0.1:9001");               \
         munit_assert_int(rv_, ==, 0);                                \
     } while (0)


### PR DESCRIPTION
This commit only changes the test suite.

It turns off the auto-recovery behavior of automatically re-trying to load the data directory in case `RAFT_CORRUPT` is hit by `raft_io->load()`.

Instead, tests now have to explicitly turn on auto-recovery if they want to enable that behavior.

This reduces the risk of inadvertently masking bugs, for example by having tests that only pass because auto-recovery is on, but would otherwise fail.

Note that auto-recovery is a best-effort and last-resort measure to prevent startup failures possibly caused by raft bugs that have left a broken state at shutdown. However it's something that we don't expect to happen, and this features comes at the cost of possible data loss. We should then normally turn it off in our tests, in order to catch bugs, and only turn it on in some tests in order to exercise the auto-recovery feature itself.