### PR TITLE
Don't convert to candidate while entries are being persisted

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -749,7 +749,8 @@ struct raft
                 raft_id id;
                 char *address;
             } current_leader;
-            uint64_t reserved[8]; /* Future use */
+            uint64_t append_in_flight_count;
+            uint64_t reserved[7]; /* Future use */
         } follower_state;
         struct
         {

--- a/src/replication.c
+++ b/src/replication.c
@@ -851,22 +851,19 @@ static void appendFollowerCb(struct raft_io_append *req, int status)
     assert(args->entries != NULL);
     assert(args->n_entries > 0);
 
+    assert(r->state == RAFT_FOLLOWER || r->state == RAFT_UNAVAILABLE);
+    if (r->state == RAFT_UNAVAILABLE) {
+        goto out;
+    }
+    assert(r->follower_state.append_in_flight_count > 0);
+    r->follower_state.append_in_flight_count -= 1;
+
     result.term = r->current_term;
     result.version = RAFT_APPEND_ENTRIES_RESULT_VERSION;
     result.features = RAFT_DEFAULT_FEATURE_FLAGS;
     if (status != 0) {
-        if (r->state != RAFT_FOLLOWER) {
-            tracef("local server is not follower -> ignore I/O failure");
-            goto out;
-        }
         result.rejected = args->prev_log_index + 1;
         goto respond;
-    }
-
-    /* If we're shutting down or have errored, ignore the result. */
-    if (r->state == RAFT_UNAVAILABLE) {
-        tracef("local server is unavailable -> ignore I/O result");
-        goto out;
     }
 
     /* We received an InstallSnapshot RPC while these entries were being
@@ -880,7 +877,7 @@ static void appendFollowerCb(struct raft_io_append *req, int status)
     /* If none of the entries that we persisted is present anymore in our
      * in-memory log, there's nothing to report or to do. We just discard
      * them. */
-    if (i == 0 || r->state != RAFT_FOLLOWER) {
+    if (i == 0) {
         goto out;
     }
 
@@ -915,10 +912,10 @@ static void appendFollowerCb(struct raft_io_append *req, int status)
         }
     }
 
-    /* If our state or term number has changed since receiving these entries,
+    /* If our term number has changed since receiving these entries,
      * our current_leader may have changed as well, so don't send a response
      * to that server. */
-    if (r->state != RAFT_FOLLOWER || r->current_term != args->term) {
+    if (r->current_term != args->term) {
         tracef("new role or term since receiving entries -> don't respond");
         goto out;
     }
@@ -1176,6 +1173,7 @@ int replicationAppend(struct raft *r,
         ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
         goto err_after_acquire_entries;
     }
+    r->follower_state.append_in_flight_count += 1;
 
     entryBatchesDestroy(args->entries, args->n_entries);
     return 0;

--- a/src/tick.c
+++ b/src/tick.c
@@ -46,6 +46,11 @@ static int tickFollower(struct raft *r)
             electionResetTimer(r);
             return 0;
         }
+        if (r->follower_state.append_in_flight_count > 0) {
+            tracef("append in progress -> don't convert to candidate");
+            electionResetTimer(r);
+            return 0;
+        }
         tracef("convert to candidate and start new election");
         rv = convertToCandidate(r, false /* disrupt leader */);
         if (rv != 0) {


### PR DESCRIPTION
Fixes #386, I think. This implements the second strategy from my comment there. I've added a new test and deleted an existing one that relied on the old behavior.

Signed-off-by: Cole Miller <cole.miller@canonical.com>