### PR TITLE
uv_fs: EAGAIN is no hard error when probing Async IO.

### DIFF
--- a/src/uv_fs.c
+++ b/src/uv_fs.c
@@ -820,6 +820,13 @@ static int probeAsyncIO(int fd, size_t size, bool *ok, char *errmsg)
          * since we allocated the file with posix_fallocate and the block size
          * is supposed to be correct. */
         *ok = false;
+        if (event.res == -EAGAIN) {
+            /* If EAGAIN is encountered we assume the functionality is supported
+             * but this write would have blocked for some reason. UvWriter has a
+             * fallback mechanism to schedule writes on the thread pool in case
+             * the async write fails with EAGAIN, so this is safe. */
+            *ok = true;
+        }
     }
 
     return 0;

--- a/test/unit/test_uv_writer.c
+++ b/test/unit/test_uv_writer.c
@@ -386,12 +386,6 @@ TEST(UvWriterClose, aio, setUp, tearDownDeps, 0, DirAioParams)
 {
     struct fixture *f = data;
     SKIP_IF_NO_FIXTURE;
-    /* FIXME: btrfs doesn't like that we perform a first write to the probe file
-     * to detect the direct I/O buffer size. */
-    if (strcmp(munit_parameters_get(params, DIR_FS_PARAM), "btrfs") == 0) {
-        WRITE_CLOSE(1, 0, 0, 0);
-        return MUNIT_OK;
-    }
     WRITE_CLOSE(1, 0, 0, RAFT_CANCELED);
     return MUNIT_OK;
 }


### PR DESCRIPTION
fixes #481 