### PR TITLE
Add raft_voter_contact()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,7 +125,8 @@ test_integration_core_SOURCES = \
   test/integration/test_start.c \
   test/integration/test_strerror.c \
   test/integration/test_tick.c \
-  test/integration/test_transfer.c
+  test/integration/test_transfer.c \
+  test/integration/test_voter_contacts.c
 test_integration_core_CFLAGS = $(AM_CFLAGS) -Wno-conversion
 test_integration_core_LDFLAGS = -no-install
 test_integration_core_LDADD = libtest.la libraft.la

--- a/include/raft.h
+++ b/include/raft.h
@@ -783,7 +783,9 @@ struct raft
             raft_index round_index;         /* Target of the current round. */
             raft_time round_start;          /* Start of current round. */
             void *requests[2];              /* Outstanding client requests. */
-            uint64_t reserved[8];           /* Future use */
+            uint32_t voter_contacts;        /* Current number of voting nodes we are in contact with */
+            uint32_t reserved2;             /* Future use */
+            uint64_t reserved[7];           /* Future use */
         } leader_state;
     };
 
@@ -980,6 +982,20 @@ RAFT_API raft_index raft_last_index(struct raft *r);
  * Return the index of the last entry that was applied to the local FSM.
  */
 RAFT_API raft_index raft_last_applied(struct raft *r);
+
+/**
+ * Return the number of voting servers that the leader has recently been in
+ * contact with. This can be used to help determine whether the cluster may be
+ * in a degraded/at risk state.
+ *
+ * Returns valid values >= 1, because a leader is always in contact with
+ * itself.
+ * Returns -1 if called on a follower.
+ *
+ * Note that the value returned may be out of date, and so should not be relied
+ * upon for absolute correctness.
+ */
+RAFT_API int raft_voter_contacts(struct raft *r);
 
 /**
  * Common fields across client request types.

--- a/src/convert.c
+++ b/src/convert.c
@@ -32,6 +32,9 @@ static void convertSetState(struct raft *r, unsigned short new_state)
            (r->state == RAFT_CANDIDATE && new_state == RAFT_UNAVAILABLE) ||
            (r->state == RAFT_LEADER && new_state == RAFT_UNAVAILABLE));
     r->state = new_state;
+    if (r->state == RAFT_LEADER) {
+        r->leader_state.voter_contacts = 1;
+    }
 
     struct raft_callbacks *cbs = raftGetCallbacks(r);
     if (cbs != NULL && cbs->state_cb != NULL) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -85,6 +85,7 @@ int raft_init(struct raft *r,
     r->last_applied = 0;
     r->last_stored = 0;
     r->state = RAFT_UNAVAILABLE;
+    r->leader_state.voter_contacts = 0;
     rv = raftInitCallbacks(r);
     if (rv != 0) {
         goto err_after_address_alloc;
@@ -189,6 +190,15 @@ void raft_set_pre_vote(struct raft *r, bool enabled)
 const char *raft_errmsg(struct raft *r)
 {
     return r->errmsg;
+}
+
+int raft_voter_contacts(struct raft *r)
+{
+    if (r->state == RAFT_LEADER) {
+        return (int)r->leader_state.voter_contacts;
+    } else {
+        return -1;
+    }
 }
 
 int raft_bootstrap(struct raft *r, const struct raft_configuration *conf)

--- a/src/tick.c
+++ b/src/tick.c
@@ -107,6 +107,7 @@ static bool checkContactQuorum(struct raft *r)
             contacts++;
         }
     }
+    r->leader_state.voter_contacts = contacts;
 
     return contacts > configurationVoterCount(&r->configuration) / 2;
 }

--- a/test/integration/test_voter_contacts.c
+++ b/test/integration/test_voter_contacts.c
@@ -1,0 +1,105 @@
+#include "../lib/cluster.h"
+#include "../lib/runner.h"
+
+#define N_SERVERS 3
+
+/******************************************************************************
+ *
+ * Fixture with a test raft cluster.
+ *
+ *****************************************************************************/
+
+struct fixture
+{
+    FIXTURE_CLUSTER;
+};
+
+/******************************************************************************
+ *
+ * Helper macros
+ *
+ *****************************************************************************/
+
+#define STEP_N(N) raft_fixture_step_n(&f->cluster, N)
+
+/******************************************************************************
+ *
+ * Set up a cluster with a three servers.
+ *
+ *****************************************************************************/
+
+static void *setUp(const MunitParameter params[], MUNIT_UNUSED void *user_data)
+{
+    struct fixture *f = munit_malloc(sizeof *f);
+    SETUP_CLUSTER(N_SERVERS);
+    CLUSTER_BOOTSTRAP;
+    CLUSTER_START;
+    CLUSTER_ELECT(0);
+    return f;
+}
+
+static void tearDown(void *data)
+{
+    struct fixture *f = data;
+    TEAR_DOWN_CLUSTER;
+    free(f);
+}
+
+/******************************************************************************
+ *
+ * raft_voter_contacts
+ *
+ *****************************************************************************/
+
+SUITE(raft_voter_contacts)
+
+TEST(raft_voter_contacts, upToDate, setUp, tearDown, 0, NULL)
+{
+    struct fixture *f = data;
+
+    CLUSTER_STEP_UNTIL_HAS_LEADER(1000);
+    CLUSTER_STEP_N(1000);
+
+    /* N node cluster with leader */
+    for (unsigned int i = 0; i < N_SERVERS; i++) {
+        int count = raft_voter_contacts(CLUSTER_RAFT(i));
+        if (i == CLUSTER_LEADER) {
+            munit_assert_int(count, ==, N_SERVERS);
+        } else {
+            munit_assert_int(count, ==, -1);
+        }
+    }
+
+    /* Kill the cluster leader, so a new leader is elected and the number of
+     * voters should be decreased */
+    unsigned int leader = CLUSTER_LEADER;
+    CLUSTER_KILL(leader);
+    CLUSTER_STEP_UNTIL_HAS_LEADER(1000);
+    CLUSTER_STEP_N(1000);
+
+    for (unsigned int i = 0; i < N_SERVERS; i++) {
+        if (i == leader) {
+            continue;
+        }
+        int count = raft_voter_contacts(CLUSTER_RAFT(i));
+        if (i == CLUSTER_LEADER) {
+            munit_assert_int(count, ==, N_SERVERS - 1);
+        } else {
+            munit_assert_int(count, ==, -1);
+        }
+    }
+
+    /* Revive the old leader, so the count should go back up */
+    CLUSTER_REVIVE(leader);
+    CLUSTER_STEP_N(1000);
+    for (unsigned int i = 0; i < N_SERVERS; i++) {
+        int count = raft_voter_contacts(CLUSTER_RAFT(i));
+        if (i == CLUSTER_LEADER) {
+            munit_assert_int(count, ==, N_SERVERS);
+        } else {
+            munit_assert_int(count, ==, -1);
+        }
+    }
+
+    return MUNIT_OK;
+}


### PR DESCRIPTION
This returns the number of voting nodes that are recently in contact with the leader, to allow determining if the cluster is currently in a degraded / at risk state.

I'd be interested on your thoughts on this. At the moment it feels like not being able to find out this information is an omission.