### PR TITLE
Don't convert to candidate while entries are being persisted, take 2

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -749,7 +749,8 @@ struct raft
                 raft_id id;
                 char *address;
             } current_leader;
-            uint64_t reserved[8]; /* Future use */
+            uint64_t append_in_flight_count;
+            uint64_t reserved[7]; /* Future use */
         } follower_state;
         struct
         {

--- a/src/convert.c
+++ b/src/convert.c
@@ -137,6 +137,7 @@ void convertToFollower(struct raft *r)
 
     r->follower_state.current_leader.id = 0;
     r->follower_state.current_leader.address = NULL;
+    r->follower_state.append_in_flight_count = 0;
 }
 
 int convertToCandidate(struct raft *r, bool disrupt_leader)

--- a/src/recv_timeout_now.c
+++ b/src/recv_timeout_now.c
@@ -65,6 +65,12 @@ int recvTimeoutNow(struct raft *r,
         return 0;
     }
 
+    /* Finally, ignore the request if we're working on persisting some
+     * entries. */
+    if (r->follower_state.append_in_flight_count > 0) {
+        return 0;
+    }
+
     /* Convert to candidate and start a new election. */
     rv = convertToCandidate(r, true /* disrupt leader */);
     if (rv != 0) {

--- a/src/tick.c
+++ b/src/tick.c
@@ -46,6 +46,11 @@ static int tickFollower(struct raft *r)
             electionResetTimer(r);
             return 0;
         }
+        if (r->follower_state.append_in_flight_count > 0) {
+            tracef("append in progress -> don't convert to candidate");
+            electionResetTimer(r);
+            return 0;
+        }
         tracef("convert to candidate and start new election");
         rv = convertToCandidate(r, false /* disrupt leader */);
         if (rv != 0) {


### PR DESCRIPTION
Fixes #386, reviving the approach from #464 as the first part of the approach worked out in the discussion of #465.

I'm not entirely happy about adding the append_in_flight_count field to `struct raft` -- it would be more principled to query our raft_io for this information. On the other hand, adding a method for that is a more invasive change that breaks compatibility with older raft_io implementations. So I'm undecided on the best design here.

Signed-off-by: Cole Miller <cole.miller@canonical.com>