### PR TITLE
raft: Add user-supplied state_cb

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -592,14 +592,21 @@ struct raft_fsm
                           unsigned *n_bufs);
 };
 
+struct raft; /* Forward declaration. */
+
 /**
  * State codes.
  */
 enum { RAFT_UNAVAILABLE, RAFT_FOLLOWER, RAFT_CANDIDATE, RAFT_LEADER };
 
-struct raft_progress;
+/**
+ * State callback to invoke if raft's state changes.
+ */
+typedef void (*raft_state_cb)(struct raft *raft,
+                              unsigned short old_state,
+                              unsigned short new_state);
 
-struct raft; /* Forward declaration. */
+struct raft_progress;
 
 /**
  * Close callback.
@@ -825,8 +832,11 @@ struct raft
     unsigned max_catch_up_rounds;
     unsigned max_catch_up_round_duration;
 
+    /* uint64_t because we used a reserved field. */
+    uint64_t state_cb;
+
     /* Future extensions */
-    uint64_t reserved[32];
+    uint64_t reserved[31];
 };
 
 RAFT_API int raft_init(struct raft *r,
@@ -836,6 +846,8 @@ RAFT_API int raft_init(struct raft *r,
                        const char *address);
 
 RAFT_API void raft_close(struct raft *r, raft_close_cb cb);
+
+RAFT_API int raft_register_state_cb(struct raft *r, raft_state_cb cb);
 
 /**
  * Bootstrap this raft instance using the given configuration. The instance must

--- a/src/convert.c
+++ b/src/convert.c
@@ -20,7 +20,8 @@ static void convertSetState(struct raft *r, unsigned short new_state)
     /* Check that the transition is legal, see Figure 3.3. Note that with
      * respect to the paper we have an additional "unavailable" state, which is
      * the initial or final state. */
-    tracef("old_state:%u new_state:%u", r->state, new_state);
+    unsigned short old_state = r->state;
+    tracef("old_state:%u new_state:%u", old_state, new_state);
     assert((r->state == RAFT_UNAVAILABLE && new_state == RAFT_FOLLOWER) ||
            (r->state == RAFT_FOLLOWER && new_state == RAFT_CANDIDATE) ||
            (r->state == RAFT_CANDIDATE && new_state == RAFT_FOLLOWER) ||
@@ -30,6 +31,9 @@ static void convertSetState(struct raft *r, unsigned short new_state)
            (r->state == RAFT_CANDIDATE && new_state == RAFT_UNAVAILABLE) ||
            (r->state == RAFT_LEADER && new_state == RAFT_UNAVAILABLE));
     r->state = new_state;
+    if (r->state_cb != 0) {
+        ((raft_state_cb)r->state_cb)(r, old_state, new_state);
+    }
 }
 
 /* Clear follower state. */

--- a/src/raft.c
+++ b/src/raft.c
@@ -84,6 +84,7 @@ int raft_init(struct raft *r,
     r->last_applied = 0;
     r->last_stored = 0;
     r->state = RAFT_UNAVAILABLE;
+    r->state_cb = 0;
     r->transfer = NULL;
     r->snapshot.pending.term = 0;
     r->snapshot.threshold = DEFAULT_SNAPSHOT_THRESHOLD;
@@ -129,6 +130,14 @@ void raft_close(struct raft *r, void (*cb)(struct raft *r))
     }
     r->close_cb = cb;
     r->io->close(r->io, ioCloseCb);
+}
+
+int raft_register_state_cb(struct raft *r, raft_state_cb cb)
+{
+    _Static_assert(sizeof(uint64_t) >= sizeof(cb),
+                   "Can't save raft_state_cb in struct raft.");
+    r->state_cb = (uint64_t)cb;
+    return 0;
 }
 
 void raft_set_election_timeout(struct raft *r, const unsigned msecs)


### PR DESCRIPTION
This was also at one point requested by a user in #147 .

It will be used by dqlite in order to fix https://github.com/canonical/dqlite/issues/541 , where the `monitor_cb` didn't have a chance to run yet after a leadership loss, leading to the observed assertion. The assertion is the same as in https://github.com/canonical/dqlite/issues/355 , and caused by an ongoing transaction on the database, while we expect that no transactions are active.

What is a bit fishy is that I save the `state_cb` in a `uint64_t`, but I try to protect from UB by asserting the size of `uint64_t` is sufficient to store the function pointer at compile time, but that doesn't guarantee it will always work. I am not very happy with this. An alternative would be to store the callback in `struct raft_fsm`, that's also not fantastic as the fsm logic is disconnected from the dqlite's server logic.