### PR TITLE
client: Only send timeout now message if persisted state is up-to-date.

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -435,7 +435,7 @@ int raft_transfer(struct raft *r,
 
     membershipLeadershipTransferInit(r, req, id, cb);
 
-    if (progressIsUpToDate(r, i)) {
+    if (progressPersistedIsUpToDate(r, i)) {
         rv = membershipLeadershipTransferStart(r);
         if (rv != 0) {
             r->transfer = NULL;

--- a/src/progress.c
+++ b/src/progress.c
@@ -102,6 +102,13 @@ bool progressIsUpToDate(struct raft *r, unsigned i)
     return p->next_index == last_index + 1;
 }
 
+bool progressPersistedIsUpToDate(struct raft *r, unsigned i)
+{
+    struct raft_progress *p = &r->leader_state.progress[i];
+    raft_index last_index = logLastIndex(r->log);
+    return p->match_index == last_index;
+}
+
 bool progressShouldReplicate(struct raft *r, unsigned i)
 {
     struct raft_progress *p = &r->leader_state.progress[i];

--- a/src/progress.h
+++ b/src/progress.h
@@ -42,9 +42,13 @@ int progressBuildArray(struct raft *r);
 int progressRebuildArray(struct raft *r,
                          const struct raft_configuration *configuration);
 
-/* Whether the log of the i'th server in the configuration up-to-date with
- * ours. */
+/* Whether the i'th server in the configuration has been sent all the log
+ * entries. */
 bool progressIsUpToDate(struct raft *r, unsigned i);
+
+/* Whether the persisted log of the i'th server in the configuration up-to-date
+ * with ours. */
+bool progressPersistedIsUpToDate(struct raft *r, unsigned i);
 
 /* Whether a new AppendEntries or InstallSnapshot message should be sent to the
  * i'th server at this time.

--- a/src/replication.c
+++ b/src/replication.c
@@ -807,7 +807,8 @@ int replicationUpdate(struct raft *r,
          * is now up-to-date and, if so, send it a TimeoutNow RPC (unless we
          * already did). */
         if (r->transfer != NULL && r->transfer->id == server->id) {
-            if (progressIsUpToDate(r, i) && r->transfer->send.data == NULL) {
+            if (progressPersistedIsUpToDate(r, i) &&
+                r->transfer->send.data == NULL) {
                 rv = membershipLeadershipTransferStart(r);
                 if (rv != 0) {
                     membershipLeadershipTransferClose(r);


### PR DESCRIPTION
Receivers of the "timeout now" message ignore the message if their in-memory logs are not up-to-date or if they are persisting log entries. When the message is ignored, the sender will not retry it which can lead to failed leadership transfers that could have been avoided. Instead, let the leader only send the message when it knows the follower has persisted all log entries, based on the follower's match_index.

Fixes https://github.com/canonical/go-dqlite/issues/271. I can no longer reproduce that bug while it was easy to reproduce without the fix.