### PR TITLE
test_uv_append: run loop to avoid race.

### DIFF
--- a/test/integration/test_uv_append.c
+++ b/test/integration/test_uv_append.c
@@ -467,6 +467,7 @@ TEST(append, noSpaceUponWrite, setUp, tearDownDeps, 0, DirTmpfsParams)
     APPEND_FAILURE(1, (SEGMENT_BLOCK_SIZE + 128), RAFT_NOSPACE,
                    "short write: 4096 bytes instead of 8192");
     DirRemoveFile(f->dir, ".fill");
+    LOOP_RUN(50);
     APPEND(5, 64);
     ASSERT_ENTRIES(6, 384);
     return MUNIT_OK;


### PR DESCRIPTION
In the append/noSpaceUponWrite test, here's a race condition where the prepare step of an open segment is started while the disk is still full, but only completes after the balloon file on disk is removed. After removal of the balloon file it is assumed that the APPEND(5, 64) step succeeds, but the append command is linked to the segment that will fail to prepare due to a full disk, resulting in a test assertion failure.

Running the eventloop a couple of times (hopefully) fixes this race.