### PR TITLE
Handle segment write failures

### DIFF
--- a/src/uv_finalize.c
+++ b/src/uv_finalize.c
@@ -41,6 +41,7 @@ static void uvFinalizeWorkCb(uv_work_t *work)
     /* If the segment hasn't actually been used (because the writer has been
      * closed or aborted before making any write), just remove it. */
     if (segment->used == 0) {
+        tracef("remove unused segment file: %s", filename1);
         rv = UvFsRemoveFile(uv->dir, filename1, errmsg);
         if (rv != 0) {
             goto err;

--- a/test/integration/append_helpers.h
+++ b/test/integration/append_helpers.h
@@ -97,5 +97,6 @@ static void appendCbAssertResult(struct raft_io_append *req, int status)
         APPEND_SUBMIT(0, N_ENTRIES, ENTRY_SIZE);              \
         APPEND_EXPECT(0, STATUS);                             \
         APPEND_WAIT(0);                                       \
+        f->count--;                                           \
         munit_assert_string_equal(f->io.errmsg, ERRMSG);      \
     }

--- a/test/integration/test_replication.c
+++ b/test/integration/test_replication.c
@@ -1210,3 +1210,27 @@ TEST(replication, failPersistBarrier, setUp, tearDown, 0, NULL)
 
     return MUNIT_OK;
 }
+
+/* All servers fail to persist the barrier entry upon election of the first
+ * leader. Ensure the cluster is able to make progress afterwards.
+ */
+TEST(replication, failPersistBarrierFollower, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    CLUSTER_GROW;
+
+    /* The servers will fail to persist entry 2, a barrier */
+    CLUSTER_IO_FAULT(1, 7, 1);
+    CLUSTER_IO_FAULT(2, 7, 1);
+
+    /* Server 0 gets elected and creates a barrier entry at index 2 */
+    CLUSTER_BOOTSTRAP;
+    CLUSTER_START;
+    CLUSTER_START_ELECT(0);
+
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+    CLUSTER_MAKE_PROGRESS;
+
+    return MUNIT_OK;
+}

--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -467,7 +467,8 @@ TEST(append, noSpaceUponWrite, setUp, tearDownDeps, 0, DirTmpfsParams)
     APPEND_FAILURE(1, (SEGMENT_BLOCK_SIZE + 128), RAFT_NOSPACE,
                    "short write: 4096 bytes instead of 8192");
     DirRemoveFile(f->dir, ".fill");
-    ASSERT_ENTRIES(1, 64);
+    APPEND(5, 64);
+    ASSERT_ENTRIES(6, 384);
     return MUNIT_OK;
 }
 


### PR DESCRIPTION
- Truncate follower log when append entries fail to persist.
- When the segment write fails:
  - ~~Reset open segment so it's ready for new writes.~~ Mark the segment for finalizing.
  - Cancel queued append requests because raft assumes all writes are in order and succeed, otherwise the log index accounting will be off and append entries will be missing on disk, leaving a 'hole' and inconsistent  data.

fixes #450 (It hasn't occurred in 20ish Jepsen runs of 78 tests)

Will still try to exactly replicate the error in the tests.