### PR TITLE
uv_fs: Don't do synced writes when emulating fallocate

### DIFF
--- a/src/uv.c
+++ b/src/uv.c
@@ -91,7 +91,8 @@ static int uvInit(struct raft_io *io, raft_id id, const char *address)
     }
 
     /* Probe file system capabilities */
-    rv = UvFsProbeCapabilities(uv->dir, &direct_io, &uv->async_io, io->errmsg);
+    rv = UvFsProbeCapabilities(uv->dir, &direct_io, &uv->async_io,
+                               &uv->fallocate, io->errmsg);
     if (rv != 0) {
         return rv;
     }
@@ -676,6 +677,7 @@ int raft_uv_init(struct raft_io *io,
     uv->errored = false;
     uv->direct_io = false;
     uv->async_io = false;
+    uv->fallocate = false;
 #ifdef LZ4_ENABLED
     uv->snapshot_compression = true;
 #else

--- a/src/uv.h
+++ b/src/uv.h
@@ -66,6 +66,7 @@ struct uv
     bool errored;                        /* If a disk I/O error was hit */
     bool direct_io;                      /* Whether direct I/O is supported */
     bool async_io;                       /* Whether async I/O is supported */
+    bool fallocate;                      /* Whether fallocate is supported */
     size_t segment_size;                 /* Initial size of open segments. */
     size_t block_size;                   /* Block size of the data dir */
     queue clients;                       /* Outbound connections */

--- a/src/uv_fs.h
+++ b/src/uv_fs.h
@@ -41,6 +41,7 @@ int UvFsAllocateFile(const char *dir,
                      const char *filename,
                      size_t size,
                      uv_file *fd,
+                     bool fallocate,
                      char *errmsg);
 
 /* Create a file and write the given content into it. */
@@ -114,6 +115,7 @@ int UvFsRenameFile(const char *dir,
 int UvFsProbeCapabilities(const char *dir,
                           size_t *direct,
                           bool *async,
+                          bool *fallocate,
                           char *errmsg);
 
 #endif /* UV_FS_H_ */

--- a/src/uv_os.h
+++ b/src/uv_os.h
@@ -40,6 +40,12 @@ int UvOsClose(uv_file fd);
 /* TODO: figure a portable abstraction. */
 int UvOsFallocate(uv_file fd, off_t offset, off_t len);
 
+/* Emulation to use in case UvOsFallocate fails with -EONOTSUPP.
+ * This might happen with a libc implementation (e.g. musl) that
+ * doesn't implement a transparent fallback if fallocate() is
+ * not supported by the underlying file system. */
+int UvOsFallocateEmulation(int fd, off_t offset, off_t len);
+
 /* Portable truncate() */
 int UvOsTruncate(uv_file fd, off_t offset);
 

--- a/src/uv_prepare.c
+++ b/src/uv_prepare.c
@@ -54,7 +54,7 @@ static void uvPrepareWorkCb(uv_work_t *work)
     int rv;
 
     rv = UvFsAllocateFile(uv->dir, segment->filename, segment->size,
-                          &segment->fd, segment->errmsg);
+                          &segment->fd, uv->fallocate, segment->errmsg);
     if (rv != 0) {
         goto err;
     }

--- a/test/unit/test_uv_writer.c
+++ b/test/unit/test_uv_writer.c
@@ -18,6 +18,7 @@ struct fixture
     int fd;
     size_t block_size;
     size_t direct_io;
+    bool fallocate;
     bool async_io;
     char errmsg[256];
     struct UvWriter writer;
@@ -191,7 +192,8 @@ static void *setUpDeps(const MunitParameter params[], void *user_data)
     int rv;
     SET_UP_DIR;
     SETUP_LOOP;
-    rv = UvFsProbeCapabilities(f->dir, &f->direct_io, &f->async_io, errmsg);
+    rv = UvFsProbeCapabilities(f->dir, &f->direct_io, &f->async_io,
+                               &f->fallocate, errmsg);
     munit_assert_int(rv, ==, 0);
     f->block_size = f->direct_io != 0 ? f->direct_io : 4096;
     rv = UvOsJoin(f->dir, "foo", path);


### PR DESCRIPTION
With the default segment size, and a blocksize of 4KB, the fallocate emulation code could perform 2048 synced writes leading to a lot of latency. Instead, sync the file once after writing without O_DSYNC. and reopen the file with O_DSYNC before giving the fd back to raft. Detect fallocate capabilities at startup.