### PR TITLE
uv_append: Initialize barrier upon creation.

### DIFF
--- a/src/uv_append.c
+++ b/src/uv_append.c
@@ -790,13 +790,14 @@ static void uvBarrierTriggerAll(struct UvBarrier *barrier)
     }
 }
 
-struct UvBarrier *uvBarrierAlloc(void)
+static struct UvBarrier *uvBarrierCreate(void)
 {
     struct UvBarrier *barrier;
-    barrier = RaftHeapMalloc(sizeof(*barrier));
+    barrier = RaftHeapCalloc(1, sizeof(*barrier));
     if (!barrier) {
         return NULL;
     }
+    barrier->blocking = false;
     QUEUE_INIT(&barrier->reqs);
     return barrier;
 }
@@ -829,7 +830,7 @@ int UvBarrier(struct uv *uv, raft_index next_index, struct UvBarrierReq *req)
         }
 
         if (!barrier) {
-            barrier = uvBarrierAlloc();
+            barrier = uvBarrierCreate();
             if (!barrier) {
                 return RAFT_NOMEM;
             }
@@ -856,7 +857,7 @@ int UvBarrier(struct uv *uv, raft_index next_index, struct UvBarrierReq *req)
             barrier = uv->barrier;
             /* There is no uv->barrier, make new one. */
         } else {
-            barrier = uvBarrierAlloc();
+            barrier = uvBarrierCreate();
             if (!barrier) {
                 return RAFT_NOMEM;
             }


### PR DESCRIPTION
Fixes #461.

`barrier->blocking` was not initialized, resulting in `barrier->blocking` being `true` in most of the cases, causing the effect seen in the issue.

The tests didn't catch the bug as the barriers are properly initialized in the tests.

edit: not going to spend time on test for now.
~~Will still add a test that uses a slow `UvSnapshot` call and ensures append requests get through.~~