### PR TITLE
packages: build, sign and push package from GHA.

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,6 +3,7 @@ on:
   - push
 jobs:
   build:
+    if: github.repository == 'canonical/raft'
     strategy:
       fail-fast: false
       matrix:
@@ -11,6 +12,8 @@ jobs:
           - jammy
           - kinetic
     runs-on: ubuntu-20.04
+    environment:
+      name: ppa
     steps:
     - name: Clone the repositories
       run: |
@@ -20,12 +23,24 @@ jobs:
     - name: Setup dependencies
       run: |
           sudo apt-get update -qq
-          sudo apt-get install -qq debhelper devscripts
+          sudo apt-get install -qq debhelper devscripts gnupg
+
+    - name: Setup GPG signing key
+      env:
+          PPA_SECRET_KEY: ${{ secrets.PPA_SECRET_KEY }}
+      run: |
+          echo "$PPA_SECRET_KEY" > private-key.asc
+          gpg --import --batch private-key.asc
+
+    - name: Delete GPG signing key file
+      if: always()
+      run: |
+          rm -f private-key.asc
 
     - name: Build source package
       env:
         DEBFULLNAME: "Github Actions"
-        DEBEMAIL: "noreply@linuxcontainers.org"
+        DEBEMAIL: "dqlitebot@lists.canonical.com"
         TARGET: ${{ matrix.target }}
       run: |
           cp -R dqlite-ppa/debian raft/
@@ -36,15 +51,8 @@ jobs:
             --package raft \
             --newversion ${VERSION}~${TARGET}1 \
             "Automatic build from Github"
-          debuild -S -sa -us -uc -d
+          debuild -S -sa -d -k${{ vars.PPA_PUBLIC_KEY }}
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: debian-${{ matrix.target }}
-        if-no-files-found: error
-        path: |
-          *.buildinfo
-          *.changes
-          *.dsc
-          *.tar.*
+    - name: Upload to Launchpad
+      run: |
+          dput -U -u ppa:dqlite/dev *.changes


### PR DESCRIPTION
Sign and upload the source package directly from Github actions. The keys are associated with dqlitebot (https://launchpad.net/~dqlite-bot) on Launchpad.

Have tested workflow on my own repo, it *should* work. The secret is only available in the `ppa` environment, that is only available on the master branch. After merging to master, a package build is triggered after 60 minutes. (the ppa environment and timeout are configured in the repository settings)