### PR TITLE
raft: Add user-supplied state_cb

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ libraft_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 libraft_la_LDFLAGS = -version-info 3:0:0
 libraft_la_SOURCES = \
   src/byte.c \
+  src/callbacks.c \
   src/client.c \
   src/compress.c \
   src/configuration.c \

--- a/include/raft.h
+++ b/include/raft.h
@@ -592,14 +592,21 @@ struct raft_fsm
                           unsigned *n_bufs);
 };
 
+struct raft; /* Forward declaration. */
+
 /**
  * State codes.
  */
 enum { RAFT_UNAVAILABLE, RAFT_FOLLOWER, RAFT_CANDIDATE, RAFT_LEADER };
 
-struct raft_progress;
+/**
+ * State callback to invoke if raft's state changes.
+ */
+typedef void (*raft_state_cb)(struct raft *raft,
+                              unsigned short old_state,
+                              unsigned short new_state);
 
-struct raft; /* Forward declaration. */
+struct raft_progress;
 
 /**
  * Close callback.
@@ -825,8 +832,13 @@ struct raft
     unsigned max_catch_up_rounds;
     unsigned max_catch_up_round_duration;
 
+    /* uint64_t because we used a reserved field. In reality this a pointer to a
+     * `struct raft_callbacks` that can be used to store e.g. various
+     * user-supplied callbacks. */
+    uint64_t callbacks;
+
     /* Future extensions */
-    uint64_t reserved[32];
+    uint64_t reserved[31];
 };
 
 RAFT_API int raft_init(struct raft *r,
@@ -836,6 +848,12 @@ RAFT_API int raft_init(struct raft *r,
                        const char *address);
 
 RAFT_API void raft_close(struct raft *r, raft_close_cb cb);
+
+/**
+ * This function MUST be called after raft_init and before raft_start.
+ * @cb will be called every time the raft state changes.
+ */
+RAFT_API void raft_register_state_cb(struct raft *r, raft_state_cb cb);
 
 /**
  * Bootstrap this raft instance using the given configuration. The instance must

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1,0 +1,24 @@
+#include "callbacks.h"
+#include "heap.h"
+
+int raftInitCallbacks(struct raft *r)
+{
+    r->callbacks = 0;
+    struct raft_callbacks *cbs = RaftHeapCalloc(1, sizeof(*cbs));
+    if (cbs == NULL) {
+        return RAFT_NOMEM;
+    }
+    r->callbacks = (uint64_t)(uintptr_t)cbs;
+    return 0;
+}
+
+void raftDestroyCallbacks(struct raft *r)
+{
+    RaftHeapFree((void *)(uintptr_t)r->callbacks);
+    r->callbacks = 0;
+}
+
+struct raft_callbacks *raftGetCallbacks(struct raft *r)
+{
+    return (void *)(uintptr_t)r->callbacks;
+}

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -1,0 +1,15 @@
+#ifndef CALLBACKS_H_
+#define CALLBACKS_H_
+
+#include "../include/raft.h"
+
+struct raft_callbacks
+{
+    raft_state_cb state_cb;
+};
+
+int raftInitCallbacks(struct raft *r);
+void raftDestroyCallbacks(struct raft *r);
+struct raft_callbacks *raftGetCallbacks(struct raft *r);
+
+#endif

--- a/test/integration/test_start.c
+++ b/test/integration/test_start.c
@@ -201,3 +201,23 @@ TEST(raft_start, singleVotingNotUs, setUp, tearDown, 0, NULL)
     CLUSTER_MAKE_PROGRESS;
     return MUNIT_OK;
 }
+
+static void state_cb(struct raft *r, unsigned short old, unsigned short new)
+{
+    munit_assert_ushort(old, !=, new);
+    r->data = (void *)(uintptr_t)0xFEEDBEEF;
+}
+
+/* There is a single voting server in the cluster, register a state_cb and
+ * assert that it's called because the node will progress to leader.  */
+TEST(raft_start, singleVotingWithStateCb, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+    CLUSTER_BOOTSTRAP;
+    struct raft *r = CLUSTER_RAFT(0);
+    r->data = (void *)(uintptr_t)0;
+    raft_register_state_cb(r, state_cb);
+    CLUSTER_START;
+    munit_assert_uint((uintptr_t)r->data, ==, 0xFEEDBEEF);
+    return MUNIT_OK;
+}


### PR DESCRIPTION
This was also at one point requested by a user in #147 .

It will be used by dqlite in order to fix https://github.com/canonical/dqlite/issues/541 , where the `monitor_cb` didn't have a chance to run yet after a leadership loss, leading to the observed assertion. The assertion is the same as in https://github.com/canonical/dqlite/issues/355 , and caused by an ongoing transaction on the database, while we expect that no transactions are active.