### PR TITLE
tracing: Align raft log message with dqlite log message.

### DIFF
--- a/src/tracing.c
+++ b/src/tracing.c
@@ -63,11 +63,11 @@ static inline void tracerEmit(const char *file,
 
     /*
       Example:
-      LIBRAFT[182942] 2023-11-27T14:46:24.912050507 001132 INFO
+      LIBRAFT  [182942] 2023-11-27T14:46:24.912050507 001132 INFO
       uvClientSend  src/uv_send.c:218 connection available...
     */
     fprintf(stderr,
-            "LIBRAFT[%6.6u] %04d-%02d-%02dT%02d:%02d:%02d.%09lu "
+            "LIBRAFT  [%6.6u] %04d-%02d-%02dT%02d:%02d:%02d.%09lu "
             "%6.6u %-7s %-20s %s:%-3i %s\n",
             tracerPidCached,
 


### PR DESCRIPTION
results in aligning dqlite's and raft's logs like:

```
LIBRAFT  [3871330] 2023-12-14T09:13:36.850973847 3871336 DEBUG   uvBarrierClose       src/uv_append.c:946 uv barrier close
LIBDQLITE[3871330] 2023-12-14T09:13:36.850977103 3871336 DEBUG   impl_close           src/transport.c:208 impl close
LIBRAFT  [3871330] 2023-12-14T09:13:36.850979067 3871336 DEBUG   uvMaybeFireCloseCb   src/uv.c:160 uv maybe fire close cb
LIBRAFT  [3871330] 2023-12-14T09:13:36.850982754 3871336 DEBUG   uvMaybeFireCloseCb   src/uv.c:160 uv maybe fire close cb
LIBRAFT  [3871330] 2023-12-14T09:13:36.850984787 3871336 DEBUG   uvMaybeFireCloseCb   src/uv.c:160 uv maybe fire close cb
LIBRAFT  [3871330] 2023-12-14T09:13:36.850987242 3871336 DEBUG   ioCloseCb            src/raft.c:121 io close cb
LIBDQLITE[3871330] 2023-12-14T09:13:36.856944350 3871330 DEBUG   fsm__close           src/fsm.c:743 fsm close
LIBDQLITE[3871330] 2023-12-14T09:13:36.856985167 3871330 DEBUG   raftProxyClose       src/transport.c:262 raft proxy close
LIBDQLITE[3871330] 2023-12-14T09:13:36.856996679 3871330 DEBUG   VfsClose             src/vfs.c:2092 vfs close
```